### PR TITLE
Emit more content types from Reticulum, small cleanup

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -187,11 +187,15 @@ defmodule Ret.MediaResolver do
           nil
 
         # note that there exist og:image:type and og:video:type tags we could use,
-        # but our OpenGraph library fails to parse them out
+        # but our OpenGraph library fails to parse them out.
+
+        # also, we could technically be correct to emit an "image/*" content type from the OG image case,
+        # but our client right now will be confused by that because some images need to turn into
+        # image-like views and some (GIFs) need to turn into video-like views.
         resp ->
           case resp.body |> OpenGraph.parse() do
             %{video: video} when is_binary(video) -> [URI.parse(video), %{expected_content_type: "video/*"}]
-            %{image: image} when is_binary(image) -> [URI.parse(image), %{expected_content_type: "image/*"}]
+            %{image: image} when is_binary(image) -> [URI.parse(image), %{}] # don't send image/*
             _ -> [uri, %{expected_content_type: content_type_from_headers(resp.headers)}]
           end
       end

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -2,12 +2,8 @@ defmodule RetWeb.Api.V1.MediaController do
   use RetWeb, :controller
   use Retry
 
-  def create(conn, %{"media" => %{"url" => url, "index" => index}}) do
-    resolve_and_render(conn, url, index)
-  end
-
   def create(conn, %{"media" => %{"url" => url}}) do
-    resolve_and_render(conn, url, 0)
+    resolve_and_render(conn, url)
   end
 
   def create(conn, %{
@@ -44,7 +40,6 @@ defmodule RetWeb.Api.V1.MediaController do
           "show.json",
           file_id: uuid,
           origin: uri |> URI.to_string(),
-          raw: uri |> URI.to_string(),
           meta: %{access_token: access_token, promotion_token: promotion_token, expected_content_type: content_type}
         )
 
@@ -53,39 +48,21 @@ defmodule RetWeb.Api.V1.MediaController do
     end
   end
 
-  defp resolve_and_render(conn, url, index) do
+  defp resolve_and_render(conn, url) do
     case Cachex.fetch(:media_urls, url) do
       {_status, nil} ->
         conn |> send_resp(404, "")
 
       {_status, %Ret.ResolvedMedia{} = resolved_media} ->
-        render_resolved_media(conn, resolved_media, index)
+        render_resolved_media(conn, resolved_media)
 
       _ ->
         conn |> send_resp(404, "")
     end
   end
 
-  defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}, index) do
-    raw = gen_farspark_url(uri, index, "raw", "")
-
+  defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}) do
     conn
-    |> render("show.json", origin: uri |> URI.to_string(), raw: raw, meta: meta)
-  end
-
-  defp gen_farspark_url(uri, index, method, extension) do
-    path = "/#{method}/0/0/0/#{index}/#{uri |> URI.to_string() |> Base.url_encode64(padding: false)}#{extension}"
-
-    host = Application.get_env(:ret, :farspark_host)
-    "#{host}/#{gen_signature(path)}#{path}"
-  end
-
-  defp gen_signature(path) do
-    key = Application.get_env(:ret, :farspark_signature_key) |> Base.decode16!(case: :lower)
-    salt = Application.get_env(:ret, :farspark_signature_salt) |> Base.decode16!(case: :lower)
-
-    :sha256
-    |> :crypto.hmac(key, salt <> path)
-    |> Base.url_encode64(padding: false)
+    |> render("show.json", origin: uri |> URI.to_string(), meta: meta)
   end
 end

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -38,7 +38,6 @@ defmodule RetWeb.Api.V1.MediaController do
     case Ret.Storage.store(upload, content_type, access_token, promotion_token) do
       {:ok, uuid} ->
         uri = Ret.Storage.uri_for(uuid, content_type)
-        images = images_for_uri_and_index(uri, 0)
 
         conn
         |> render(
@@ -46,7 +45,6 @@ defmodule RetWeb.Api.V1.MediaController do
           file_id: uuid,
           origin: uri |> URI.to_string(),
           raw: uri |> URI.to_string(),
-          images: images,
           meta: %{access_token: access_token, promotion_token: promotion_token, expected_content_type: content_type}
         )
 
@@ -70,17 +68,9 @@ defmodule RetWeb.Api.V1.MediaController do
 
   defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}, index) do
     raw = gen_farspark_url(uri, index, "raw", "")
-    images = images_for_uri_and_index(uri, index)
 
     conn
-    |> render("show.json", origin: uri |> URI.to_string(), raw: raw, meta: meta, images: images)
-  end
-
-  defp images_for_uri_and_index(uri, index) do
-    %{
-      "png" => gen_farspark_url(uri, index, "extract", ".png"),
-      "jpg" => gen_farspark_url(uri, index, "extract", ".jpg")
-    }
+    |> render("show.json", origin: uri |> URI.to_string(), raw: raw, meta: meta)
   end
 
   defp gen_farspark_url(uri, index, method, extension) do

--- a/lib/ret_web/views/api/v1/media_view.ex
+++ b/lib/ret_web/views/api/v1/media_view.ex
@@ -4,13 +4,12 @@ defmodule RetWeb.Api.V1.MediaView do
   def render("show.json", %{
         file_id: file_id,
         origin: origin,
-        raw: raw,
         meta: meta
       }) do
-    %{file_id: file_id, origin: origin, raw: raw, meta: meta}
+    %{file_id: file_id, origin: origin, meta: meta}
   end
 
-  def render("show.json", %{origin: origin, raw: raw, meta: meta}) do
-    %{origin: origin, raw: raw, meta: meta}
+  def render("show.json", %{origin: origin, meta: meta}) do
+    %{origin: origin, meta: meta}
   end
 end

--- a/lib/ret_web/views/api/v1/media_view.ex
+++ b/lib/ret_web/views/api/v1/media_view.ex
@@ -5,13 +5,12 @@ defmodule RetWeb.Api.V1.MediaView do
         file_id: file_id,
         origin: origin,
         raw: raw,
-        meta: meta,
-        images: images
+        meta: meta
       }) do
-    %{file_id: file_id, origin: origin, raw: raw, meta: meta, images: images}
+    %{file_id: file_id, origin: origin, raw: raw, meta: meta}
   end
 
-  def render("show.json", %{origin: origin, raw: raw, meta: meta, images: images}) do
-    %{origin: origin, raw: raw, meta: meta, images: images}
+  def render("show.json", %{origin: origin, raw: raw, meta: meta}) do
+    %{origin: origin, raw: raw, meta: meta}
   end
 end


### PR DESCRIPTION
**Don't merge quite yet, relies on correct `image/*` handling on the client.**

Whenever we return a content type it saves us a round trip on the client to go see what is there, so we should do it whenever we can.

Also fixed up the imgur handling, which was making an extra API request to get out imgur media URLs which were already present in the original API response; and removed obsolete Farspark-URL-generating machinery.