### PR TITLE
Update API for new push client changes

### DIFF
--- a/lib/ret/web_push_subscription.ex
+++ b/lib/ret/web_push_subscription.ex
@@ -76,6 +76,12 @@ defmodule Ret.WebPushSubscription do
     |> Repo.one()
   end
 
+  def endpoint_has_subscriptions?(endpoint) do
+    WebPushSubscription
+    |> where([t], t.endpoint == ^endpoint)
+    |> Repo.one() != nil
+  end
+
   def changeset_for_new(%WebPushSubscription{} = subscription, hub, params) do
     subscription
     |> cast(params, [:p256dh, :auth, :endpoint])


### PR DESCRIPTION
This updates the push API support in reticulum:

- Joining a hub channel now expects an optional web push subscription endpoint, and if supplied will return a flag in the response if there is a subscription for the hub channel being joined for that endpoint

- The `unsubscribe` channel message now provides a response which will tell the caller if the endpoint being unsubscribed has any remaining subscriptions
