### PR TITLE
Feature/object spawn telemetry

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -56,7 +56,7 @@ defmodule Ret.Hub do
   def changeset_for_new_spawned_object_type(%Hub{} = hub, object_type)
       when object_type in 1..32 do
     # spawned_object_types is a bitmask of the seen object types
-    new_spawned_object_types = hub.spawned_object_types ||| object_type
+    new_spawned_object_types = hub.spawned_object_types ||| 1 <<< object_type
 
     hub
     |> cast(%{spawned_object_types: new_spawned_object_types}, [:spawned_object_types])

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -104,7 +104,8 @@ defmodule RetWeb.HubChannel do
   end
 
   defp handle_max_occupant_update(socket, occupant_count) do
-    Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid)
+    socket
+    |> hub_for_socket
     |> Hub.changeset_for_new_seen_occupant_count(occupant_count)
     |> Repo.update!()
 
@@ -112,10 +113,15 @@ defmodule RetWeb.HubChannel do
   end
 
   defp handle_object_spawned(socket, object_type) do
-    Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid)
+    socket
+    |> hub_for_socket
     |> Hub.changeset_for_new_spawned_object_type(object_type)
     |> Repo.update!()
 
     socket
+  end
+
+  defp hub_for_socket(socket) do
+    Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid)
   end
 end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -30,6 +30,15 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
+  def handle_in("events:object_spawned", %{"object_type" => object_type}, socket) do
+    socket
+    |> handle_object_spawned(object_type)
+
+    Statix.increment("ret.channels.hub.objects_spawned", 1)
+
+    {:noreply, socket}
+  end
+
   def handle_in(_message, _payload, socket) do
     {:noreply, socket}
   end
@@ -95,13 +104,18 @@ defmodule RetWeb.HubChannel do
   end
 
   defp handle_max_occupant_update(socket, occupant_count) do
-    with hub <- Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid),
-         max_occupant_count <- max(occupant_count, hub.max_occupant_count) do
-      hub
-      |> Hub.changeset_for_new_max_occupants(max_occupant_count)
-      |> Repo.update!()
+    Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid)
+    |> Hub.changeset_for_new_seen_occupant_count(occupant_count)
+    |> Repo.update!()
 
-      socket
-    end
+    socket
+  end
+
+  defp handle_object_spawned(socket, object_type) do
+    Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid)
+    |> Hub.changeset_for_new_spawned_object_type(object_type)
+    |> Repo.update!()
+
+    socket
   end
 end

--- a/priv/repo/migrations/20180808191456_add_has_media_objects_bit.exs
+++ b/priv/repo/migrations/20180808191456_add_has_media_objects_bit.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddHasMediaObjectsBit do
+  use Ecto.Migration
+
+  def change do
+    alter table("hubs") do
+      add(:spawned_object_types, :int, null: false, default: 0)
+    end
+  end
+end


### PR DESCRIPTION
Goes with https://github.com/mozilla/hubs/pull/507

Adds a new `object_spawned` Hub channel message that is used to record the types of objects that were spawned in a room for telemetry purposes.