### PR TITLE
Add APIs in the hub channel to allow scene + name changes to hubs

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -1,5 +1,5 @@
 defmodule Ret.Hub.HubSlug do
-  use EctoAutoslugField.Slug, from: :name, to: :slug
+  use EctoAutoslugField.Slug, from: :name, to: :slug, always_change: true
 
   def get_sources(_changeset, _opts) do
     [:hub_sid, :name]
@@ -59,7 +59,6 @@ defmodule Ret.Hub do
     |> unique_constraint(:entry_code)
     |> put_assoc(:scene, scene)
     |> HubSlug.maybe_generate_slug()
-    |> HubSlug.unique_constraint()
   end
 
   def changeset_for_new_seen_occupant_count(%Hub{} = hub, occupant_count) do
@@ -75,6 +74,13 @@ defmodule Ret.Hub do
     |> cast(%{}, [])
     |> put_assoc(:scene, scene)
     |> validate_required([:scene])
+  end
+
+  def changeset_for_new_name(%Hub{} = hub, name) do
+    hub
+    |> cast(%{name: name}, [:name])
+    |> validate_required([:name])
+    |> HubSlug.maybe_generate_slug()
   end
 
   def changeset_for_new_environment_url(%Hub{} = hub, url) do

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -70,6 +70,19 @@ defmodule Ret.Hub do
     |> validate_required([:max_occupant_count])
   end
 
+  def changeset_for_new_scene(%Hub{} = hub, scene) do
+    hub
+    |> cast(%{}, [])
+    |> put_assoc(:scene, scene)
+    |> validate_required([:scene])
+  end
+
+  def changeset_for_new_environment_url(%Hub{} = hub, url) do
+    hub
+    |> cast(%{default_environment_gltf_bundle_url: url}, [:default_environment_gltf_bundle_url])
+    |> validate_required([:default_environment_gltf_bundle_url])
+  end
+
   def changeset_for_new_spawned_object_type(%Hub{} = hub, object_type)
       when object_type in 0..31 do
     # spawned_object_types is a bitmask of the seen object types

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -181,7 +181,7 @@ defmodule RetWeb.HubChannel do
       |> Repo.update!()
       |> Repo.preload(@hub_preloads)
 
-    response = HubView.render("show.json", %{hub: hub})
+    response = HubView.render("show.json", %{hub: hub}) |> Map.put(:session_id, socket.assigns.session_id)
     broadcast!(socket, "hub_changed", response)
 
     {:noreply, socket}

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -16,6 +16,7 @@ defmodule RetWeb.Api.V1.HubView do
         %{
           hub_id: hub.hub_sid,
           name: hub.name,
+          slug: hub.slug,
           entry_code: hub.entry_code,
           host: hub.host,
           scene: RetWeb.Api.V1.SceneView.render_scene(hub.scene)
@@ -36,6 +37,7 @@ defmodule RetWeb.Api.V1.HubView do
         %{
           hub_id: hub.hub_sid,
           name: hub.name,
+          slug: hub.slug,
           entry_code: hub.entry_code,
           host: hub.host,
           topics: [


### PR DESCRIPTION
This adds two new hub channel messages, `update_scene` and `update_hub`. `update_scene` expects a URL to a scene (a Spoke uploaded scene, or a media-resolvable URL to a GLTF/GLB) and updates the database appropriately. `update_hub` allows updating the other aspects to a hub, currently just the name/slug, but eventually likely other user-modifiable attributes of the hub.

additionally, whenever a the state about a hub is changed or needs to be refreshed (such as a scene reload) channel members will get a `hub_refresh` message over the channel, which also includes a list of the stale fields that need to be dealt with. eg if `scene` is a stale scene it means the scene needs to be reloaded/changed and the UI updated, and if the `name` is stale it means the UI needs to be refreshed and the browser location URL replaced with the new slug.