### PR TITLE
Feature/janus load balancing

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -157,3 +157,5 @@ config :sentry,
   tags: %{
     env: "dev"
   }
+
+config :ret, Ret.JanusLoadStatus, default_janus_host: "dev.reticulum.io"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -160,6 +160,6 @@ config :sentry,
 
 config :ret, Ret.Habitat, ip: "127.0.0.1", http_port: 9631
 
-config :ret, Ret.JanusLoadStatus,
-  default_janus_host: "dev.reticulum.io",
-  balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
+config :ret, Ret.JanusLoadStatus, default_janus_host: "dev.reticulum.io"
+
+config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -158,4 +158,8 @@ config :sentry,
     env: "dev"
   }
 
-config :ret, Ret.JanusLoadStatus, default_janus_host: "dev.reticulum.io"
+config :ret, Ret.Habitat, ip: "127.0.0.1", http_port: 9631
+
+config :ret, Ret.JanusLoadStatus,
+  default_janus_host: "dev.reticulum.io",
+  balancer_weights: [{600, 1}, {300, 50}, {0, 500}]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -101,3 +101,5 @@ config :sentry,
   tags: %{
     env: "prod"
   }
+
+config :ret, Ret.JanusLoadStatus, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -102,4 +102,4 @@ config :sentry,
     env: "prod"
   }
 
-config :ret, Ret.JanusLoadStatus, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
+config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -26,7 +26,7 @@ hostname = "{{ cfg.db.hostname }}"
 template = "{{ cfg.db.template }}"
 pool_size = {{ cfg.db.pool_size }}
 
-[ret."Elixir.Ret.PeerageProvider"]
+[ret."Elixir.Ret.Habitat"]
 ip = "{{ cfg.habitat.ip }}"
 http_port = {{ cfg.habitat.http_port }}
 

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -30,6 +30,12 @@ pool_size = {{ cfg.db.pool_size }}
 ip = "{{ cfg.habitat.ip }}"
 http_port = {{ cfg.habitat.http_port }}
 
+[ret."JanusLoadStatus"]
+default_janus_host = "{{ cfg.janus.default_host }}"
+janus_service_name = "{{ cfg.janus.service_name }}"
+janus_admin_secret = "{{ cfg.janus.admin_secret }}"
+janus_admin_port = {{ cfg.janus.admin_port }}
+
 [ret."Elixir.Ret.Guardian"]
 secret_key = "{{ cfg.guardian.secret_key }}"
 

--- a/lib/ret/application.ex
+++ b/lib/ret/application.ex
@@ -22,6 +22,8 @@ defmodule Ret.Application do
       worker(Ret.Scheduler, []),
       # Quantum singleton scheduler
       worker(Ret.SingletonScheduler, []),
+      # Room assigner monitor
+      worker(Ret.RoomAssignerMonitor, []),
       # Storage for rate limiting
       worker(PlugAttack.Storage.Ets, [RetWeb.RateLimit.Storage, [clean_period: 60_000]]),
       # Media resolution cache

--- a/lib/ret/application.ex
+++ b/lib/ret/application.ex
@@ -49,6 +49,18 @@ defmodule Ret.Application do
         id: :page_chunk_cache
       ),
 
+      # Janus load status cache
+      worker(
+        Cachex,
+        [
+          :janus_load_status,
+          [
+            warmers: [warmer(module: Ret.JanusLoadStatus)]
+          ]
+        ],
+        id: :janus_load_status
+      ),
+
       # Graceful shutdown
       supervisor(TheEnd.Of.Phoenix, [[timeout: 10_000, endpoint: RetWeb.Endpoint]])
     ]

