### PR TITLE
Feature/hub scenes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,7 @@ config :phoenix, :format_encoders, "json-api": Poison
 config :mime, :types, %{
   "application/vnd.api+json" => ["json-api"],
   "model/gltf+json" => ["gltf"],
-  "model/gltf+binary" => ["glb"]
+  "model/gltf-binary" => ["glb"]
 }
 
 # Configures the endpoint

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,8 @@ config :phoenix, :format_encoders, "json-api": Poison
 config :mime, :types, %{
   "application/vnd.api+json" => ["json-api"],
   "model/gltf+json" => ["gltf"],
-  "model/gltf-binary" => ["glb"]
+  "model/gltf-binary" => ["glb"],
+  "model/vnd.spoke.scene" => ["spoke"]
 }
 
 # Configures the endpoint

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -28,11 +28,12 @@ defmodule Ret.Hub do
     field(:max_occupant_count, :integer, default: 0)
     field(:spawned_object_types, :integer, default: 0)
     field(:entry_mode, Ret.Hub.EntryMode)
+    belongs_to(:scene, Ret.Scene, references: :scene_id)
 
     timestamps()
   end
 
-  def changeset(%Hub{} = hub, attrs) do
+  def changeset(%Hub{} = hub, scene, attrs) do
     hub
     |> cast(attrs, [:name, :default_environment_gltf_bundle_url])
     |> validate_required([:name, :default_environment_gltf_bundle_url])
