### PR TITLE
Fix perms token guard

### DIFF
--- a/lib/ret/perms_token.ex
+++ b/lib/ret/perms_token.ex
@@ -21,7 +21,7 @@ defmodule Ret.PermsToken do
         # PermsTokens do not have a resource associated with them
         nil,
         perms |> Map.put(:aud, :ret_perms),
-        ttl: {500, :minutes},
+        ttl: {5, :minutes},
         allowed_drift: 60 * 1000
       )
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -283,7 +283,8 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  def handle_in("refresh_perms_token", _args, %{assigns: %{oauth_account_id: oauth_account_id}} = socket) do
+  def handle_in("refresh_perms_token", _args, %{assigns: %{oauth_account_id: oauth_account_id}} = socket)
+      when oauth_account_id != nil do
     perms_token = socket |> hub_for_socket |> get_perms_token(%Ret.OAuthProvider{provider_account_id: oauth_account_id})
     {:reply, {:ok, %{perms_token: perms_token}}, socket}
   end


### PR DESCRIPTION
Regular perms token refreshes were going into the overload meant for oauth perms token refreshes 😞 