### PR TITLE
Fix setting multiple avatar maps at once and add cachebusting url to avatar response

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -113,13 +113,13 @@ defmodule Ret.Avatar do
     |> AvatarSlug.unique_constraint()
   end
 
-  defp put_owned_files(changeset, owned_files_map) do
-    Enum.reduce(owned_files_map, changeset, fn
+  defp put_owned_files(in_changeset, owned_files_map) do
+    Enum.reduce(owned_files_map, in_changeset, fn
       {key, :remove}, changes ->
         changes |> put_assoc(:"#{key}_owned_file", nil)
 
       {key, file}, changes ->
-        changeset |> put_assoc(:"#{key}_owned_file", file)
+        changes |> put_assoc(:"#{key}_owned_file", file)
     end)
   end
 

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -18,6 +18,7 @@ defmodule RetWeb.Api.V1.AvatarView do
   end
 
   def render_avatar(avatar) do
+    version = avatar.updated_at |> NaiveDateTime.to_erl |> :calendar.datetime_to_gregorian_seconds
     %{
       avatar_id: avatar.avatar_sid,
       parent_avatar_id: unless(is_nil(avatar.parent_avatar), do: avatar.parent_avatar.avatar_sid),
@@ -26,6 +27,7 @@ defmodule RetWeb.Api.V1.AvatarView do
       attributions: if(is_nil(avatar.attributions), do: [], else: avatar.attributions),
       allow_remixing: avatar.allow_remixing,
       allow_promotion: avatar.allow_promotion,
+      gltf_url: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}/avatar.gltf?v=#{version}",
       files:
         for col <- Avatar.file_columns(), into: %{} do
           key = col |> Atom.to_string() |> String.replace_suffix("_owned_file", "")


### PR DESCRIPTION
When setting multiple maps at once on an avatar only the last map would actually apply because the wrong changeset was being carried forward. This regressed when adding the ability to remove maps.

Also adds `gltf_url` to the response for an avatar which points at the reticulum endpoint for the generated skinned avatar, with a query param for cachebusting based on the `updated_at` column. We should eventually return a CDN cached url for this.