### PR TITLE
Feature/sketchfab

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -94,4 +94,5 @@ config :ret, Ret.MediaResolver,
   imgur_mashape_api_key: nil,
   imgur_client_id: nil,
   google_poly_api_key: nil,
+  sketchfab_api_key: nil,
   ytdl_host: "http://localhost:9191"

--- a/habitat/config/ret.prod.conf
+++ b/habitat/config/ret.prod.conf
@@ -26,3 +26,4 @@ ret.Elixir.Ret.MediaResolver.deviantart_client_secret = "{{ cfg.resolver.deviant
 ret.Elixir.Ret.MediaResolver.imgur_mashape_api_key = "{{ cfg.resolver.imgur_mashape_api_key }}"
 ret.Elixir.Ret.MediaResolver.imgur_client_id = "{{ cfg.resolver.imgur_client_id }}"
 ret.Elixir.Ret.MediaResolver.google_poly_api_key = "{{ cfg.resolver.google_poly_api_key }}"
+ret.Elixir.Ret.MediaResolver.sketchfab_api_key = "{{ cfg.resolver.sketchfab_api_key }}"

--- a/habitat/config/ret.schema.exs
+++ b/habitat/config/ret.schema.exs
@@ -212,6 +212,13 @@
       doc: "Google Poly API Key",
       hidden: false,
       to: "ret.Elixir.Ret.MediaResolver.google_poly_api_key"
+    ],
+    "ret.Elixir.Ret.MediaResolver.sketchfab_api_key": [
+      commented: false,
+      datatype: :binary,
+      doc: "Sketchfab API Key",
+      hidden: false,
+      to: "ret.Elixir.Ret.MediaResolver.sketchfab_api_key"
     ]
   ],
   transforms: [],

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -49,7 +49,7 @@ defmodule Ret.MediaResolver do
         |> retry_get_until_valid_ytdl_response
 
       case ytdl_resp do
-        %HTTPoison.Response{status_code: 302, headers: headers} = res ->
+        %HTTPoison.Response{status_code: 302, headers: headers} ->
           {:commit, headers |> media_url_from_ytdl_headers |> URI.parse() |> resolved}
 
         _ ->
@@ -199,7 +199,7 @@ defmodule Ret.MediaResolver do
           end
       end
 
-    uri = {:commit, uri |> resolved}
+    {:commit, uri |> resolved}
   end
 
   defp resolve_giphy_media_uri(%URI{} = uri, preferred_type) do
@@ -257,7 +257,7 @@ defmodule Ret.MediaResolver do
         when status_code >= 200 and status_code < 300 ->
           resp
 
-        {:ok, %HTTPoison.Response{status_code: status_code} = resp}
+        {:ok, %HTTPoison.Response{status_code: status_code}}
         when status_code >= 400 and status_code < 500 ->
           :unauthorized
 

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -166,7 +166,7 @@ defmodule Ret.MediaResolver do
         uri =
           case res do
             :error ->
-              uri
+              :error
 
             res ->
               res

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -49,8 +49,8 @@ defmodule Ret.MediaResolver do
         |> retry_get_until_valid_ytdl_response
 
       case ytdl_resp do
-        %HTTPoison.Response{status_code: 302, headers: headers} ->
-          {:commit, headers |> media_url_from_ytdl_headers |> resolved}
+        %HTTPoison.Response{status_code: 302, headers: headers} = res ->
+          {:commit, headers |> media_url_from_ytdl_headers |> URI.parse() |> resolved}
 
         _ ->
           resolve_non_video(uri, root_host)

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -153,12 +153,43 @@ defmodule Ret.MediaResolver do
     {:commit, uri |> resolved(meta)}
   end
 
+  defp resolve_non_video(
+         %URI{path: "/models/" <> model_id} = uri,
+         "sketchfab.com"
+       ) do
+    [uri, meta] =
+      with api_key when is_binary(api_key) <- resolver_config(:sketchfab_api_key) do
+        res =
+          "https://api.sketchfab.com/v3/models/#{model_id}/download"
+          |> retry_get_until_success([{"Authorization", "Token #{api_key}"}])
+
+        uri =
+          case res do
+            :error ->
+              uri
+
+            res ->
+              res
+              |> Map.get(:body)
+              |> Poison.decode!()
+              |> Kernel.get_in(["gltf", "url"])
+              |> URI.parse()
+          end
+
+        [uri, %{expected_content_type: "model/gltf+zip"}]
+      else
+        _err -> [uri, nil]
+      end
+
+    {:commit, uri |> resolved(meta)}
+  end
+
   defp resolve_non_video(%URI{} = uri, _root_host) do
     # Fall back on og: tags
     uri =
       case uri |> URI.to_string() |> retry_get_until_success([{"Range", "bytes=0-32768"}]) do
         :error ->
-          uri
+          :error
 
         resp ->
           case resp.body |> OpenGraph.parse() do
@@ -226,11 +257,19 @@ defmodule Ret.MediaResolver do
         when status_code >= 200 and status_code < 300 ->
           resp
 
+        {:ok, %HTTPoison.Response{status_code: status_code} = resp}
+        when status_code >= 400 and status_code < 500 ->
+          :unauthorized
+
         _ ->
           :error
       end
     after
-      result -> result
+      result ->
+        case result do
+          :unauthorized -> :error
+          _ -> result
+        end
     else
       error -> error
     end
@@ -285,6 +324,10 @@ defmodule Ret.MediaResolver do
     else
       _err -> nil
     end
+  end
+
+  def resolved(:error) do
+    nil
   end
 
   def resolved(%URI{} = uri) do

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -12,6 +12,9 @@ defmodule RetWeb.Api.V1.MediaController do
 
   defp resolve_and_render(conn, url, index) do
     case Cachex.fetch(:media_urls, url) do
+      {_status, nil} ->
+        conn |> send_resp(404, "")
+
       {_status, %Ret.ResolvedMedia{} = resolved_media} ->
         render_resolved_media(conn, resolved_media, index)
 


### PR DESCRIPTION
This PR:

- Adds support for the Sketchfab API
- Causes the GET retry loop to terminate immediately for 4XX HTTP responses
- Fixes an issue where the wrong kind of argument was being passed from YT-DL, causing YT-DL resolution to break