### PR TITLE
Recognize MIME type based upon path for uploads

### DIFF
--- a/lib/ret/uploads.ex
+++ b/lib/ret/uploads.ex
@@ -3,7 +3,7 @@ defmodule Ret.Uploads do
 
   @chunk_size 1024 * 1024
 
-  # Given a Plug.Upload and an optional encryption key, returns an id
+  # Given a Plug.Upload, a content-type, and an optional encryption key, returns an id
   # that can be used to fetch a stream to the uploaded file after this call.
   def store(%Plug.Upload{filename: filename, path: path}, content_type, key) do
     with uploads_storage_path when is_binary(uploads_storage_path) <- module_config(:storage_path) do

--- a/lib/ret/uploads.ex
+++ b/lib/ret/uploads.ex
@@ -5,7 +5,7 @@ defmodule Ret.Uploads do
 
   # Given a Plug.Upload and an optional encryption key, returns an id
   # that can be used to fetch a stream to the uploaded file after this call.
-  def store(%Plug.Upload{content_type: content_type, filename: filename, path: path}, key) do
+  def store(%Plug.Upload{filename: filename, path: path}, content_type, key) do
     with uploads_storage_path when is_binary(uploads_storage_path) <- module_config(:storage_path) do
       {:ok, %{size: content_length}} = File.stat(path)
       uuid = Ecto.UUID.generate()

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -10,11 +10,22 @@ defmodule RetWeb.Api.V1.MediaController do
     resolve_and_render(conn, url, 0)
   end
 
+  def create(conn, %{
+        "media" =>
+          %Plug.Upload{filename: filename, content_type: "application/octet-stream"} = upload
+      }) do
+    render_upload(conn, upload, MIME.from_path(filename))
+  end
+
   def create(conn, %{"media" => %Plug.Upload{content_type: content_type} = upload}) do
+    render_upload(conn, upload, content_type)
+  end
+
+  defp render_upload(conn, %Plug.Upload{} = upload, content_type) do
     token = SecureRandom.hex()
     ext = MIME.extensions(content_type) |> List.first()
 
-    case Ret.Uploads.store(upload, token) do
+    case Ret.Uploads.store(upload, content_type, token) do
       {:ok, upload_id} ->
         upload_host = Application.get_env(:ret, Ret.Uploads)[:host] || RetWeb.Endpoint.url()
 


### PR DESCRIPTION
This PR updates the reticulum media API to try to extract the mime type from the uploaded file path if the browser did not specify a content type.