### PR TITLE
Fix scene mutation security issue

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -2,7 +2,6 @@ defmodule RetWeb.HubChannel do
   @moduledoc "Ret Web Channel for Hubs"
 
   use RetWeb, :channel
-  import Ecto.Query
 
   alias Ret.{Hub, Repo, SessionStat, Statix}
   alias RetWeb.{Presence}

--- a/test/ret/storage_test.exs
+++ b/test/ret/storage_test.exs
@@ -1,5 +1,6 @@
 defmodule Ret.StorageTest do
   use Ret.DataCase
+  import Ret.TestHelpers
 
   alias Ret.{OwnedFile, Storage}
 
@@ -74,16 +75,5 @@ defmodule Ret.StorageTest do
 
     assert content_type == expected_content_type
     assert stream |> Enum.map(& &1) |> Enum.join() == expected_content
-  end
-
-  defp generate_temp_file(contents) do
-    {:ok, temp_path} = Temp.mkdir("stored-file-test")
-    file_path = temp_path |> Path.join("test.txt")
-    file_path |> File.write(contents)
-    file_path
-  end
-
-  defp clear_all_stored_files do
-    File.rm_rf(Application.get_env(:ret, Storage)[:storage_path])
   end
 end

--- a/test/ret_web/controllers/api/scene_controller_test.exs
+++ b/test/ret_web/controllers/api/scene_controller_test.exs
@@ -54,7 +54,6 @@ defmodule RetWeb.SceneControllerTest do
     assert updated_scene.description == "New Description"
   end
 
-  @tag :authenticated
   test "scene update disallowed for different user", %{conn: conn, owned_file: owned_file, scene: scene} do
     {:ok, token, _claims} =
       "test2@mozilla.com"

--- a/test/ret_web/controllers/api/scene_controller_test.exs
+++ b/test/ret_web/controllers/api/scene_controller_test.exs
@@ -4,7 +4,7 @@ defmodule RetWeb.SceneControllerTest do
 
   alias Ret.{Account, Scene, Repo}
 
-  setup [:create_account, :create_owned_file]
+  setup [:create_account, :create_owned_file, :create_scene]
 
   setup do
     on_exit(fn ->
@@ -12,15 +12,7 @@ defmodule RetWeb.SceneControllerTest do
     end)
   end
 
