### PR TITLE
Add super simple sketchfab search API

### DIFF
--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -1,0 +1,28 @@
+defmodule Ret.HttpUtils do
+  use Retry
+
+  def retry_get_until_success(url, headers \\ []) do
+    retry with: exp_backoff() |> randomize |> cap(5_000) |> expiry(10_000) do
+      case HTTPoison.get(url, headers, follow_redirect: true) do
+        {:ok, %HTTPoison.Response{status_code: status_code} = resp}
+        when status_code >= 200 and status_code < 300 ->
+          resp
+
+        {:ok, %HTTPoison.Response{status_code: status_code}}
+        when status_code >= 400 and status_code < 500 ->
+          :unauthorized
+
+        _ ->
+          :error
+      end
+    after
+      result ->
+        case result do
+          :unauthorized -> :error
+          _ -> result
+        end
+    else
+      error -> error
+    end
+  end
+end

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -5,6 +5,7 @@ end
 
 defmodule Ret.MediaResolver do
   use Retry
+  import Ret.HttpUtils
 
   @ytdl_valid_status_codes [200, 302, 500]
 
@@ -246,31 +247,6 @@ defmodule Ret.MediaResolver do
       |> URI.parse()
     else
       _err -> nil
-    end
-  end
-
-  defp retry_get_until_success(url, headers \\ []) do
-    retry with: exp_backoff() |> randomize |> cap(5_000) |> expiry(10_000) do
-      case HTTPoison.get(url, headers, follow_redirect: true) do
-        {:ok, %HTTPoison.Response{status_code: status_code} = resp}
-        when status_code >= 200 and status_code < 300 ->
-          resp
-
-        {:ok, %HTTPoison.Response{status_code: status_code}}
-        when status_code >= 400 and status_code < 500 ->
-          :unauthorized
-
-        _ ->
-          :error
-      end
-    after
-      result ->
-        case result do
-          :unauthorized -> :error
-          _ -> result
-        end
-    else
-      error -> error
     end
   end
 

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -1,0 +1,47 @@
+defmodule Ret.MediaSearchQuery do
+  @enforce_keys [:api]
+  defstruct [:api, :user]
+end
+
+defmodule Ret.MediaSearch do
+  import Ret.HttpUtils
+
+  def search(%Ret.MediaSearchQuery{api: "sketchfab", user: user}) do
+    with api_key when is_binary(api_key) <- resolver_config(:sketchfab_api_key) do
+      res =
+        "https://api.sketchfab.com/v3/search?type=models&downloadable=true&user=#{user}"
+        |> retry_get_until_success([{"Authorization", "Token #{api_key}"}])
+
+      case res do
+        :error ->
+          :error
+
+        res ->
+          res
+          |> Map.get(:body)
+          |> Poison.decode!()
+          |> Map.get("results")
+          |> Enum.map(&sketchfab_api_result_to_media_result/1)
+      end
+    else
+      _ -> %{}
+    end
+  end
+
+  defp sketchfab_api_result_to_media_result(result) do
+    %{
+      media_url: "https://sketchfab.com/models/#{result["uid"]}",
+      images: %{
+        preview:
+          result["thumbnails"]["images"]
+          |> Enum.sort_by(fn x -> -x["size"] end)
+          |> Enum.at(0)
+          |> Kernel.get_in(["url"])
+      }
+    }
+  end
+
+  defp resolver_config(key) do
+    Application.get_env(:ret, Ret.MediaResolver)[key]
+  end
+end

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -3,8 +3,7 @@ defmodule RetWeb.Api.V1.MediaSearchController do
   use Retry
 
   def index(conn, %{"api" => api, "user" => user}) when api in ["sketchfab"] do
-    query = %Ret.MediaSearchQuery{api: api, user: user}
-    results = Ret.MediaSearch.search(query)
+    results = %Ret.MediaSearchQuery{api: api, user: user} |> Ret.MediaSearch.search()
     conn |> render("index.json", results: results)
   end
 

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -1,0 +1,14 @@
+defmodule RetWeb.Api.V1.MediaSearchController do
+  use RetWeb, :controller
+  use Retry
+
+  def index(conn, %{"api" => api, "user" => user}) when api in ["sketchfab"] do
+    query = %Ret.MediaSearchQuery{api: api, user: user}
+    results = Ret.MediaSearch.search(query)
+    conn |> render("index.json", results: results)
+  end
+
+  def index(conn) do
+    conn |> send_resp(422, "")
+  end
+end

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -52,6 +52,7 @@ defmodule RetWeb.Router do
     scope "/v1", as: :api_v1 do
       resources("/hubs", Api.V1.HubController, only: [:create, :delete])
       resources("/media", Api.V1.MediaController, only: [:create])
+      resources("/media/search", Api.V1.MediaSearchController, only: [:index])
     end
   end
 

--- a/lib/ret_web/views/api/v1/media_search_view.ex
+++ b/lib/ret_web/views/api/v1/media_search_view.ex
@@ -1,0 +1,7 @@
+defmodule RetWeb.Api.V1.MediaSearchView do
+  use RetWeb, :view
+
+  def render("index.json", %{results: results}) do
+    %{results: results}
+  end
+end


### PR DESCRIPTION
This adds a super simple /media/search API which currently just allows looking up the first page of a sketchfab user's downloadable models.