### PR TITLE
Add ability to remvoe maps from avatars

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -40,13 +40,18 @@ defmodule Ret.Avatar do
     field(:allow_promotion, :boolean)
     belongs_to(:account, Account, references: :account_id)
 
-    belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id)
-    belongs_to(:bin_owned_file, OwnedFile, references: :owned_file_id)
+    belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:bin_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 
-    belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id)
-    belongs_to(:emissive_map_owned_file, OwnedFile, references: :owned_file_id)
-    belongs_to(:normal_map_owned_file, OwnedFile, references: :owned_file_id)
-    belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id)
+    belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+
+    belongs_to(:emissive_map_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+    )
+
+    belongs_to(:normal_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 
     field(:state, Avatar.State)
 
@@ -92,7 +97,7 @@ defmodule Ret.Avatar do
   def changeset(
         %Avatar{} = avatar,
         account,
-        owned_files,
+        owned_files_map,
         parent_avatar,
         attrs \\ %{}
       ) do
@@ -103,14 +108,18 @@ defmodule Ret.Avatar do
     |> unique_constraint(:avatar_sid)
     |> put_assoc(:account, account)
     |> put_assoc(:parent_avatar, parent_avatar)
-    |> put_owned_files(owned_files)
+    |> put_owned_files(owned_files_map)
     |> AvatarSlug.maybe_generate_slug()
     |> AvatarSlug.unique_constraint()
   end
 
-  defp put_owned_files(changeset, owned_files) do
-    Enum.reduce(owned_files, changeset, fn {key, file}, changes ->
-      changes |> put_change(:"#{key}_owned_file_id", file.owned_file_id)
+  defp put_owned_files(changeset, owned_files_map) do
+    Enum.reduce(owned_files_map, changeset, fn
+      {key, :remove}, changes ->
+        changes |> put_assoc(:"#{key}_owned_file", nil)
+
+      {key, file}, changes ->
+        changeset |> put_assoc(:"#{key}_owned_file", file)
     end)
   end
 

--- a/lib/ret/storage.ex
+++ b/lib/ret/storage.ex
@@ -76,7 +76,7 @@ defmodule Ret.Storage do
 
   # Promotes multiple files into the given account.
   #
-  # Given a map that has { id, key } tuple values, returns a similarly-keyed map
+  # Given a map that has { id, key } or { id, key, promotion_token} tuple values, returns a similarly-keyed map
   # that has the return values of promote as values.
   def promote(map, %Account{} = account) when is_map(map) do
     map


### PR DESCRIPTION
When updating an avatar files that are `null` in the request will correctly be unassociated with the avatar record.