### PR TITLE
Stop using smoke- pages

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -88,7 +88,7 @@ config :ret,
   farspark_host: "https://farspark-dev.reticulum.io"
 
 config :ret, Ret.PageOriginWarmer,
-  page_origin_url: "https://hubs.local:8080",
+  page_origin: "https://hubs.local:8080",
   insecure_ssl: true
 
 config :ret, Ret.MediaResolver,

--- a/lib/ret/page_origin_warmer.ex
+++ b/lib/ret/page_origin_warmer.ex
@@ -8,13 +8,8 @@ defmodule Ret.PageOriginWarmer do
 
   def execute(_state) do
     with page_origin when is_binary(page_origin) <- module_config(:page_origin) do
-      page_set =
-        for prefix <- ["", "smoke-"], page <- @pages do
-          "#{prefix}#{page}"
-        end
-
       cache_values =
-        page_set
+        @pages
         |> Enum.map(&Task.async(fn -> page_to_cache_entry(&1) end))
         |> Enum.map(&Task.await(&1, 15000))
         |> Enum.reject(&is_nil/1)

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -18,10 +18,6 @@ defmodule RetWeb.PageController do
     conn |> render_page("avatar-selector")
   end
 
-  def render_for_path("/smoke-avatar-selector.html", conn) do
-    conn |> render_page("avatar-selector")
-  end
-
   def render_for_path(path, conn) do
     hub_sid =
       path
@@ -41,23 +37,13 @@ defmodule RetWeb.PageController do
     |> send_resp(200, chunks)
   end
 
-  defp with_page_prefix(page, conn) do
-    if conn.host =~ "smoke" do
-      "smoke-#{page}"
-    else
-      page
-    end
-  end
-
   defp render_page(conn, page) do
     chunks = conn |> chunks_for_page(page)
     conn |> render_chunks(chunks)
   end
 
   defp chunks_for_page(conn, page) do
-    key = page |> with_page_prefix(conn)
-
-    with {:ok, chunks} <- Cachex.get(:page_chunks, key) do
+    with {:ok, chunks} <- Cachex.get(:page_chunks, page) do
       chunks
     else
       _ -> nil

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,9 +38,6 @@ while ! [ -f /hab/svc/postgresql/PID ] ; do sleep 1; done
 
 MIX_ENV=test
 
-touch priv/static/hub.html
-touch priv/static/smoke-hub.html
-
 mix do local.hex --force, local.rebar --force, deps.get, ecto.create, ecto.migrate
 
 mix test > tmp/reticulum-test-$(date +%Y%m%d%H%M%S).log && build


### PR DESCRIPTION
After this PR, we should neither fetch nor try to use any of the smoke-prefixed pages from S3 in Reticulum, which is great because we had no reason to.