### PR TITLE
Broadcast successful pins to clients

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -318,7 +318,7 @@ defmodule RetWeb.HubChannel do
   end
 
   defp broadcast_pinned_media(socket, object_id, gltf_node) do
-    broadcast!(socket, "pin", %{object_id: object_id, gltf_node: gltf_node, pinner: socket.assigns.session_id})
+    broadcast!(socket, "pin", %{object_id: object_id, gltf_node: gltf_node, pinned_by: socket.assigns.session_id})
   end
 
   # Broadcasts the full hub info as well as an (optional) list of specific fields which

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -299,6 +299,7 @@ defmodule RetWeb.HubChannel do
   defp perform_pin!(object_id, gltf_node, account, socket) do
     hub = socket |> hub_for_socket
     RoomObject.perform_pin!(hub, account, %{object_id: object_id, gltf_node: gltf_node})
+    broadcast_pinned_media(socket, object_id, gltf_node)
   end
 
   def terminate(_reason, socket) do
@@ -314,6 +315,10 @@ defmodule RetWeb.HubChannel do
   defp broadcast_presence_update(socket) do
     Presence.update(socket, socket.assigns.session_id, socket |> presence_meta_for_socket)
     socket
+  end
+
+  defp broadcast_pinned_media(socket, object_id, gltf_node) do
+    broadcast!(socket, "pin", %{object_id: object_id, gltf_node: gltf_node, pinner: socket.assigns.session_id})
   end
 
   # Broadcasts the full hub info as well as an (optional) list of specific fields which


### PR DESCRIPTION
This is sort of redundant for our client, since the pinnage is also communicated via a NAF update on the `pinnable` component. However, it's necessary in order for our Discord bot, which doesn't receive unreliable NAF messages, to know about pins.

In theory, this could probably be fixed more cleanly (in some sense) by making the NAF component update reliable, or by making the Discord bot subscribe to the Janus data channel, but both of those are so much more of a PITA in our architecture that this seems like the best solution.