@@ -40,6 +41,7 @@ defmodule Ret.Hub do
     |> validate_format(:name, ~r/^[A-Za-z0-9-':"!@#$%^&*(),.?~ ]+$/)
     |> add_hub_sid_to_changeset
     |> unique_constraint(:hub_sid)
+    |> put_assoc(:scene, scene)
     |> HubSlug.maybe_generate_slug()
     |> HubSlug.unique_constraint()
   end

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -36,7 +36,6 @@ defmodule Ret.Hub do
   def changeset(%Hub{} = hub, scene, attrs) do
     hub
     |> cast(attrs, [:name, :default_environment_gltf_bundle_url])
-    |> validate_required([:name, :default_environment_gltf_bundle_url])
     |> validate_length(:name, min: 4, max: 64)
     |> validate_format(:name, ~r/^[A-Za-z0-9-':"!@#$%^&*(),.?~ ]+$/)
     |> add_hub_sid_to_changeset

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -22,9 +22,12 @@ defmodule Ret.Scene do
     field(:name, :string)
     field(:description, :string)
     field(:attribution, :string)
+    field(:allow_remixing, :boolean)
+    field(:allow_promotion, :boolean)
     belongs_to(:account, Ret.Account, references: :account_id)
     belongs_to(:model_owned_file, Ret.OwnedFile, references: :owned_file_id)
     belongs_to(:screenshot_owned_file, Ret.OwnedFile, references: :owned_file_id)
+    belongs_to(:scene_owned_file, Ret.OwnedFile, references: :owned_file_id)
     field(:state, Scene.State)
 
     timestamps()
@@ -35,6 +38,7 @@ defmodule Ret.Scene do
         account,
         model_owned_file,
         screenshot_owned_file,
+        scene_owned_file,
         params \\ %{}
       ) do
     scene
@@ -42,6 +46,8 @@ defmodule Ret.Scene do
       :name,
       :description,
       :attribution,
+      :allow_remixing,
+      :allow_promotion,
       :state
     ])
     |> validate_required([
@@ -55,6 +61,7 @@ defmodule Ret.Scene do
     |> put_assoc(:account, account)
     |> put_change(:model_owned_file_id, model_owned_file.owned_file_id)
     |> put_change(:screenshot_owned_file_id, screenshot_owned_file.owned_file_id)
+    |> put_change(:scene_owned_file_id, scene_owned_file.owned_file_id)
     |> SceneSlug.maybe_generate_slug()
     |> SceneSlug.unique_constraint()
   end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -9,6 +9,7 @@ defmodule RetWeb.HubChannel do
   def join("hub:" <> hub_sid, _payload, socket) do
     Hub
     |> Repo.get_by(hub_sid: hub_sid)
+    |> Repo.preload(scene: [:model_owned_file, :screenshot_owned_file])
     |> join_with_hub(socket)
   end
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -9,10 +9,8 @@ defmodule RetWeb.HubChannel do
 
   def join("hub:" <> hub_sid, _payload, socket) do
     Hub
-    |> where(hub_sid: ^hub_sid)
-    |> Repo.all()
+    |> Repo.get_by(hub_sid: hub_sid)
     |> Repo.preload(scene: [:model_owned_file, :screenshot_owned_file])
-    |> Enum.at(0)
     |> join_with_hub(socket)
   end
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -2,14 +2,17 @@ defmodule RetWeb.HubChannel do
   @moduledoc "Ret Web Channel for Hubs"
 
   use RetWeb, :channel
+  import Ecto.Query
 
   alias Ret.{Hub, Repo, SessionStat, Statix}
   alias RetWeb.{Presence}
 
   def join("hub:" <> hub_sid, _payload, socket) do
     Hub
-    |> Repo.get_by(hub_sid: hub_sid)
+    |> where(hub_sid: ^hub_sid)
+    |> Repo.all()
     |> Repo.preload(scene: [:model_owned_file, :screenshot_owned_file])
+    |> Enum.at(0)
     |> join_with_hub(socket)
   end
 

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -17,7 +17,7 @@ defmodule RetWeb.Api.V1.HubController do
     |> exec_create(conn)
   end
 
-  def create(conn, %{"hub" => hub_params} = params) do
+  def create(conn, %{"hub" => _hub_params} = params) do
     %Hub{}
     |> Hub.changeset(nil, params["hub"])
     |> exec_create(conn)

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -1,8 +1,7 @@
 defmodule RetWeb.Api.V1.HubController do
   use RetWeb, :controller
 
-  alias Ret.Hub
-  alias Ret.Repo
+  alias Ret.{Hub, Scene, Repo}
 
   # Limit to 1 TPS
   plug(RetWeb.Plugs.RateLimit)
@@ -10,11 +9,22 @@ defmodule RetWeb.Api.V1.HubController do
   # Only allow access with secret header
   plug(RetWeb.Plugs.HeaderAuthorization when action in [:delete])
 
+  def create(conn, %{"hub" => %{"scene_id" => scene_id}} = hub_params) do
+    scene = Scene |> Repo.get_by(scene_sid: scene_id)
+
+    %Hub{}
+    |> Hub.changeset(scene, hub_params)
+    |> exec_create(conn)
+  end
+
   def create(conn, %{"hub" => hub_params}) do
-    {result, hub} =
-      %Hub{}
-      |> Hub.changeset(hub_params)
-      |> Repo.insert()
+    %Hub{}
+    |> Hub.changeset(nil, hub_params)
+    |> exec_create(conn)
+  end
+
+  defp exec_create(hub_changeset, conn) do
+    {result, hub} = hub_changeset |> Repo.insert()
 
     case result do
       :ok -> render(conn, "create.json", hub: hub)

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -9,17 +9,17 @@ defmodule RetWeb.Api.V1.HubController do
   # Only allow access with secret header
   plug(RetWeb.Plugs.HeaderAuthorization when action in [:delete])
 
-  def create(conn, %{"hub" => %{"scene_id" => scene_id}} = hub_params) do
+  def create(conn, %{"hub" => %{"scene_id" => scene_id}} = params) do
     scene = Scene |> Repo.get_by(scene_sid: scene_id)
 
     %Hub{}
-    |> Hub.changeset(scene, hub_params)
+    |> Hub.changeset(scene, params["hub"])
     |> exec_create(conn)
   end
 
-  def create(conn, %{"hub" => hub_params}) do
+  def create(conn, %{"hub" => hub_params} = params) do
     %Hub{}
-    |> Hub.changeset(nil, hub_params)
+    |> Hub.changeset(nil, params["hub"])
     |> exec_create(conn)
   end
 

--- a/lib/ret_web/controllers/api/v1/scene_controller.ex
+++ b/lib/ret_web/controllers/api/v1/scene_controller.ex
@@ -36,7 +36,8 @@ defmodule RetWeb.Api.V1.SceneController do
       Storage.promote(
         %{
           model: {params["model_file_id"], params["model_file_token"]},
-          screenshot: {params["screenshot_file_id"], params["screenshot_file_token"]}
+          screenshot: {params["screenshot_file_id"], params["screenshot_file_token"]},
+          scene: {params["scene_file_id"], params["scene_file_token"]}
         },
         account
       )
@@ -45,16 +46,16 @@ defmodule RetWeb.Api.V1.SceneController do
 
     case promotion_error do
       nil ->
-        %{model: {:ok, model_file}, screenshot: {:ok, screenshot_file}} = owned_file_results
+        %{model: {:ok, model_file}, screenshot: {:ok, screenshot_file}, scene: {:ok, scene_file}} = owned_file_results
 
         {result, scene} =
           scene
-          |> Scene.changeset(account, model_file, screenshot_file, params)
+          |> Scene.changeset(account, model_file, screenshot_file, scene_file, params)
           |> Repo.insert_or_update()
 
         scene =
           scene
-          |> Repo.preload([:model_owned_file, :screenshot_owned_file])
+          |> Repo.preload([:model_owned_file, :screenshot_owned_file, :scene_owned_file])
 
         case result do
           :ok ->

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -28,8 +28,8 @@ defmodule RetWeb.PageController do
       |> String.split("/")
       |> Enum.at(1)
 
-    hub = Hub |> Repo.get_by(hub_sid: hub_sid)
-    hub_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "hub-meta.html", hub: hub)
+    hub = Hub |> Repo.get_by(hub_sid: hub_sid) |> Repo.preload(scene: [:screenshot_owned_file])
+    hub_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "hub-meta.html", hub: hub, scene: hub.scene)
 
     chunks =
       chunks_for_page("hub")

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -2,10 +2,18 @@
 <meta property="og:url" content="<%= RetWeb.Endpoint.url %>/<%= @hub.hub_sid %>/<%= @hub.slug %>" />
 <meta property="og:title" content="<%= @hub.name %> | Hubs by Mozilla" />
 <meta property="og:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
+<%= if @scene do %>
+<meta property="og:image" content="<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
+<% else %>
 <meta property="og:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png" />
+<% end %>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
 <meta name="twitter:title" value="<%= @hub.name %> | Hubs by Mozilla" />
 <meta name="twitter:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
-<meta name="twitter:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png" />
+<%= if @scene do %>
+<meta property="twitter:image" content="<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
+<% else %>
+<meta property="twitter:image" content="<%= RetWeb.Endpoint.url %>/hub-preview.png" />
+<% end %>
 <meta name="twitter:url" value="<%= RetWeb.Endpoint.url %>/<%= @hub.hub_sid %>/<%= @hub.slug %>" />

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -11,7 +11,7 @@ defmodule RetWeb.Api.V1.HubView do
   end
 
   def render("show.json", %{hub: %Hub{scene: %Scene{model_owned_file: model_owned_file}} = hub}) do
-    hub |> render_with_scene_asset(:glb, model_owned_file |> OwnedFile.uri_for() |> URI.to_string())
+    hub |> render_with_scene_asset(:glb, (model_owned_file |> OwnedFile.uri_for() |> URI.to_string()) <> ".glb")
   end
 
   def render("show.json", %{hub: hub}) do

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -11,7 +11,7 @@ defmodule RetWeb.Api.V1.HubView do
   end
 
   def render("show.json", %{hub: %Hub{scene: %Scene{model_owned_file: model_owned_file}} = hub}) do
-    hub |> render_with_scene_asset(:glb, (model_owned_file |> OwnedFile.uri_for() |> URI.to_string()) <> ".glb")
+    hub |> render_with_scene_asset(:glb, model_owned_file |> OwnedFile.uri_for() |> URI.to_string())
   end
 
   def render("show.json", %{hub: hub}) do

--- a/priv/repo/migrations/20180919235959_add_licensing_columns_to_scenes.exs
+++ b/priv/repo/migrations/20180919235959_add_licensing_columns_to_scenes.exs
@@ -1,0 +1,11 @@
+defmodule Ret.Repo.Migrations.AddLicensingColumnsToScenes do
+  use Ecto.Migration
+
+  def change do
+    alter table("scenes") do
+      add(:allow_remixing, :boolean, null: false, default: false)
+      add(:allow_promotion, :boolean, null: false, default: false)
+      add(:scene_owned_file_id, references(:owned_files, column: :owned_file_id))
+    end
+  end
+end

--- a/priv/repo/migrations/20180920000254_add_scene_to_hubs.exs
+++ b/priv/repo/migrations/20180920000254_add_scene_to_hubs.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddSceneToHubs do
+  use Ecto.Migration
+
+  def change do
+    alter table("hubs") do
+      add(:scene_id, references(:scenes, column: :scene_id))
+    end
+  end
+end

--- a/priv/repo/migrations/20180920032008_drop_null_constraint_on_gltf_bundle_url.exs
+++ b/priv/repo/migrations/20180920032008_drop_null_constraint_on_gltf_bundle_url.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.DropNullConstraintOnGltfBundleUrl do
+  use Ecto.Migration
+
+  def change do
+    alter table("hubs") do
+      modify(:default_environment_gltf_bundle_url, :string, null: true)
+    end
+  end
+end


### PR DESCRIPTION
This PR:

- Adds a scene reference to the hub table and wires up all relevant APIs to use that if it is set
- Adds the `allow_promotion` and `allow_remixing` bits to scenes
- Adds the spoke scene file references to scenes and accepts it when uploading a scene
- Shows the scene screenshot in the unfurl