-  test "scene show looks up by scene sid", %{conn: conn, account: account, owned_file: owned_file} do
-    {:ok, scene} =
-      %Scene{}
-      |> Scene.changeset(account, owned_file, owned_file, owned_file, %{
-        name: "Test Scene",
-        description: "Test Scene Description"
-      })
-      |> Repo.insert_or_update()
-
+  test "scene show looks up by scene sid", %{conn: conn, scene: scene} do
     response = conn |> get(api_v1_scene_path(conn, :show, scene.scene_sid)) |> json_response(200)
 
     %{
@@ -33,11 +25,69 @@ defmodule RetWeb.SceneControllerTest do
     assert scene_description == "Test Scene Description"
   end
 
+  test "scene create 401's when not logged in", %{conn: conn, owned_file: owned_file} do
+    params = scene_create_or_update_params(owned_file)
+    conn |> post(api_v1_scene_path(conn, :create), params) |> response(401)
+  end
+
+  @tag :authenticated
+  test "scene create works when logged in", %{conn: conn, owned_file: owned_file} do
+    params = scene_create_or_update_params(owned_file)
+    conn |> Plug.Conn.get_req_header("authorization") |> IO.inspect()
+
+    response = conn |> post(api_v1_scene_path(conn, :create), params) |> json_response(200)
+    %{"scenes" => [%{"scene_id" => scene_id}]} = response
+
+    created_scene = Scene |> Repo.get_by(scene_sid: scene_id)
+
+    assert created_scene.name == "Name"
+    assert created_scene.description == "Description"
+  end
+
+  @tag :authenticated
+  test "scene update works when logged in", %{conn: conn, owned_file: owned_file, scene: scene} do
+    params = scene_create_or_update_params(owned_file, "New Name", "New Description")
+    conn |> Plug.Conn.get_req_header("authorization") |> IO.inspect()
+
+    conn |> patch(api_v1_scene_path(conn, :update, scene.scene_sid), params) |> json_response(200)
+    updated_scene = Scene |> Repo.get_by(scene_sid: scene.scene_sid)
+
+    assert updated_scene.name == "New Name"
+    assert updated_scene.description == "New Description"
+  end
+
   defp create_account(_) do
     {:ok, account: Account.account_for_email("test@mozilla.com")}
   end
 
   defp create_owned_file(%{account: account}) do
     {:ok, owned_file: generate_temp_owned_file(account)}
+  end
+
+  defp create_scene(%{account: account, owned_file: owned_file}) do
+    {:ok, scene} =
+      %Scene{}
+      |> Scene.changeset(account, owned_file, owned_file, owned_file, %{
+        name: "Test Scene",
+        description: "Test Scene Description"
+      })
+      |> Repo.insert_or_update()
+
+    {:ok, scene: scene}
+  end
+
+  defp scene_create_or_update_params(owned_file, name \\ "Name", description \\ "Description") do
+    %{
+      "scene" => %{
+        "name" => name,
+        "description" => description,
+        "model_file_id" => owned_file.owned_file_uuid,
+        "model_file_token" => owned_file.key,
+        "screenshot_file_id" => owned_file.owned_file_uuid,
+        "screenshot_file_token" => owned_file.key,
+        "scene_file_id" => owned_file.owned_file_uuid,
+        "scene_file_token" => owned_file.key
+      }
+    }
   end
 end

--- a/test/ret_web/controllers/api/scene_controller_test.exs
+++ b/test/ret_web/controllers/api/scene_controller_test.exs
@@ -1,0 +1,43 @@
+defmodule RetWeb.SceneControllerTest do
+  use RetWeb.ConnCase
+  import Ret.TestHelpers
+
+  alias Ret.{Account, Scene, Repo}
+
+  setup [:create_account, :create_owned_file]
+
+  setup do
+    on_exit(fn ->
+      clear_all_stored_files()
+    end)
+  end
+
+  test "scene show looks up by scene sid", %{conn: conn, account: account, owned_file: owned_file} do
+    {:ok, scene} =
+      %Scene{}
+      |> Scene.changeset(account, owned_file, owned_file, owned_file, %{
+        name: "Test Scene",
+        description: "Test Scene Description"
+      })
+      |> Repo.insert_or_update()
+
+    response = conn |> get(api_v1_scene_path(conn, :show, scene.scene_sid)) |> json_response(200)
+
+    %{
+      "scenes" => [
+        %{"name" => scene_name, "description" => scene_description}
+      ]
+    } = response
+
+    assert scene_name == "Test Scene"
+    assert scene_description == "Test Scene Description"
+  end
+
+  defp create_account(_) do
+    {:ok, account: Account.account_for_email("test@mozilla.com")}
+  end
+
+  defp create_owned_file(%{account: account}) do
+    {:ok, owned_file: generate_temp_owned_file(account)}
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,21 @@
+defmodule Ret.TestHelpers do
+  alias Ret.{Storage}
+
+  def generate_temp_owned_file(account) do
+    temp_file = generate_temp_file("test")
+    {:ok, uuid} = Storage.store(%Plug.Upload{path: temp_file}, "text/plain", "secret")
+    {:ok, owned_file} = Storage.promote(uuid, "secret", account)
+    owned_file
+  end
+
+  def generate_temp_file(contents) do
+    {:ok, temp_path} = Temp.mkdir("stored-file-test")
+    file_path = temp_path |> Path.join("test.txt")
+    file_path |> File.write(contents)
+    file_path
+  end
+
+  def clear_all_stored_files do
+    File.rm_rf(Application.get_env(:ret, Storage)[:storage_path])
+  end
+end


### PR DESCRIPTION
Before this PR it was possible to mutate a scene regardless of what account you were logged in as (oops.) As part of this I added a test suite for the scene controller.