### PR TITLE
add `<meta>` tags for search engines and omit deprecated, redundant Twitter tags

### DIFF
--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -1,11 +1,13 @@
-<meta property="og:type" content="website" />
-<meta property="og:url" content="<%= RetWeb.Endpoint.url %>/<%= @hub.hub_sid %>/<%= @hub.slug %>" />
-<meta property="og:title" content="<%= @hub.name %> | Hubs by Mozilla" />
-<meta property="og:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
-<meta property="og:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png" />
+<!-- Search engines -->
+<meta name="description" content="Join others in VR at <%= @hub.name %>, right in your browser.">
+<!-- Schema.org for Google -->
+<meta itemprop="name" content="<%= @hub.name %> | Hubs by Mozilla">
+<meta itemprop="description" content="Join others in VR at <%= @hub.name %>, right in your browser.">
+<!-- OpenGraph for Facebook -->
+<meta property="og:type" content="website">
+<meta property="og:url" content="<%= RetWeb.Endpoint.url %>/<%= @hub.hub_sid %>/<%= @hub.slug %>">
+<meta property="og:title" content="<%= @hub.name %> | Hubs by Mozilla">
+<meta property="og:description" content="Join others in VR at <%= @hub.name %>, right in your browser.">
+<meta property="og:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png">
+<!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
-<meta name="twitter:title" value="<%= @hub.name %> | Hubs by Mozilla" />
-<meta name="twitter:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
-<meta name="twitter:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png" />
-<meta name="twitter:url" value="<%= RetWeb.Endpoint.url %>/<%= @hub.hub_sid %>/<%= @hub.slug %>" />


### PR DESCRIPTION
- add `meta[name="description"]` for search engines
    ![screenshot of Google results](https://user-images.githubusercontent.com/203725/40072735-6fe2921c-583a-11e8-992d-91035010fff1.png)
- remove deprecated `meta[name="twitter:domain"]` tag
- removed redundant `meta[name="twitter:…"]` tags (for the tags that are inferred from `meta[property="og:…"]`, based on the [Twitter's docs](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image))