--- a/lib/ret/habitat.ex
+++ b/lib/ret/habitat.ex
@@ -1,0 +1,35 @@
+defmodule Ret.Habitat do
+  def get_service_name do
+    habitat_config = Application.get_env(:ret, Ret.Habitat)
+    habitat_ip = habitat_config[:ip]
+    habitat_port = habitat_config[:http_port]
+
+    "http://#{habitat_ip}:#{habitat_port}/services"
+    |> fetch_json
+    |> Enum.map(& &1["service_group"])
+    |> Enum.filter(&String.starts_with?(&1, "reticulum"))
+    |> List.first()
+  end
+
+  def get_hosts_for_service(nil) do
+    []
+  end
+
+  def get_hosts_for_service(service_name, hostname_xform \\ fn x -> x end) do
+    habitat_config = Application.get_env(:ret, Ret.Habitat)
+    habitat_ip = habitat_config[:ip]
+    habitat_port = habitat_config[:http_port]
+
+    fetch_json("http://#{habitat_ip}:#{habitat_port}/census")
+    |> get_in(["census_groups", service_name, "population"])
+    |> Map.values()
+    |> Enum.filter(&(&1["alive"] == true))
+    |> Enum.map(&hostname_xform.(&1["sys"]["hostname"]))
+    |> Enum.map(&:erlang.binary_to_atom(&1, :utf8))
+  end
+
+  defp fetch_json(url) do
+    %{status_code: 200, body: body} = HTTPoison.get!(url)
+    body |> Poison.decode!()
+  end
+end

--- a/lib/ret/janus_load_status.ex
+++ b/lib/ret/janus_load_status.ex
@@ -20,7 +20,7 @@ defmodule Ret.JanusLoadStatus do
     {:ok, [{:entries, entries}]}
   end
 
-  # Load tuple is { host, ccu }
+  # Load tuple is { host, ccu || nil } -- if nil then host admin interface is down/unreachable
   defp janus_host_to_load(janus_host) do
     with janus_secret when is_binary(janus_secret) <- module_config(:janus_secret) do
       janus_port = module_config(:janus_admin_port)

--- a/lib/ret/janus_load_status.ex
+++ b/lib/ret/janus_load_status.ex
@@ -1,0 +1,75 @@
+defmodule Ret.JanusLoadStatus do
+  use Cachex.Warmer
+  use Retry
+
+  def interval, do: :timer.seconds(15)
+
+  def execute(_state) do
+    janus_hosts =
+      with default_janus_host when is_binary(default_janus_host) <- module_config(:default_janus_host) do
+        [default_janus_host] |> Enum.map(&:erlang.binary_to_atom(&1, :utf8))
+      else
+        _ -> module_config(:janus_service_name) |> Ret.Habitat.get_hosts_for_service()
+      end
+
+    entries =
+      janus_hosts
+      |> Enum.map(fn h -> Task.async(fn -> janus_host_to_load(h) end) end)
+      |> Enum.map(&Task.await(&1, 30_000))
+
+    {:ok, [{:entries, entries}]}
+  end
+
+  # Load tuple is { host, ccu }
+  defp janus_host_to_load(janus_host) do
+    with janus_secret when is_binary(janus_secret) <- module_config(:janus_secret) do
+      janus_port = module_config(:janus_admin_port)
+
+      janus_payload = %{
+        janus: "list_sessions",
+        transaction: :crypto.strong_rand_bytes(16) |> Base.url_encode64(),
+        admin_secret: janus_secret
+      }
+
+      janus_resp = retry_api_post_until_success("http://#{janus_host}:#{janus_port}/admin", janus_payload)
+
+      case janus_resp do
+        %HTTPoison.Response{status_code: 200, body: body} ->
+          {janus_host, body |> Poison.decode!() |> Kernel.get_in(["sessions"]) |> Enum.count()}
+
+        _ ->
+          {janus_host, nil}
+      end
+    else
+      # No admin secret, don't perform load balancing
+      _ -> {janus_host, 0}
+    end
+  end
+
+  defp retry_api_post_until_success(url, payload) do
+    retry with: exp_backoff() |> randomize |> cap(3_000) |> expiry(5_000) do
+      hackney_options =
+        if module_config(:insecure_ssl) == true do
+          [:insecure]
+        else
+          []
+        end
+
+      # For local dev, allow insecure SSL because of webpack server
+      case HTTPoison.post(url, payload |> Poison.encode!(), [{"Content-Type", "application/json"}],
+             hackney: hackney_options
+           ) do
+        {:ok, %HTTPoison.Response{status_code: 200} = resp} -> resp
+        _ -> :error
+      end
+    after
+      result -> result
+    else
+      error -> error
+    end
+  end
+
+  defp module_config(key) do
+    Application.get_env(:ret, __MODULE__)[key]
+  end
+end

