### PR TITLE
Fix typo: Posion->Poison

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,7 @@ use Mix.Config
 # General application configuration
 config :ret, ecto_repos: [Ret.Repo]
 
-config :phoenix, :format_encoders, "json-api": Posion
+config :phoenix, :format_encoders, "json-api": Poison
 
 config :mime, :types, %{
   "application/vnd.api+json" => ["json-api"]


### PR DESCRIPTION
I think this was a typo back when it was added in https://github.com/mozilla/socialmr/commit/857a6f84c244f738c4b0471ed725833232a27fa2#diff-1b1ba7f7894ccf1a0c686635b9d5b942R12

Not sure if this has actually affected anything.