### PR TITLE
Add meta tags for hubs

### DIFF
--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -1,5 +1,13 @@
 defmodule RetWeb.PageController do
   use RetWeb, :controller
+  alias Ret.{Repo, Hub}
+
+  # Split the HTML file into two parts, on the line that contains HUB_META_TAGS, so we can add meta tags
+  @hub_html_chunks "#{Application.app_dir(:ret)}/priv/static/hub.html"
+                   |> File.read!()
+                   |> String.split("\n")
+                   |> Enum.split_while(&(!Regex.match?(~r/HUB_META_TAGS/, &1)))
+                   |> Tuple.to_list()
 
   def call(conn, _params) do
     render_for_path(conn.request_path, conn)
@@ -9,8 +17,17 @@ defmodule RetWeb.PageController do
     render_file(conn, "#{get_file_prefix(conn)}index.html")
   end
 
-  def render_for_path(_, conn) do
-    render_file(conn, "#{get_file_prefix(conn)}hub.html")
+  def render_for_path(path, conn) do
+    hub_sid =
+      path
+      |> String.split("/")
+      |> Enum.at(1)
+
+    hub = Hub |> Repo.get_by(hub_sid: hub_sid)
+    hub_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "hub-meta.html", hub: hub)
+
+    body = List.insert_at(@hub_html_chunks, 1, hub_meta_tags)
+    conn |> send_resp(200, body)
   end
 
   defp get_file_prefix(conn) do

--- a/lib/ret_web/endpoint.ex
+++ b/lib/ret_web/endpoint.ex
@@ -12,7 +12,8 @@ defmodule RetWeb.Endpoint do
     at: "/",
     from: :ret,
     gzip: false,
-    only: ~w(assets robots.txt favicon.ico avatar-selector.html smoke-avatar-selector.html),
+    only:
+      ~w(assets robots.txt favicon.ico hub-preview.png avatar-selector.html smoke-avatar-selector.html),
     headers: [{"access-control-allow-origin", "*"}]
   )
 

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -1,0 +1,11 @@
+<meta property="og:type" content="website" />
+<meta property="og:url" content="<%= RetWeb.Endpoint.url %>/<%= @hub.hub_sid %>/<%= @hub.slug %>" />
+<meta property="og:title" content="<%= @hub.name %> | Hubs by Mozilla" />
+<meta property="og:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
+<meta property="og:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png" />
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
+<meta name="twitter:title" value="<%= @hub.name %> | Hubs by Mozilla" />
+<meta name="twitter:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
+<meta name="twitter:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png" />
+<meta name="twitter:url" value="<%= RetWeb.Endpoint.url %>/<%= @hub.hub_sid %>/<%= @hub.slug %>" />


### PR DESCRIPTION
This makes an attempt at inlining proper META tags at the top of the hub landing page so it will unfurl reasonably.

Goes with https://github.com/mozilla/hubs/pull/281