### PR TITLE
Feature/admin credentials

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -113,7 +113,7 @@ config :ret, Ret.Storage,
 
 asset_hosts =
   "https://localhost:4000 https://localhost:8080 " <>
-    "https://#{host}:4000 https://#{host}:8080 https://#{host}:3001 " <>
+    "https://#{host}:4000 https://#{host}:8080 https://#{host}:3000 " <>
     "https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
     "https://farspark-prod.reticulum.io https://farspark-dev.reticulum.io " <> "https://hubs-proxy.com"
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -113,7 +113,7 @@ config :ret, Ret.Storage,
 
 asset_hosts =
   "https://localhost:4000 https://localhost:8080 " <>
-    "https://#{host}:4000 https://#{host}:8080 " <>
+    "https://#{host}:4000 https://#{host}:8080 https://#{host}:3001 " <>
     "https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
     "https://farspark-prod.reticulum.io https://farspark-dev.reticulum.io " <> "https://hubs-proxy.com"
 

--- a/lib/ret/account.ex
+++ b/lib/ret/account.ex
@@ -9,6 +9,7 @@ defmodule Ret.Account do
 
   schema "accounts" do
     field(:min_token_issued_at, :utc_datetime)
+    field(:is_admin, :boolean)
     has_one(:login, Ret.Login, foreign_key: :account_id)
     has_many(:owned_files, Ret.OwnedFile, foreign_key: :account_id)
     has_many(:created_hubs, Ret.Hub, foreign_key: :created_by_account_id)
@@ -46,4 +47,10 @@ defmodule Ret.Account do
   def identifier_hash_for_email(email) do
     email |> String.downcase() |> Ret.Crypto.hash()
   end
+
+  def add_global_perms_for_account(perms, %Ret.Account{is_admin: true}) do
+    perms |> Map.put(:postgrest_role, :ret_admin)
+  end
+
+  def add_global_perms_for_account(perms, _), do: perms
 end

--- a/lib/ret/page_origin_warmer.ex
+++ b/lib/ret/page_origin_warmer.ex
@@ -4,7 +4,7 @@ defmodule Ret.PageOriginWarmer do
 
   @pages ~w(index.html whats-new.html hub.html link.html scene.html spoke.html admin.html avatar-selector.html hub.service.js)
 
-  def interval, do: :timer.seconds(5)
+  def interval, do: :timer.seconds(15)
 
   def execute(_state) do
     with page_origin when is_binary(page_origin) <- module_config(:page_origin) do

--- a/lib/ret/page_origin_warmer.ex
+++ b/lib/ret/page_origin_warmer.ex
@@ -2,9 +2,9 @@ defmodule Ret.PageOriginWarmer do
   use Cachex.Warmer
   use Retry
 
-  @pages ~w(index.html whats-new.html hub.html link.html scene.html spoke.html avatar-selector.html hub.service.js)
+  @pages ~w(index.html whats-new.html hub.html link.html scene.html spoke.html admin.html avatar-selector.html hub.service.js)
 
-  def interval, do: :timer.seconds(15)
+  def interval, do: :timer.seconds(5)
 
   def execute(_state) do
     with page_origin when is_binary(page_origin) <- module_config(:page_origin) do

--- a/lib/ret/perms_token.ex
+++ b/lib/ret/perms_token.ex
@@ -5,6 +5,10 @@ defmodule Ret.PermsToken do
     {:ok, "#{account_id}_#{hub_id}"}
   end
 
+  def subject_for_token(_resource, %{"account_id" => account_id}) do
+    {:ok, "#{account_id}_global"}
+  end
+
   def subject_for_token(_, _) do
     {:error, "Not found"}
   end