--- a/lib/ret/janus_load_status.ex
+++ b/lib/ret/janus_load_status.ex
@@ -2,7 +2,18 @@ defmodule Ret.JanusLoadStatus do
   use Cachex.Warmer
   use Retry
 
+  import Ret.Stats
+
   def interval, do: :timer.seconds(15)
+
+  def get_host_for_room do
+    {:ok, host_to_ccu} = Cachex.get(:janus_load_status, :host_to_ccu)
+
+    hosts_by_weight =
+      host_to_ccu |> Enum.filter(&(elem(&1, 1) != nil)) |> Enum.map(fn {host, ccu} -> {host, ccu |> weight_for_ccu} end)
+
+    hosts_by_weight |> weighted_sample |> Atom.to_string()
+  end
 
   def execute(_state) do
     janus_hosts =
@@ -14,14 +25,14 @@ defmodule Ret.JanusLoadStatus do
 
     entries =
       janus_hosts
-      |> Enum.map(fn h -> Task.async(fn -> janus_host_to_load(h) end) end)
+      |> Enum.map(fn h -> Task.async(fn -> janus_host_to_ccu(h) end) end)
       |> Enum.map(&Task.await(&1, 30_000))
 
-    {:ok, [{:entries, entries}]}
+    {:ok, [{:host_to_ccu, entries}]}
   end
 
-  # Load tuple is { host, ccu || nil } -- if nil then host admin interface is down/unreachable
-  defp janus_host_to_load(janus_host) do
+  # For given host return { host, ccu || nil } -- if nil then host admin interface is down/unreachable
+  defp janus_host_to_ccu(janus_host) do
     with janus_secret when is_binary(janus_secret) <- module_config(:janus_secret) do
       janus_port = module_config(:janus_admin_port)
 
@@ -71,5 +82,11 @@ defmodule Ret.JanusLoadStatus do
 
   defp module_config(key) do
     Application.get_env(:ret, __MODULE__)[key]
+  end
+
+  # Gets the load balancing weight for the given CCU, which is the first entry in
+  # the balancer_weights config that the CCU exceeds.
+  def weight_for_ccu(ccu) do
+    module_config(:balancer_weights) |> Enum.find(&(ccu >= elem(&1, 0))) |> elem(1) || 1
   end
 end

--- a/lib/ret/load_balancing/janus_load_status.ex
+++ b/lib/ret/load_balancing/janus_load_status.ex
@@ -6,7 +6,8 @@ defmodule Ret.JanusLoadStatus do
 
   def execute(_state) do
     janus_hosts =
-      with default_janus_host when is_binary(default_janus_host) <- module_config(:default_janus_host) do
+      with default_janus_host when is_binary(default_janus_host) and default_janus_host != "" <-
+             module_config(:default_janus_host) do
         [default_janus_host] |> Enum.map(&:erlang.binary_to_atom(&1, :utf8))
       else
         _ -> module_config(:janus_service_name) |> Ret.Habitat.get_hosts_for_service()
@@ -22,7 +23,7 @@ defmodule Ret.JanusLoadStatus do
 
   # For given host return { host, ccu || nil } -- if nil then host admin interface is down/unreachable
   defp janus_host_to_ccu(janus_host) do
