### PR TITLE
Create priv/static/ directory if it doesn't exist.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,7 @@ export MIX_ENV=prod
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
 mkdir -p tmp
+mkdir -p priv/static/
 
 # Rebar3 will hate us otherwise because it looks for
 # /usr/bin/env when it does some of its compiling


### PR DESCRIPTION
This directory was not created when rebuilding the reticulum box. We now ensure the directory is created when running the build script.