### PR TITLE
Properly render farspark urls for pdf uploads

### DIFF
--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -37,14 +37,20 @@ defmodule RetWeb.Api.V1.MediaController do
 
     case Ret.Storage.store(upload, content_type, access_token, promotion_token) do
       {:ok, uuid} ->
-        uri = Ret.Storage.uri_for(uuid, content_type)
+        origin_uri = Ret.Storage.uri_for(uuid, content_type)
+
+        raw_uri =
+          case content_type do
+            "application/pdf" -> gen_farspark_url(origin_uri, 0, "raw", "") |> URI.parse()
+            _ -> origin_uri
+          end
 
         conn
         |> render(
           "show.json",
           file_id: uuid,
-          origin: uri |> URI.to_string(),
-          raw: uri |> URI.to_string(),
+          origin: origin_uri |> URI.to_string(),
+          raw: raw_uri |> URI.to_string(),
           meta: %{access_token: access_token, promotion_token: promotion_token, expected_content_type: content_type}
         )
 

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -41,7 +41,7 @@ defmodule RetWeb.Api.V1.MediaController do
 
         raw_uri =
           case content_type do
-            "application/pdf" -> gen_farspark_url(origin_uri, 0, "raw", "") |> URI.parse()
+            "application/pdf" -> gen_farspark_url(origin_uri) |> URI.parse()
             _ -> origin_uri
           end
 
@@ -81,14 +81,14 @@ defmodule RetWeb.Api.V1.MediaController do
   end
 
   defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}, index) do
-    raw = gen_farspark_url(uri, index, "raw", "")
+    raw = gen_farspark_url(uri, index)
 
     conn
     |> render("show.json", origin: uri |> URI.to_string(), raw: raw, meta: meta)
   end
 
-  defp gen_farspark_url(uri, index, method, extension) do
-    path = "/#{method}/0/0/0/#{index}/#{uri |> URI.to_string() |> Base.url_encode64(padding: false)}#{extension}"
+  defp gen_farspark_url(uri, index \\ 0) do
+    path = "/raw/0/0/0/#{index}/#{uri |> URI.to_string() |> Base.url_encode64(padding: false)}"
 
     host = Application.get_env(:ret, :farspark_host)
     "#{host}/#{gen_signature(path)}#{path}"


### PR DESCRIPTION
Fixes a bug where we were not properly returning farspark paginating URLs for PDF uploads.