### PR TITLE
Greatly loosen hub name restrictions

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -77,8 +77,7 @@ defmodule Ret.Hub do
     changeset
     |> cast(attrs, [:name])
     |> validate_required([:name])
-    |> validate_length(:name, min: 4, max: 64)
-    |> validate_format(:name, ~r/^[A-Za-z0-9-':"!@#$%^&*(),.?~ ]+$/)
+    |> validate_length(:name, max: 64)
     |> HubSlug.maybe_generate_slug()
   end
 


### PR DESCRIPTION
It doesn't seem like there is any reason for these, and obviously it is nice to put all of the rest of the characters into Hubs names.

In addition, it's painful to have any reason why Reticulum rejects hub creations or renames, since if you make a request and the name you submitted is invalid you will either get (in the case of creations) a meaningless and hard-to-guess-why-it-happened error message back or (in the case of renames) radio silence. So until that's fixed it's nice to minimize how often that happens.