### PR TITLE
Handle removed scenes, add removed scene enum

### DIFF
--- a/lib/ret/enums.ex
+++ b/lib/ret/enums.ex
@@ -2,6 +2,6 @@ import EctoEnum
 
 defenum(Ret.Hub.EntryMode, :hub_entry_mode, [:allow, :deny], schema: "ret0")
 defenum(Ret.OwnedFile.State, :owned_file_state, [:active, :inactive, :removed], schema: "ret0")
-defenum(Ret.Scene.State, :scene_state, [:active], schema: "ret0")
+defenum(Ret.Scene.State, :scene_state, [:active, :removed], schema: "ret0")
 defenum(Ret.SceneListing.State, :scene_listing_state, [:active, :delisted], schema: "ret0")
 defenum(Ret.Avatar.State, :avatar_state, [:active], schema: "ret0")

--- a/lib/ret_web/templates/page/scene-meta.html.eex
+++ b/lib/ret_web/templates/page/scene-meta.html.eex
@@ -1,3 +1,4 @@
+<%= if @scene.state == :active do %>
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= @scene |> Ret.Scene.to_url %>" />
 <meta property="og:title" content="<%= @scene.name %> | Hubs by Mozilla" />
@@ -10,3 +11,4 @@
 <meta property="twitter:image" content="<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
 <meta name="twitter:url" value="<%= @scene |> Ret.Scene.to_url %>" />
 <title><%= @scene.name %> | Hubs by Mozilla</title>
+<% end %>

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -10,6 +10,9 @@ defmodule RetWeb.Api.V1.SceneView do
     %{scenes: [render_scene(scene)]}
   end
 
+  def render_scene(%Scene{state: :removed}), do: %{}
+  def render_scene(%SceneListing{state: :delisted}), do: %{}
+
   # scene var passed in can be either a Ret.Scene or Ret.SceneListing
   def render_scene(scene) do
     map = %{

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -10,8 +10,8 @@ defmodule RetWeb.Api.V1.SceneView do
     %{scenes: [render_scene(scene)]}
   end
 
-  def render_scene(%Scene{state: :removed}), do: %{}
-  def render_scene(%SceneListing{state: :delisted}), do: %{}
+  def render_scene(%Scene{state: :removed}), do: nil
+  def render_scene(%SceneListing{state: :delisted}), do: nil
 
   # scene var passed in can be either a Ret.Scene or Ret.SceneListing
   def render_scene(scene) do

--- a/priv/repo/migrations/20190312171503_add_removed_state_to_scenes.exs
+++ b/priv/repo/migrations/20190312171503_add_removed_state_to_scenes.exs
@@ -1,0 +1,8 @@
+defmodule Ret.Repo.Migrations.AddRemovedStateToScenes do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+  def change do
+    Ecto.Migration.execute("ALTER TYPE scene_state ADD VALUE IF NOT EXISTS 'removed'")
+  end
+end


### PR DESCRIPTION
Adds the `removed` enum state to scenes, and now masks out all places where we return scene information in the API if the scene (or listing) has been taken down.