### PR TITLE
Feature/support api

### DIFF
--- a/habitat/config/ret.prod.conf
+++ b/habitat/config/ret.prod.conf
@@ -37,4 +37,5 @@ ret.Elixir.Ret.Mailer.server = "{{ cfg.email.server }}"
 ret.Elixir.Ret.Mailer.port = {{ cfg.email.port }}
 ret.Elixir.Ret.Mailer.username = "{{ cfg.email.username }}"
 ret.Elixir.Ret.Mailer.password = "{{ cfg.email.password }}"
+ret.Elixir.Ret.Support.slack_webhook_url = "{{ cfg.support.slack_webhook_url }}"
 secure_headers.Elixir.SecureHeaders.secure_headers.config.content_security_policy = "{{ cfg.security.content_security_policy }}"

--- a/habitat/config/ret.schema.exs
+++ b/habitat/config/ret.schema.exs
@@ -296,6 +296,13 @@
       doc: "SMTP server password for sending outgoing email",
       hidden: false,
       to: "ret.Elixir.Ret.Mailer.password"
+    ],
+    "ret.Elixir.Ret.Support.slack_webhook_url": [
+      commented: false,
+      datatype: :binary,
+      doc: "Slack Webhook URL for incoming support requests",
+      hidden: false,
+      to: "ret.Elixir.Ret.Support.slack_webhook_url"
     ]
   ],
   transforms: [],

--- a/lib/ret/support.ex
+++ b/lib/ret/support.ex
@@ -1,0 +1,44 @@
+defmodule Ret.Support do
+  alias Ret.{Repo, Support, SupportSubscription}
+
+  import Ecto.Query
+
+  def available? do
+    SupportSubscription |> Repo.all() |> Enum.empty?() |> Kernel.not()
+  end
+
+  def request_support_for_hub(hub) do
+    if Support.available?() do
+      SupportSubscription
+      |> where(channel: "slack")
+      |> Repo.all()
+      |> Enum.map(&Map.get(&1, :identifier))
+      |> notify_slack_handles(hub)
+    end
+  end
+
+  defp notify_slack_handles(handles, hub) do
+    with slack_url when is_binary(slack_url) <- module_config(:slack_webhook_url) do
+      at_handles = handles |> Enum.map(fn h -> "@#{h}" end)
+
+      payload =
+        %{
+          "icon_emoji" => ":quest:",
+          "link_names" => "1",
+          "text" =>
+            "*Incoming support request*\nOn call: #{at_handles |> Enum.join(" ")}\n<#{RetWeb.Endpoint.url()}/#{
+              hub.hub_sid
+            }|Enter Now>"
+        }
+        |> Poison.encode!()
+
+      {:ok, _resp} = HTTPoison.post(slack_url, payload, [{"Content-Type", "application/json"}])
+    end
+
+    {:ok}
+  end
+
+  defp module_config(key) do
+    Application.get_env(:ret, __MODULE__)[key]
+  end
+end

--- a/lib/ret/support_subscription.ex
+++ b/lib/ret/support_subscription.ex
@@ -1,0 +1,32 @@
+defmodule Ret.SupportSubscription do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Ret.{SupportSubscription, Repo}
+
+  @schema_prefix "ret0"
+  @primary_key {:support_subscription_id, :id, autogenerate: true}
+
+  schema "support_subscriptions" do
+    field(:channel, :string)
+    field(:identifier, :string)
+
+    timestamps()
+  end
+
+  def changeset(
+        %SupportSubscription{} = subscription,
+        params \\ %{}
+      ) do
+    subscription
+    |> cast(params, [:identifier])
+    |> validate_required([:identifier])
+    |> validate_length(:identifier, min: 3, max: 64)
+    # TODO more channels
+    |> put_change(:channel, "slack")
+  end
+
+  def support_available? do
+    SupportSubscription |> Repo.all() |> Enum.empty?() |> Kernel.not()
+  end
+end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -39,6 +39,13 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
+  def handle_in("events:request_support", _payload, socket) do
+    hub = socket |> hub_for_socket
+    Task.async(fn -> hub |> Ret.Support.request_support_for_hub() end)
+
+    {:noreply, socket}
+  end
+
   def handle_in(_message, _payload, socket) do
     {:noreply, socket}
   end

--- a/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
+++ b/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
@@ -6,10 +6,17 @@ defmodule RetWeb.Api.V1.SupportSubscriptionController do
   alias Ret.Repo
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit)
+  plug(RetWeb.Plugs.RateLimit when action in [:create, :delete])
 
   # Only allow access with secret header
-  plug(RetWeb.Plugs.HeaderAuthorization when action in [])
+  plug(RetWeb.Plugs.HeaderAuthorization when action in [:create, :delete])
+
+  def index(conn, _params) do
+    case SupportSubscription.support_available?() do
+      true -> conn |> send_resp(200, "OK")
+      false -> conn |> send_resp(404, "Unavailable")
+    end
+  end
 
   def create(conn, %{"subscription" => %{"identifier" => identifier}}) do
     with %SupportSubscription{} <- SupportSubscription |> Repo.get_by(identifier: identifier) do

