### PR TITLE
Bug/media api fixes

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -147,7 +147,7 @@ defmodule Ret.MediaResolver do
 
         [uri, meta]
       else
-        _err -> uri
+        _err -> [uri, nil]
       end
 
     {:commit, uri |> resolved(meta)}

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -203,7 +203,7 @@ defmodule Ret.MediaResolver do
 
   defp retry_get_until_success(url, headers \\ []) do
     retry with: exp_backoff() |> randomize |> cap(5_000) |> expiry(10_000) do
-      case HTTPoison.get(url, headers) do
+      case HTTPoison.get(url, headers, follow_redirect: true) do
         {:ok, %HTTPoison.Response{status_code: status_code} = resp}
         when status_code in @success_status_codes ->
           resp

--- a/lib/ret_web/views/api/v1/media_view.ex
+++ b/lib/ret_web/views/api/v1/media_view.ex
@@ -1,7 +1,16 @@
 defmodule RetWeb.Api.V1.MediaView do
   use RetWeb, :view
 
-  def render("show.json", %{raw: raw, images: images}) do
-    %{raw: raw, images: images}
+  def render("show.json", %{origin: origin, raw: raw, meta: nil, images: images}) do
+    %{origin: origin, raw: raw, images: images}
+  end
+
+  def render("show.json", %{
+        meta: meta,
+        origin: origin,
+        raw: raw,
+        images: images
+      }) do
+    %{meta: meta, origin: origin, raw: raw, images: images}
   end
 end


### PR DESCRIPTION
This PR fixes a variety of bugs and adds some functionality to the media API:

- Properly handles redirects
- Fixes the fact we weren't checking the full range of HTTP success codes for success
- Returns the un-farsparked origin URL in the response
- Adds a `Range` header to the fallthrough crawl request so we don't download large files if we can avoid it
- Includes metadata for google Poly API calls: the expected content type, the license, and the asset name