### PR TITLE
Add new attributions to schema

### DIFF
--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -22,6 +22,7 @@ defmodule Ret.Scene do
     field(:name, :string)
     field(:description, :string)
     field(:attribution, :string)
+    field(:attributions, :map)
     field(:allow_remixing, :boolean)
     field(:allow_promotion, :boolean)
     belongs_to(:account, Ret.Account, references: :account_id)
@@ -46,6 +47,7 @@ defmodule Ret.Scene do
       :name,
       :description,
       :attribution,
+      :attributions,
       :allow_remixing,
       :allow_promotion,
       :state

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -22,6 +22,7 @@ defmodule RetWeb.Api.V1.SceneView do
           name: scene.name,
           description: scene.description,
           attribution: scene.attribution,
+          attributions: scene.attributions,
           model_url: scene.model_owned_file |> OwnedFile.uri_for() |> URI.to_string(),
           screenshot_url: scene.screenshot_owned_file |> OwnedFile.uri_for() |> URI.to_string(),
           url: url_for_scene(scene)


### PR DESCRIPTION
This PR updates the attributions to be structured JSON data, which will be passed in from spoke to include the individual content attributions (which will have the origin url, name, and author)

See also https://github.com/MozillaReality/Spoke/pull/358 https://github.com/mozilla/hubs/pull/664