### PR TITLE
Set NODE_ENV properly in package build

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -67,7 +67,7 @@ do_build() {
 
     pushd client
     yarn install --cache-folder ../.yarn
-    GENERATE_SMOKE_TESTS=true BASE_ASSETS_PATH="https://assets-dev.reticulum.io/" yarn build -- --output-path ../../priv/static
+    NODE_ENV=production GENERATE_SMOKE_TESTS=true BASE_ASSETS_PATH="https://assets-dev.reticulum.io/" yarn build -- --output-path ../../priv/static
     popd
 
     rm -rf client


### PR DESCRIPTION
We weren't building the bundle with NODE_ENV=production
