### PR TITLE
Don't store the filename in the meta file

### DIFF
--- a/lib/ret/uploads.ex
+++ b/lib/ret/uploads.ex
@@ -18,7 +18,6 @@ defmodule Ret.Uploads do
           meta = %{
             content_type: content_type,
             content_length: content_length,
-            filename: filename,
             blob: blob_file_path,
             encrypted: key != nil
           }

--- a/lib/ret/uploads.ex
+++ b/lib/ret/uploads.ex
@@ -5,7 +5,7 @@ defmodule Ret.Uploads do
 
   # Given a Plug.Upload, a content-type, and an optional encryption key, returns an id
   # that can be used to fetch a stream to the uploaded file after this call.
-  def store(%Plug.Upload{filename: filename, path: path}, content_type, key) do
+  def store(%Plug.Upload{path: path}, content_type, key) do
     with uploads_storage_path when is_binary(uploads_storage_path) <- module_config(:storage_path) do
       {:ok, %{size: content_length}} = File.stat(path)
       uuid = Ecto.UUID.generate()


### PR DESCRIPTION
This tiny PR removes storage of the original filename in the meta file for uploads, because we don't need it and it may contain private information.