--- a/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
+++ b/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
@@ -1,0 +1,38 @@
+defmodule RetWeb.Api.V1.SupportSubscriptionController do
+  use RetWeb, :controller
+  import Ecto.Query
+
+  alias Ret.{Repo, SupportSubscription}
+  alias Ret.Repo
+
+  # Limit to 1 TPS
+  plug(RetWeb.Plugs.RateLimit)
+
+  # Only allow access with secret header
+  plug(RetWeb.Plugs.HeaderAuthorization when action in [])
+
+  def create(conn, %{"subscription" => %{"identifier" => identifier}}) do
+    with %SupportSubscription{} <- SupportSubscription |> Repo.get_by(identifier: identifier) do
+      conn |> send_resp(200, "OK")
+    else
+      _ ->
+        {result, _subscription} =
+          %SupportSubscription{}
+          |> SupportSubscription.changeset(%{identifier: identifier})
+          |> Repo.insert()
+
+        case result do
+          :ok -> conn |> send_resp(200, "OK")
+          :error -> conn |> send_resp(422, "error")
+        end
+    end
+  end
+
+  def delete(conn, %{"id" => identifier}) do
+    SupportSubscription
+    |> where(identifier: ^identifier)
+    |> Repo.delete_all()
+
+    conn |> send_resp(200, "OK")
+  end
+end

--- a/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
+++ b/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
@@ -2,7 +2,7 @@ defmodule RetWeb.Api.V1.SupportSubscriptionController do
   use RetWeb, :controller
   import Ecto.Query
 
-  alias Ret.{Repo, SupportSubscription}
+  alias Ret.{Repo, Support, SupportSubscription}
   alias Ret.Repo
 
   # Limit to 1 TPS
@@ -12,7 +12,7 @@ defmodule RetWeb.Api.V1.SupportSubscriptionController do
   plug(RetWeb.Plugs.HeaderAuthorization when action in [:create, :delete])
 
   def index(conn, _params) do
-    case SupportSubscription.support_available?() do
+    case Support.available?() do
       true -> conn |> send_resp(200, "OK")
       false -> conn |> send_resp(404, "Unavailable")
     end

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -57,6 +57,7 @@ defmodule RetWeb.Router do
 
       scope "/support" do
         resources("/subscriptions", Api.V1.SupportSubscriptionController, only: [:create, :delete])
+        resources("/availability", Api.V1.SupportSubscriptionController, only: [:index])
       end
     end
 

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -48,15 +48,16 @@ defmodule RetWeb.Router do
   end
 
   scope "/api", RetWeb do
-    pipe_through(
-      [:secure_headers, :api] ++
-        if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: [])
-    )
+    pipe_through([:secure_headers, :api] ++ if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: []))
 
     scope "/v1", as: :api_v1 do
       resources("/hubs", Api.V1.HubController, only: [:create, :delete])
       resources("/media", Api.V1.MediaController, only: [:create])
       resources("/scenes", Api.V1.SceneController, only: [:show])
+
+      scope "/support" do
+        resources("/subscriptions", Api.V1.SupportSubscriptionController, only: [:create, :delete])
+      end
     end
 
     scope "/v1", as: :api_v1 do
@@ -72,10 +73,7 @@ defmodule RetWeb.Router do
   end
 
   scope "/", RetWeb do
-    pipe_through(
-      [:secure_headers, :browser] ++
-        if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: [])
-    )
+    pipe_through([:secure_headers, :browser] ++ if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: []))
 
     get("/*path", PageController, only: [:index])
   end

--- a/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
+++ b/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
@@ -1,0 +1,13 @@
+defmodule Ret.Repo.Migrations.AddSupportSubscriptionsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:support_subscriptions, prefix: "ret0", primary_key: false) do
+      add(:support_subscription_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+      add(:channel, :string, null: false)
+      add(:identifier, :string, null: false)
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
+++ b/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
@@ -9,5 +9,7 @@ defmodule Ret.Repo.Migrations.AddSupportSubscriptionsTable do
 
       timestamps()
     end
+
+    create(index(:support_subscriptions, [:channel, :identifier], unique: true))
   end
 end

--- a/test/ret/support_subscription_test.exs
+++ b/test/ret/support_subscription_test.exs
@@ -1,0 +1,13 @@
+defmodule Ret.SupportSubscriptionTest do
+  use Ret.DataCase
+
+  alias Ret.{SupportSubscription}
+
+  test "support availability" do
+    assert SupportSubscription.support_available?() == false
+
+    %SupportSubscription{} |> SupportSubscription.changeset(%{identifier: "csr"}) |> Ret.Repo.insert!()
+
+    assert SupportSubscription.support_available?() == true
+  end
+end

--- a/test/ret/support_subscription_test.exs
+++ b/test/ret/support_subscription_test.exs
@@ -1,13 +1,13 @@
 defmodule Ret.SupportSubscriptionTest do
   use Ret.DataCase
 
-  alias Ret.{SupportSubscription}
+  alias Ret.{Support, SupportSubscription}
 
   test "support availability" do
-    assert SupportSubscription.support_available?() == false
+    assert Support.available?() == false
 
     %SupportSubscription{} |> SupportSubscription.changeset(%{identifier: "csr"}) |> Ret.Repo.insert!()
 
-    assert SupportSubscription.support_available?() == true
+    assert Support.available?() == true
   end
 end


### PR DESCRIPTION
Adds a really simple API (to be wired up via a Slack command) to subscribe/unsubscribe from support notifications, as well as a new Hub channel message you can send to trigger a support request.

```
GET /api/v1/support/availability 200 or 404  -> 200 if anyone is available
POST /api/v1/support/subscriptions -> add to support subscriptions table
DELETE /api/v1/support/subscriptions -> remove from support subscriptions table
```

the `request_support` message when sent to a hub channel will ping our slack. there's no rate limiting on our side right now, not sure if that's something we should worry about. 