### PR TITLE
Allow passing index, add extract return values

### DIFF
--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -1,11 +1,26 @@
 defmodule RetWeb.Api.V1.MediaController do
   use RetWeb, :controller
 
-  def create(conn, %{"media" => %{"url" => url}}) do
-    path = "/raw/0/0/0/0/#{Base.url_encode64(url, padding: false)}"
+  def create(conn, %{"media" => %{"url" => url}} = params) do
+    index =
+      case params do
+        %{"media" => %{"index" => index}} -> index
+        _ -> "0"
+      end
+
+    images = %{
+      "raw" => gen_farspark_url(url, index, "raw", ""),
+      "extract_png" => gen_farspark_url(url, index, "extract", ".png"),
+      "extract_jpg" => gen_farspark_url(url, index, "extract", ".jpg")
+    }
+
+    render(conn, "show.json", images: images)
+  end
+
+  defp gen_farspark_url(url, index, method, extension) do
+    path = "/#{method}/0/0/0/#{index}/#{Base.url_encode64(url, padding: false)}#{extension}"
     host = Application.get_env(:ret, :farspark_host)
-    raw_image_url = "#{host}/#{gen_signature(path)}#{path}"
-    render(conn, "show.json", %{raw_image_url: raw_image_url})
+    "#{host}/#{gen_signature(path)}#{path}"
   end
 
   defp gen_signature(path) do

--- a/lib/ret_web/views/api/v1/media_view.ex
+++ b/lib/ret_web/views/api/v1/media_view.ex
@@ -1,9 +1,7 @@
 defmodule RetWeb.Api.V1.MediaView do
   use RetWeb, :view
 
-  def render("show.json", %{raw_image_url: raw_image_url}) do
-    %{
-      images: %{raw: raw_image_url}
-    }
+  def render("show.json", %{images: images}) do
+    %{images: images}
   end
 end


### PR DESCRIPTION
Adds the ability to pass an optional "index" to the farspark URL generator API, and also returns URLs for extracting frames/pages via index (as either PNG or JPG)