-    with janus_secret when is_binary(janus_secret) <- module_config(:janus_secret) do
+    with janus_secret when is_binary(janus_secret) <- module_config(:janus_admin_secret) do
       janus_port = module_config(:janus_admin_port)
 
       janus_payload = %{

--- a/lib/ret/load_balancing/janus_load_status.ex
+++ b/lib/ret/load_balancing/janus_load_status.ex
@@ -2,18 +2,7 @@ defmodule Ret.JanusLoadStatus do
   use Cachex.Warmer
   use Retry
 
-  import Ret.Stats
-
   def interval, do: :timer.seconds(15)
-
-  def get_host_for_room do
-    {:ok, host_to_ccu} = Cachex.get(:janus_load_status, :host_to_ccu)
-
-    hosts_by_weight =
-      host_to_ccu |> Enum.filter(&(elem(&1, 1) != nil)) |> Enum.map(fn {host, ccu} -> {host, ccu |> weight_for_ccu} end)
-
-    hosts_by_weight |> weighted_sample |> Atom.to_string()
-  end
 
   def execute(_state) do
     janus_hosts =
@@ -82,11 +71,5 @@ defmodule Ret.JanusLoadStatus do
 
   defp module_config(key) do
     Application.get_env(:ret, __MODULE__)[key]
-  end
-
-  # Gets the load balancing weight for the given CCU, which is the first entry in
-  # the balancer_weights config that the CCU exceeds.
-  def weight_for_ccu(ccu) do
-    module_config(:balancer_weights) |> Enum.find(&(ccu >= elem(&1, 0))) |> elem(1) || 1
   end
 end

--- a/lib/ret/load_balancing/room_assigner.ex
+++ b/lib/ret/load_balancing/room_assigner.ex
@@ -1,0 +1,46 @@
+defmodule Ret.RoomAssigner do
+  use GenServer
+
+  import Ret.Stats
+
+  def init(state) do
+    {:ok, state}
+  end
+
+  def get_available_host(existing_host \\ nil) do
+    GenServer.call({:global, __MODULE__}, {:get_available_host, existing_host})
+  end
+
+  def handle_call({:get_available_host, existing_host}, _pid, state) do
+    {:ok, host_to_ccu} = Cachex.get(:janus_load_status, :host_to_ccu)
+    is_alive = host_to_ccu |> Keyword.keys() |> Enum.find(&(Atom.to_string(&1) == existing_host)) != nil
+
+    host =
+      if is_alive do
+        existing_host
+      else
+        pick_host()
+      end
+
+    {:reply, host, state}
+  end
+
+  defp pick_host do
+    {:ok, host_to_ccu} = Cachex.get(:janus_load_status, :host_to_ccu)
+
+    hosts_by_weight =
+      host_to_ccu |> Enum.filter(&(elem(&1, 1) != nil)) |> Enum.map(fn {host, ccu} -> {host, ccu |> weight_for_ccu} end)
+
+    hosts_by_weight |> weighted_sample |> Atom.to_string()
+  end
+
+  defp module_config(key) do
+    Application.get_env(:ret, __MODULE__)[key]
+  end
+
+  # Gets the load balancing weight for the given CCU, which is the first entry in
+  # the balancer_weights config that the CCU exceeds.
+  defp weight_for_ccu(ccu) do
+    module_config(:balancer_weights) |> Enum.find(&(ccu >= elem(&1, 0))) |> elem(1) || 1
+  end
+end

--- a/lib/ret/load_balancing/room_assigner_monitor.ex
+++ b/lib/ret/load_balancing/room_assigner_monitor.ex
@@ -6,7 +6,7 @@ defmodule Ret.RoomAssignerMonitor do
   end
 
   def init(_arg) do
-    {:ok, ensure_process()}
+    {:ok, ensure_assigner_process()}
   end
 
   def handle_info({:DOWN, _, :process, _pid, :normal}, assigner_pid) do
@@ -16,10 +16,10 @@ defmodule Ret.RoomAssignerMonitor do
 
   def handle_info({:DOWN, _, :process, _pid, _reason}, _assigner_pid) do
     # Crash/disconnect, restart it
-    {:noreply, ensure_process()}
+    {:noreply, ensure_assigner_process()}
   end
 
-  defp ensure_process do
+  defp ensure_assigner_process do
     pid =
       case GenServer.start_link(Ret.RoomAssigner, [], name: {:global, Ret.RoomAssigner}) do
         {:ok, pid} -> pid

--- a/lib/ret/load_balancing/room_assigner_monitor.ex
+++ b/lib/ret/load_balancing/room_assigner_monitor.ex
@@ -1,0 +1,32 @@
+defmodule Ret.RoomAssignerMonitor do
+  use GenServer
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_arg) do
+    {:ok, ensure_process()}
+  end
+
+  def handle_info({:DOWN, _, :process, _pid, :normal}, assigner_pid) do
+    # Normal shutdown, shut down monitor
+    {:stop, :normal, assigner_pid}
+  end
+
+  def handle_info({:DOWN, _, :process, _pid, _reason}, _assigner_pid) do
+    # Crash/disconnect, restart it
+    {:noreply, ensure_process()}
+  end
+
+  defp ensure_process do
+    pid =
+      case GenServer.start_link(Ret.RoomAssigner, [], name: {:global, Ret.RoomAssigner}) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+
+    Process.monitor(pid)
+    pid
+  end
+end