--- a/lib/ret/perms_token.ex
+++ b/lib/ret/perms_token.ex
@@ -18,7 +18,7 @@ defmodule Ret.PermsToken do
       Ret.PermsToken.encode_and_sign(
         # PermsTokens do not have a resource associated with them
         nil,
-        perms,
+        perms |> Map.put(:aud, :ret_perms),
         secret: secret,
         allowed_algos: ["RS512"],
         ttl: {5, :minutes},

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -375,6 +375,7 @@ defmodule RetWeb.HubChannel do
 
     hub
     |> Hub.perms_for_account(account)
+    |> Account.add_global_perms_for_account(account)
     |> Map.put(:account_id, account_id)
     |> Map.put(:hub_id, hub.hub_sid)
     |> Ret.PermsToken.token_for_perms()

--- a/lib/ret_web/channels/ret_channel.ex
+++ b/lib/ret_web/channels/ret_channel.ex
@@ -3,17 +3,37 @@ defmodule RetWeb.RetChannel do
 
   use RetWeb, :channel
 
-  alias Ret.{Statix}
+  alias Ret.{Account, Statix}
   alias RetWeb.{Presence}
 
   intercept(["presence_diff"])
 
-  def join("ret", %{"hub_id" => hub_id}, socket) do
-    Statix.increment("ret.channels.ret.joins.ok")
-    vapid_public_key = Application.get_env(:web_push_encryption, :vapid_details)[:public_key]
+  def join("ret", %{"hub_id" => hub_id, "token" => token}, socket) do
+    case Ret.Guardian.resource_from_token(token) do
+      {:ok, %Account{} = account, _claims} ->
+        socket
+        |> Guardian.Phoenix.Socket.put_current_resource(account)
+        |> handle_join(hub_id)
 
-    send(self(), {:begin_tracking, socket.assigns.session_id, hub_id})
-    {:ok, %{vapid_public_key: vapid_public_key}, socket}
+      {:error, reason} ->
+        {:reply, {:error, %{message: "Sign in failed", reason: reason}}, socket}
+    end
+  end
+
+  def join("ret", %{"hub_id" => hub_id}, socket) do
+    socket |> handle_join(hub_id)
+  end
+
+  def handle_in("refresh_perms_token", _params, socket) do
+    account = Guardian.Phoenix.Socket.current_resource(socket)
+
+    perms_token =
+      %{}
+      |> Account.add_global_perms_for_account(account)
+      |> Map.put(:account_id, account.account_id)
+      |> Ret.PermsToken.token_for_perms()
+
+    {:reply, {:ok, %{perms_token: perms_token}}, socket}
   end
 
   def handle_info({:begin_tracking, session_id, hub_id}, socket) do
@@ -28,5 +48,13 @@ defmodule RetWeb.RetChannel do
   def handle_out("presence_diff", _payload, socket) do
     # Do not send presence updates on this channel, for privacy reasons
     {:noreply, socket}
+  end
+
+  defp handle_join(socket, hub_id) do
+    Statix.increment("ret.channels.ret.joins.ok")
+    vapid_public_key = Application.get_env(:web_push_encryption, :vapid_details)[:public_key]
+
+    send(self(), {:begin_tracking, socket.assigns.session_id, hub_id})
+    {:ok, %{vapid_public_key: vapid_public_key}, socket}
   end
 end

--- a/lib/ret_web/channels/ret_channel.ex
+++ b/lib/ret_web/channels/ret_channel.ex
@@ -27,13 +27,19 @@ defmodule RetWeb.RetChannel do
   def handle_in("refresh_perms_token", _params, socket) do
     account = Guardian.Phoenix.Socket.current_resource(socket)
 
-    perms_token =
-      %{}
-      |> Account.add_global_perms_for_account(account)
-      |> Map.put(:account_id, account.account_id)
-      |> Ret.PermsToken.token_for_perms()
+    case account do
+      %Account{} ->
+        perms_token =
+          %{}
+          |> Account.add_global_perms_for_account(account)
+          |> Map.put(:account_id, account.account_id)
+          |> Ret.PermsToken.token_for_perms()
 
-    {:reply, {:ok, %{perms_token: perms_token}}, socket}
+        {:reply, {:ok, %{perms_token: perms_token}}, socket}
+
+      _ ->
+        {:reply, {:error, %{message: "Not logged in"}}, socket}
+    end
   end
 
   def handle_info({:begin_tracking, session_id, hub_id}, socket) do

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -50,6 +50,8 @@ defmodule RetWeb.PageController do
   def render_for_path("/avatar-selector.html", conn), do: conn |> render_page("avatar-selector.html")
   def render_for_path("/hub.service.js", conn), do: conn |> render_page("hub.service.js")
 
+  def render_for_path("/admin", conn), do: conn |> render_page("admin.html")
+
   def render_for_path("/" <> path, conn) do
     [hub_sid | subresource] = path |> String.split("/")
 

--- a/priv/repo/migrations/20190130052213_add_is_admin_column.exs
+++ b/priv/repo/migrations/20190130052213_add_is_admin_column.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddIsAdminColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table("accounts") do
+      add(:is_admin, :boolean)
+    end
+  end
+end


### PR DESCRIPTION
This PR:

- Adds an `is_admin` flag to user accounts
- Adds the necessary permissions to allow access to PostgREST to admin perms tokens
- Updates the `ret_channel` to have a way to refresh global perm tokens
- Adds routes for `/admin` (pending)

One question I had is we needed to add an `aud` to the perms token to properly enforce it on the PostgREST side, I am not sure if this matters but wanted to highlight it.