### PR TITLE
Short permalinks

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -112,8 +112,7 @@ defmodule Ret.Hub do
 
   defp add_hub_sid_to_changeset(changeset) do
     hub_sid = Ret.Sids.generate_sid()
-    # Prefix with 0 just to make migration off of these links easier.
-    changeset |> put_change(:hub_sid, "0#{hub_sid}")
+    changeset |> put_change(:hub_sid, hub_sid)
   end
 
   defp add_entry_code_to_changeset(changeset) do

--- a/lib/ret/sids.ex
+++ b/lib/ret/sids.ex
@@ -6,6 +6,6 @@ defmodule Ret.Sids do
     |> :crypto.strong_rand_bytes()
     |> Base.url_encode64()
     |> String.slice(0, 7)
-    |> String.replace(~r/[_-]/, "z")
+    |> String.replace(~r/[_-]/, (:rand.uniform(9) - 1) |> Integer.to_string())
   end
 end

--- a/lib/ret/sids.ex
+++ b/lib/ret/sids.ex
@@ -1,10 +1,11 @@
 defmodule Ret.Sids do
   @num_random_bits_for_sid 16
+
   def generate_sid() do
     @num_random_bits_for_sid
     |> :crypto.strong_rand_bytes()
-    |> Base.encode32()
-    |> String.downcase()
-    |> String.slice(0, 10)
+    |> Base.url_encode64()
+    |> String.slice(0, 7)
+    |> String.replace(~r/[_-]/, "z")
   end
 end

--- a/lib/ret/sids.ex
+++ b/lib/ret/sids.ex
@@ -5,7 +5,7 @@ defmodule Ret.Sids do
     @num_random_bits_for_sid
     |> :crypto.strong_rand_bytes()
     |> Base.url_encode64()
-    |> String.slice(0, 7)
+    |> String.slice(0, 6)
     |> String.replace(~r/[_-]/, "z")
   end
 end

--- a/lib/ret/sids.ex
+++ b/lib/ret/sids.ex
@@ -5,7 +5,7 @@ defmodule Ret.Sids do
     @num_random_bits_for_sid
     |> :crypto.strong_rand_bytes()
     |> Base.url_encode64()
-    |> String.slice(0, 6)
+    |> String.slice(0, 7)
     |> String.replace(~r/[_-]/, "z")
   end
 end

--- a/lib/ret/sids.ex
+++ b/lib/ret/sids.ex
@@ -6,6 +6,6 @@ defmodule Ret.Sids do
     |> :crypto.strong_rand_bytes()
     |> Base.url_encode64()
     |> String.slice(0, 7)
-    |> String.replace(~r/[_-]/, (:rand.uniform(9) - 1) |> Integer.to_string())
+    |> String.replace(~r/[_-]/, (:rand.uniform(10) - 1) |> Integer.to_string())
   end
 end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -29,11 +29,16 @@ defmodule RetWeb.PageController do
   def render_for_path("/link", conn), do: conn |> render_page("link")
   def render_for_path("/link/", conn), do: conn |> render_page("link")
 
-  def render_for_path("/link/" <> entry_code, conn) do
+  def render_for_path("/link/" <> hub_sid_and_slug, conn) do
+    hub_sid = hub_sid_and_slug |> String.split("/") |> List.first()
+    conn |> redirect_to_hub_sid(hub_sid)
+  end
+
+  defp redirect_to_hub_sid(conn, hub_sid) do
     # Rate limit requests for redirects.
     :timer.sleep(500)
 
-    case Hub.get_by_entry_code_string(entry_code) do
+    case Hub.get_by(hub_sid: hub_sid) do
       %Hub{} = hub -> conn |> redirect(to: "/#{hub.hub_sid}/#{hub.slug}")
       _ -> conn |> send_resp(404, "")
     end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -34,16 +34,6 @@ defmodule RetWeb.PageController do
     conn |> redirect_to_hub_sid(hub_sid)
   end
 
-  defp redirect_to_hub_sid(conn, hub_sid) do
-    # Rate limit requests for redirects.
-    :timer.sleep(500)
-
-    case Hub.get_by(hub_sid: hub_sid) do
-      %Hub{} = hub -> conn |> redirect(to: "/#{hub.hub_sid}/#{hub.slug}")
-      _ -> conn |> send_resp(404, "")
-    end
-  end
-
   def render_for_path("/spoke", conn), do: conn |> render_page("spoke")
   def render_for_path("/spoke/", conn), do: conn |> render_page("spoke")
   def render_for_path("/avatar-selector.html", conn), do: conn |> render_page("avatar-selector")
@@ -64,6 +54,16 @@ defmodule RetWeb.PageController do
     conn
     |> put_resp_header("content-type", "text/html; charset=utf-8")
     |> send_resp(200, chunks)
+  end
+
+  defp redirect_to_hub_sid(conn, hub_sid) do
+    # Rate limit requests for redirects.
+    :timer.sleep(500)
+
+    case Hub |> Repo.get_by(hub_sid: hub_sid) do
+      %Hub{} = hub -> conn |> redirect(to: "/#{hub.hub_sid}/#{hub.slug}")
+      _ -> conn |> send_resp(404, "")
+    end
   end
 
   defp render_page(conn, page) do

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -57,9 +57,6 @@ defmodule RetWeb.PageController do
   end
 
   defp redirect_to_hub_sid(conn, hub_sid) do
-    # Rate limit requests for redirects.
-    :timer.sleep(500)
-
     case Hub |> Repo.get_by(hub_sid: hub_sid) do
       %Hub{} = hub -> conn |> redirect(to: "/#{hub.hub_sid}/#{hub.slug}")
       _ -> conn |> send_resp(404, "")


### PR DESCRIPTION
This PR tries to put things in a bit of a saner place wrt sids and permalinks. The goal is to:

- Enable permalinks via hub.link
- Keep them relatively short

Currently, the invite dialog in the client shares `hub.link/entry code` links, which unintuitively expire after 24h. It seems like a good idea to just use entry codes for the case of "go to hub.link directly, type in entry code" since having those expire is OK since it's likely you are getting that information verbally or due to an immediate need, whereas any URL we share ideally should not expire (unless the user wants it to, which is something we may add later.)

This PR:

- Changes the sid generation to 7 alphanumeric chars for a keyspace of 78364164096. (This may not be enough in the long run, but for now is probably fine given the small number of rooms.)

- Drops the leading "0" in hub sids that are fixed -- this was there to future proof the key space for URL redirects but I think we can figure out a better solution if/when the time comes. (Better to have shorter URLs.)

- Updates the /link/ redirector to expect hub sids. You can also include the slug at the end of the redirect link, which is used in the client PR for the longer permalink. (So eg `https://hub.link/acD93Ad/gregs-room`) edit: Upon reflection I'm abandoning this in the client PR -- we should only show the slug for rooms that have custom names I think, but will leave that to a future PR

- Note that hub.link/`entry code` URLs will no longer work, but they expired in 24h anyway.

The net effect is now permanent links to rooms can take on the form of `hub.link/Ab83Dcq` for example, which will redirect to the full canonical URL.