### PR TITLE
Handle unknown object type spawning

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -72,7 +72,8 @@ defmodule Ret.Hub do
   def changeset_for_new_spawned_object_type(%Hub{} = hub, object_type)
       when object_type in 0..31 do
     # spawned_object_types is a bitmask of the seen object types
-    new_spawned_object_types = hub.spawned_object_types ||| 1 <<< object_type
+    <<new_spawned_object_types::integer-signed-32>> =
+      <<hub.spawned_object_types ||| 1 <<< object_type::integer-signed-32>>
 
     hub
     |> cast(%{spawned_object_types: new_spawned_object_types}, [:spawned_object_types])

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -1,5 +1,6 @@
 defmodule Ret.HubTest do
   use Ret.DataCase
+  use Bitwise
   import Ret.TestHelpers
 
   alias Ret.{Hub, Repo}
@@ -22,5 +23,14 @@ defmodule Ret.HubTest do
     hub = hub |> Hub.ensure_valid_entry_code!()
     assert hub.entry_code > 0
     assert hub |> Hub.entry_code_expired?() == false
+  end
+
+  test "should handle bitmask properly for high order bit", %{scene: scene} do
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+    {:ok, hub} = hub |> Hub.changeset_for_new_spawned_object_type(31) |> Repo.update()
+    {:ok, hub} = hub |> Hub.changeset_for_new_spawned_object_type(4) |> Repo.update()
+
+    <<expected_value::integer-signed-32>> = <<1 <<< 31 ||| 1 <<< 4::integer-unsigned-32>>
+    assert hub.spawned_object_types == expected_value
   end
 end


### PR DESCRIPTION
Fixes a bug causing: https://sentry.prod.mozaws.net/operations/reticulum/issues/4926378/?query=is:unresolved because we're not handling the 31'st bit case properly in telemetry.