--- a/lib/ret/peerage_provider.ex
+++ b/lib/ret/peerage_provider.ex
@@ -1,45 +1,13 @@
 defmodule Ret.PeerageProvider do
+  alias Ret.Habitat
+
   def poll do
-    get_service_name()
-    |> get_hosts_for_service
+    Habitat.get_service_name()
+    |> Habitat.get_hosts_for_service(&hostname_to_erlang_node/1)
   end
 
-  defp get_service_name do
-    habitat_config = Application.get_env(:ret, Ret.PeerageProvider)
-    habitat_ip = habitat_config[:ip]
-    habitat_port = habitat_config[:http_port]
-
-    "http://#{habitat_ip}:#{habitat_port}/services"
-    |> fetch_json
-    |> Enum.map(& &1["service_group"])
-    |> Enum.filter(&String.starts_with?(&1, "reticulum"))
-    |> List.first()
-  end
-
-  defp get_hosts_for_service(nil) do
-    []
-  end
-
-  defp get_hosts_for_service(service_name) do
-    habitat_config = Application.get_env(:ret, Ret.PeerageProvider)
-    habitat_ip = habitat_config[:ip]
-    habitat_port = habitat_config[:http_port]
-
-    fetch_json("http://#{habitat_ip}:#{habitat_port}/census")
-    |> get_in(["census_groups", service_name, "population"])
-    |> Map.values()
-    |> Enum.filter(&(&1["alive"] == true))
-    |> Enum.map(&"ret@#{hostname_to_local(&1["sys"]["hostname"])}")
-    |> Enum.map(&:erlang.binary_to_atom(&1, :utf8))
-  end
-
-  defp hostname_to_local(hostname) do
+  defp hostname_to_erlang_node(hostname) do
     [name | tail] = String.split(hostname, ".")
-    Enum.join(["#{name}-local" | tail], ".")
-  end
-
-  defp fetch_json(url) do
-    %{status_code: 200, body: body} = HTTPoison.get!(url)
-    body |> Poison.decode!()
+    Enum.join(["ret@#{name}-local" | tail], ".")
   end
 end

--- a/lib/ret/stats.ex
+++ b/lib/ret/stats.ex
@@ -1,0 +1,15 @@
+defmodule Ret.Stats do
+  # Given a keyword list of symbols to integer weights returns a value according to that distribution
+  #
+  # Eg weighted_sample(a: 1, b: 10) will sample according to a distribution where b is 10x more likely than a.
+  def weighted_sample(value_to_weights) do
+    sum = value_to_weights |> Keyword.values() |> Enum.sum()
+    values_to_p = value_to_weights |> Enum.map(fn {value, weight} -> {value, weight / sum} end)
+    weighted_sample(values_to_p, :rand.uniform())
+  end
+
+  defp weighted_sample([{value, _}], _), do: value
+  defp weighted_sample([{value, p} | _], x) when x < p, do: value
+  defp weighted_sample([{_, p} | t], x), do: weighted_sample(t, x - p)
+  defp weighted_sample(_, _), do: nil
+end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -194,8 +194,7 @@ defmodule RetWeb.HubChannel do
   end
 
   defp join_with_hub(%Hub{} = hub, socket, push_subscription_endpoint) do
-    hub = hub |> Hub.ensure_valid_entry_code!()
-    hub = hub |> Hub.ensure_room!()
+    hub = hub |> Hub.ensure_valid_entry_code!() |> Hub.ensure_room!()
 
     is_push_subscribed =
       push_subscription_endpoint &&

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -195,6 +195,7 @@ defmodule RetWeb.HubChannel do
 
   defp join_with_hub(%Hub{} = hub, socket, push_subscription_endpoint) do
     hub = hub |> Hub.ensure_valid_entry_code!()
+    hub = hub |> Hub.ensure_room!()
 
     is_push_subscribed =
       push_subscription_endpoint &&

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -6,17 +6,6 @@ defmodule RetWeb.PageController do
     render_for_path(conn.request_path, conn)
   end
 
-  def render_for_path("/", conn), do: conn |> render_page("index.html")
-
-  def render_for_path("/scenes/" <> path, conn) do
-    scene_sid =
-      path
-      |> String.split("/")
-      |> Enum.at(0)
-
-    Scene |> Repo.get_by(scene_sid: scene_sid) |> Repo.preload([:screenshot_owned_file]) |> render_scene_content(conn)
-  end
-
   defp render_scene_content(%Scene{} = scene, conn) do
     scene_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "scene-meta.html", scene: scene)
 
@@ -31,6 +20,17 @@ defmodule RetWeb.PageController do
 
   defp render_scene_content(nil, conn) do
     conn |> send_resp(404, "")
+  end
+
+  def render_for_path("/", conn), do: conn |> render_page("index.html")
+
+  def render_for_path("/scenes/" <> path, conn) do
+    scene_sid =
+      path
+      |> String.split("/")
+      |> Enum.at(0)
+
+    Scene |> Repo.get_by(scene_sid: scene_sid) |> Repo.preload([:screenshot_owned_file]) |> render_scene_content(conn)
   end
 
   def render_for_path("/link", conn), do: conn |> render_page("link.html")

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -25,6 +25,7 @@ defmodule RetWeb.Api.V1.HubView do
           hub_id: hub.hub_sid,
           name: hub.name,
           entry_code: hub.entry_code,
+          host: hub.host,
           topics: [
             %{
               topic_id: "#{hub.hub_sid}/#{hub.slug}",

--- a/priv/repo/migrations/20181227040710_add_host_to_hub.exs
+++ b/priv/repo/migrations/20181227040710_add_host_to_hub.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddHostToHub do
+  use Ecto.Migration
+
+  def change do
+    alter table("hubs") do
+      add(:host, :string)
+    end
+  end
+end


### PR DESCRIPTION
Adds the facility to dynamically assign Janus hosts to rooms:

- Introduces a cluster-global process that is responsible for Janus load balancing

- Adds a Cachex warmer that keeps a local cached data structure with maps all healthy Janus nodes (as per the Habitat cansus) to their current CCU (as per the Janus admin API)

- Implements a simple weighted load balancing algorithm (at time of this writing, Janus nodes with > 600 CCU get weight 1, > 300 CCU weight 50, otherwise weight 500)

- When a hub channel is joined, the room (re-)assignment is performed via the gen server