### PR TITLE
New Asset, Project, and ProjectAsset routes

### DIFF
--- a/lib/ret/asset.ex
+++ b/lib/ret/asset.ex
@@ -40,7 +40,7 @@ defmodule Ret.Asset do
     Repo.transaction(multi)
   end
 
-  def asset_by_sid_for_account(account, asset_sid) do
+  def asset_by_sid_for_account(asset_sid, account) do
     from(a in Asset,
       where: a.asset_sid == ^asset_sid and a.account_id == ^account.account_id,
       preload: [:account, :asset_owned_file, :thumbnail_owned_file])

--- a/lib/ret/asset.ex
+++ b/lib/ret/asset.ex
@@ -1,6 +1,7 @@
 defmodule Ret.Asset do
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
 
   alias Ecto.{Multi}
   alias Ret.{Repo, Asset, ProjectAsset}
@@ -20,6 +21,12 @@ defmodule Ret.Asset do
     timestamps()
   end
 
+  def create_asset(account, asset_owned_file, thumbnail_owned_file, params) do
+    %Asset{}
+    |> Asset.changeset(account, asset_owned_file, thumbnail_owned_file, params)
+    |> Repo.insert()
+  end
+
   def create_asset_and_project_asset(account, project, asset_owned_file, thumbnail_owned_file, params) do
     asset_changeset = Asset.changeset(%Asset{}, account, asset_owned_file, thumbnail_owned_file, params)
 
@@ -31,6 +38,13 @@ defmodule Ret.Asset do
       end)
 
     Repo.transaction(multi)
+  end
+
+  def asset_by_sid_for_account(account, asset_sid) do
+    from(a in Asset,
+      where: a.asset_sid == ^asset_sid and a.account_id == ^account.account_id,
+      preload: [:account, :asset_owned_file, :thumbnail_owned_file])
+    |> Repo.one
   end
 
   # Create an Asset

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -3,7 +3,7 @@ defmodule Ret.Project do
   import Ecto.Changeset
   import Ecto.Query
 
-  alias Ret.{Repo, Project, OwnedFile}
+  alias Ret.{Repo, Project, ProjectAsset, OwnedFile}
 
   @schema_prefix "ret0"
   @primary_key {:project_id, :id, autogenerate: true}
@@ -30,7 +30,7 @@ defmodule Ret.Project do
   def project_by_sid_for_account(account, project_sid) do
     from(p in Project,
       where: p.project_sid == ^project_sid and p.created_by_account_id == ^account.account_id,
-      preload: [assets: [:asset_owned_file, :thumbnail_owned_file]])
+      preload: [:created_by_account, assets: [:asset_owned_file, :thumbnail_owned_file]])
     |> Repo.one
   end
 
@@ -38,6 +38,12 @@ defmodule Ret.Project do
     Repo.all from p in Project,
       where: p.created_by_account_id == ^account.account_id,
       preload: [:project_owned_file, :thumbnail_owned_file]
+  end
+
+  def add_asset_to_project(project, asset) do
+    %ProjectAsset{}
+    |> ProjectAsset.changeset(project, asset)
+    |> Repo.insert
   end
 
   # Create a Project

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -27,7 +27,7 @@ defmodule Ret.Project do
     |> Repo.preload([:created_by_account, :project_owned_file, :thumbnail_owned_file])
   end
 
-  def project_by_sid_for_account(account, project_sid) do
+  def project_by_sid_for_account(project_sid, account) do
     from(p in Project,
       where: p.project_sid == ^project_sid and p.created_by_account_id == ^account.account_id,
       preload: [:created_by_account, assets: [:asset_owned_file, :thumbnail_owned_file]])
@@ -44,6 +44,12 @@ defmodule Ret.Project do
     %ProjectAsset{}
     |> ProjectAsset.changeset(project, asset)
     |> Repo.insert
+  end
+
+  def create_project(account, params) do
+    with {:ok, project} <- %Project{} |> Project.changeset(account, params) |> Repo.insert() do
+      {:ok, project: Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])}
+    end
   end
 
   # Create a Project

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -48,7 +48,7 @@ defmodule Ret.Project do
 
   def create_project(account, params) do
     with {:ok, project} <- %Project{} |> Project.changeset(account, params) |> Repo.insert() do
-      {:ok, project: Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])}
+      {:ok, Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])}
     end
   end
 

--- a/lib/ret_web.ex
+++ b/lib/ret_web.ex
@@ -23,6 +23,7 @@ defmodule RetWeb do
       import Plug.Conn
       import RetWeb.Router.Helpers
       import RetWeb.Gettext
+      import RetWeb.ControllerHelpers
     end
   end
 

--- a/lib/ret_web/controllers/api/v1/assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/assets_controller.ex
@@ -1,0 +1,42 @@
+defmodule RetWeb.Api.V1.AssetsController do
+  use RetWeb, :controller
+
+  alias Ret.{Asset, Repo, Storage}
+
+  # Limit to 1 TPS
+  plug(RetWeb.Plugs.RateLimit when action in [:create])
+
+  def create(conn, %{"asset" => params}) do
+    account = conn |> Guardian.Plug.current_resource()
+
+    case Storage.promote(params["file_id"], params["access_token"], nil, account) do
+      {:ok, asset_owned_file} ->
+        case Storage.promote(params["thumbnail_file_id"], params["thumbnail_access_token"], nil, account) do
+          {:ok, thumbnail_owned_file} ->
+            case Asset.create_asset(account, asset_owned_file, thumbnail_owned_file, params) do
+              {:ok, asset} ->
+                conn |> render("show.json", asset: asset)
+              {:error, _reason} ->
+                conn |> send_resp(500, "error creating asset")
+            end
+          {:error, _reason} ->
+              conn |> send_resp(422, "invalid owned file")
+        end
+      {:error, _reason} ->
+        conn |> send_resp(422, "invalid owned file")
+    end
+  end
+
+  def delete(conn, %{"id" => asset_sid }) do
+    account = Guardian.Plug.current_resource(conn)
+
+    case Asset.asset_by_sid_for_account(account, asset_sid) do
+      %Asset{} = asset ->
+        case Repo.delete(asset) do
+          {:ok, _} -> conn |> send_resp(200, "OK")
+          {:error, _} -> conn |> send_resp(500, "error deleting asset")
+        end
+      _ -> conn |> send_resp(404, "not found")
+    end
+  end
+end

--- a/lib/ret_web/controllers/api/v1/assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/assets_controller.ex
@@ -7,36 +7,25 @@ defmodule RetWeb.Api.V1.AssetsController do
   plug(RetWeb.Plugs.RateLimit when action in [:create])
 
   def create(conn, %{"asset" => params}) do
-    account = conn |> Guardian.Plug.current_resource()
+    account = Guardian.Plug.current_resource(conn)
 
-    case Storage.promote(params["file_id"], params["access_token"], nil, account) do
-      {:ok, asset_owned_file} ->
-        case Storage.promote(params["thumbnail_file_id"], params["thumbnail_access_token"], nil, account) do
-          {:ok, thumbnail_owned_file} ->
-            case Asset.create_asset(account, asset_owned_file, thumbnail_owned_file, params) do
-              {:ok, asset} ->
-                conn |> render("show.json", asset: asset)
-              {:error, _reason} ->
-                conn |> send_resp(500, "error creating asset")
-            end
-          {:error, _reason} ->
-              conn |> send_resp(422, "invalid owned file")
-        end
-      {:error, _reason} ->
-        conn |> send_resp(422, "invalid owned file")
+    with {:ok, asset_owned_file} <- Storage.promote(params["file_id"], params["access_token"], nil, account),
+         {:ok, thumbnail_owned_file} <- Storage.promote(params["thumbnail_file_id"], params["thumbnail_access_token"], nil, account),
+         {:ok, asset} <- Asset.create_asset(account, asset_owned_file, thumbnail_owned_file, params) do
+      render(conn, "show.json", asset: asset)
+    else
+      {:error, error } ->  render_error_json(conn, error)
     end
   end
 
   def delete(conn, %{"id" => asset_sid }) do
     account = Guardian.Plug.current_resource(conn)
 
-    case Asset.asset_by_sid_for_account(account, asset_sid) do
+    case Asset.asset_by_sid_for_account(asset_sid, account) do
       %Asset{} = asset ->
-        case Repo.delete(asset) do
-          {:ok, _} -> conn |> send_resp(200, "OK")
-          {:error, _} -> conn |> send_resp(500, "error deleting asset")
-        end
-      _ -> conn |> send_resp(404, "not found")
+        Repo.delete(asset)
+        send_resp(conn, 200, "OK")
+      nil -> render_error_json(conn, :not_found)
     end
   end
 end

--- a/lib/ret_web/controllers/api/v1/project_assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_assets_controller.ex
@@ -9,79 +9,58 @@ defmodule RetWeb.Api.V1.ProjectAssetsController do
   def index(conn, %{"project_id" => project_sid}) do
     account = Guardian.Plug.current_resource(conn)
 
-    case Project.project_by_sid_for_account(account, project_sid) do
+    case Project.project_by_sid_for_account(project_sid, account) do
       %Project{} = project -> render(conn, "index.json", assets: project.assets)
-      nil -> conn |> send_resp(404, "Project not found")
+      nil -> render_error_json(conn, :not_found)
     end
   end
 
   def create(conn, %{"project_id" => project_sid, "asset_id" => asset_sid}) do
-    account = conn |> Guardian.Plug.current_resource()
+    account = Guardian.Plug.current_resource(conn)
 
-    case Project.project_by_sid_for_account(account, project_sid) do
-      %Project{} = project ->
-        case Asset.asset_by_sid_for_account(account, asset_sid) do
-          %Asset{} = asset ->
-            case Project.add_asset_to_project(project, asset) do
-              {:ok, _} ->
-                asset = Repo.preload(asset, [:asset_owned_file, :thumbnail_owned_file])
-                conn |> render("show.json", asset: asset)
-              {:error, _} -> conn |> send_resp(500, "error adding asset to project")
-            end
-          _ -> conn |> send_resp(404, "Asset not found")
-        end
-      nil -> conn |> send_resp(404, "Project not found")
+    with %Project{} = project <- Project.project_by_sid_for_account(project_sid, account),
+         %Asset{} = asset <- Asset.asset_by_sid_for_account(asset_sid, account),
+         {:ok, _} <- Project.add_asset_to_project(project, asset) do
+      asset = Repo.preload(asset, [:asset_owned_file, :thumbnail_owned_file])
+      render(conn, "show.json", asset: asset)
+    else
+      {:error, error} -> render_error_json(conn, error)
+      nil -> render_error_json(conn, :not_found)
     end
   end
 
   def create(conn, %{"project_id" => project_sid, "asset" => params}) do
     account = conn |> Guardian.Plug.current_resource()
 
-    case Project.project_by_sid_for_account(account, project_sid) do
+    case Project.project_by_sid_for_account(project_sid, account) do
       %Project{} = project -> create(conn, params, account, project)
-      nil -> conn |> send_resp(404, "Project not found")
+      nil -> render_error_json(conn, :not_found)
     end
   end
 
   defp create(conn, params, account, project) do
-    case Storage.promote(params["file_id"], params["access_token"], nil, account) do
-      {:ok, asset_owned_file} ->
-        case Storage.promote(params["thumbnail_file_id"], params["thumbnail_access_token"], nil, account) do
-          {:ok, thumbnail_owned_file} ->
-            case Asset.create_asset_and_project_asset(account, project, asset_owned_file, thumbnail_owned_file, params) do
-              {:ok, result} ->
-                asset = Repo.preload(result.asset, [:asset_owned_file, :thumbnail_owned_file])
-                conn |> render("show.json", asset: asset)
-              {:error, :asset, _changeset, %{}} ->
-                conn |> send_resp(422, "Invalid asset")
-              {:error, :project_asset, _changeset, %{}} ->
-                conn |> send_resp(500, "Error creating project asset")
-            end
-          {:error, _reason} ->
-              conn |> send_resp(422, "invalid owned file")
-        end
-      {:error, _reason} ->
-        conn |> send_resp(422, "invalid owned file")
+    with {:ok, asset_owned_file} <- Storage.promote(params["file_id"], params["access_token"], nil, account),
+         {:ok, thumbnail_owned_file} <- Storage.promote(params["thumbnail_file_id"], params["thumbnail_access_token"], nil, account),
+         {:ok, result } <- Asset.create_asset_and_project_asset(account, project, asset_owned_file, thumbnail_owned_file, params) do
+      asset = Repo.preload(result.asset, [:asset_owned_file, :thumbnail_owned_file])
+      conn |> render("show.json", asset: asset)
+    else
+      {:error, _, changeset, %{}} -> render_error_json(conn, changeset)
+      {:error, error} -> render_error_json(conn, error)
     end
   end
 
   def delete(conn, %{"project_id" => project_sid, "id" => asset_sid }) do
     account = Guardian.Plug.current_resource(conn)
 
-    case Project.project_by_sid_for_account(account, project_sid) do
-      %Project{} = project -> 
-        case Asset.asset_by_sid_for_account(account, asset_sid) do
-          %Asset{} = asset -> 
-            case Repo.get_by(ProjectAsset, [project_id: project.project_id, asset_id: asset.asset_id]) do
-              %ProjectAsset{} = project_asset ->
-                case Repo.delete(project_asset) do
-                  {:ok, _} -> conn |> send_resp(200, "OK")
-                  {:error, _} -> conn |> send_resp(500, "error removing project asset")
-                end
-            end
-          _ -> conn |> send_resp(404, "not found")
-        end
-      _ -> conn |> send_resp(404, "not found")
+    with %Project{} = project <- Project.project_by_sid_for_account(project_sid, account),
+         %Asset{} = asset <- Asset.asset_by_sid_for_account(asset_sid, account),
+         %ProjectAsset{} = project_asset <- Repo.get_by(ProjectAsset, [project_id: project.project_id, asset_id: asset.asset_id]),
+         {:ok, _} <- Repo.delete(project_asset) do
+      conn |> send_resp(200, "OK")
+    else
+      {:error, error} -> render_error_json(conn, error)
+      nil -> render_error_json(conn, :not_found)
     end
   end
 end

--- a/lib/ret_web/controllers/api/v1/project_assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_assets_controller.ex
@@ -1,12 +1,12 @@
 defmodule RetWeb.Api.V1.ProjectAssetsController do
   use RetWeb, :controller
 
-  alias Ret.{Asset, Project, Repo, Storage}
+  alias Ret.{Asset, Project, ProjectAsset, Repo, Storage}
 
   # Limit to 1 TPS
   plug(RetWeb.Plugs.RateLimit when action in [:create])
 
-  def index(conn, %{"id" => project_sid}) do
+  def index(conn, %{"project_id" => project_sid}) do
     account = Guardian.Plug.current_resource(conn)
 
     case Project.project_by_sid_for_account(account, project_sid) do
@@ -15,7 +15,26 @@ defmodule RetWeb.Api.V1.ProjectAssetsController do
     end
   end
 
-  def create(conn, %{"id" => project_sid, "asset" => params}) do
+  def create(conn, %{"project_id" => project_sid, "asset_id" => asset_sid}) do
+    account = conn |> Guardian.Plug.current_resource()
+
+    case Project.project_by_sid_for_account(account, project_sid) do
+      %Project{} = project ->
+        case Asset.asset_by_sid_for_account(account, asset_sid) do
+          %Asset{} = asset ->
+            case Project.add_asset_to_project(project, asset) do
+              {:ok, _} ->
+                asset = Repo.preload(asset, [:asset_owned_file, :thumbnail_owned_file])
+                conn |> render("show.json", asset: asset)
+              {:error, _} -> conn |> send_resp(500, "error adding asset to project")
+            end
+          _ -> conn |> send_resp(404, "Asset not found")
+        end
+      nil -> conn |> send_resp(404, "Project not found")
+    end
+  end
+
+  def create(conn, %{"project_id" => project_sid, "asset" => params}) do
     account = conn |> Guardian.Plug.current_resource()
 
     case Project.project_by_sid_for_account(account, project_sid) do
@@ -43,6 +62,26 @@ defmodule RetWeb.Api.V1.ProjectAssetsController do
         end
       {:error, _reason} ->
         conn |> send_resp(422, "invalid owned file")
+    end
+  end
+
+  def delete(conn, %{"project_id" => project_sid, "id" => asset_sid }) do
+    account = Guardian.Plug.current_resource(conn)
+
+    case Project.project_by_sid_for_account(account, project_sid) do
+      %Project{} = project -> 
+        case Asset.asset_by_sid_for_account(account, asset_sid) do
+          %Asset{} = asset -> 
+            case Repo.get_by(ProjectAsset, [project_id: project.project_id, asset_id: asset.asset_id]) do
+              %ProjectAsset{} = project_asset ->
+                case Repo.delete(project_asset) do
+                  {:ok, _} -> conn |> send_resp(200, "OK")
+                  {:error, _} -> conn |> send_resp(500, "error removing project asset")
+                end
+            end
+          _ -> conn |> send_resp(404, "not found")
+        end
+      _ -> conn |> send_resp(404, "not found")
     end
   end
 end

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -14,89 +14,50 @@ defmodule RetWeb.Api.V1.ProjectController do
 
   def show(conn, %{"id" => project_sid}) do
     account = Guardian.Plug.current_resource(conn)
-    case Project.project_by_sid_for_account(account, project_sid) do
+
+    case Project.project_by_sid_for_account(project_sid, account) do
       %Project{} = project -> render(conn, "show.json", project: project)
-      _ -> conn |> send_resp(404, "not found")
+      nil -> render_error_json(conn, :not_found)
     end
   end
 
   def create(conn, %{"project" => params}) do
-    account = conn |> Guardian.Plug.current_resource()
+    account = Guardian.Plug.current_resource(conn)
 
-    {result, project} =
-      %Project{}
-      |> Project.changeset(account, params)
-      |> Repo.insert_or_update()
-
-    project = Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])
-
-    case result do
-      :ok ->
-        conn |> render("show.json", project: project)
-
-      :error ->
-        conn |> send_resp(422, "invalid project")
+    case Project.create_project(account, params) do
+      {:ok, project} -> render(conn, "show.json", project: project)
+      {:error, error} -> render_error_json(conn, error)
     end
   end
 
   def update(conn, %{"id" => project_sid, "project" => params}) do
-    account = conn |> Guardian.Plug.current_resource()
+    account = Guardian.Plug.current_resource(conn)
 
-    case Project.project_by_sid_for_account(account, project_sid) do
-      %Project{} = project -> update(conn, params, project, account)
-      _ -> conn |> send_resp(404, "not found")
-    end
-  end
+    promotion_params = %{
+      project: {params["project_file_id"], params["project_file_token"]},
+      thumbnail: {params["thumbnail_file_id"], params["thumbnail_file_token"]},
+    }
 
-  defp update(conn, params, project, account) do
-    owned_file_results =
-      Storage.promote(
-        %{
-          project: {params["project_file_id"], params["project_file_token"]},
-          thumbnail: {params["thumbnail_file_id"], params["thumbnail_file_token"]},
-        },
-        account
-      )
-
-    promotion_error = owned_file_results |> Map.values() |> Enum.filter(&(elem(&1, 0) == :error)) |> Enum.at(0)
-
-    case promotion_error do
-      nil ->
-        %{project: {:ok, project_file}, thumbnail: {:ok, thumbnail_file}} = owned_file_results
-
-        {result, project} =
-          project
-          |> Project.changeset(account, project_file, thumbnail_file, params)
-          |> Repo.update()
-
-        project = Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])
-
-        case result do
-          :ok ->
-            conn |> render("show.json", project: project)
-
-          :error ->
-            conn |> send_resp(422, "invalid project")
-        end
-
-      {:error, :not_found} ->
-        conn |> send_resp(404, "no such file(s)")
-
-      {:error, :not_allowed} ->
-        conn |> send_resp(401, "")
+    with %Project{} = project <- Project.project_by_sid_for_account(project_sid, account),
+         %{project: {:ok, project_file}, thumbnail: {:ok, thumbnail_file}} <- Storage.promote(promotion_params, account),
+         {:ok, project} <- project |> Project.changeset(account, project_file, thumbnail_file, params) |> Repo.update() do
+      project = Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])
+      render(conn, "show.json", project: project)
+    else
+      {:error, error} -> render_error_json(conn, error)
+      nil -> render_error_json(conn, :not_found)
     end
   end
 
   def delete(conn, %{"id" => project_sid }) do
     account = Guardian.Plug.current_resource(conn)
 
-    case Project.project_by_sid_for_account(account, project_sid) do
-      %Project{} = project -> 
-        case Repo.delete(project) do
-          {:ok, _} -> conn |> send_resp(200, "OK")
-          {:error, _} -> conn |> send_resp(500, "error deleting project")
-        end
-      _ -> conn |> send_resp(404, "not found")
+    with %Project{} = project <- Project.project_by_sid_for_account(project_sid, account),
+         {:ok, _} <- Repo.delete(project) do
+      send_resp(conn, 200, "OK")
+    else
+      {:error, error} -> render_error_json(conn, error)
+      nil -> render_error_json(conn, :not_found)
     end
   end
 end

--- a/lib/ret_web/controllers/controller_helpers.ex
+++ b/lib/ret_web/controllers/controller_helpers.ex
@@ -1,0 +1,20 @@
+defmodule RetWeb.ControllerHelpers do
+  import Plug.Conn
+  import Phoenix.Controller
+  import RetWeb.ErrorHelpers
+
+  def render_error_json(conn, status, params) do
+    conn |> put_status(status) |> put_layout(false) |> render(RetWeb.ErrorView, "error.json", %{ error: params })
+  end
+
+  def render_error_json(conn, %Ecto.Changeset{} = changeset) do
+    errors = Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+    render_error_json(conn, 422, errors)
+  end
+
+  def render_error_json(conn, status) do
+    code = Plug.Conn.Status.code(status)
+    reason = Plug.Conn.Status.reason_phrase(code)
+    render_error_json(conn, status, reason)
+  end
+end

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -91,8 +91,10 @@ defmodule RetWeb.Router do
       resources("/scenes", Api.V1.SceneController, only: [:create, :update])
       resources("/avatars", Api.V1.AvatarController, only: [:create, :update])
       resources("/hubs", Api.V1.HubController, only: [:update])
-      resources("/projects", Api.V1.ProjectController, only: [:index, :show, :create, :update])
-      resources("/projects/:id/assets", Api.V1.ProjectAssetsController, only: [:index, :create])
+      resources("/assets", Api.V1.AssetsController, only: [:create, :delete])
+      resources("/projects", Api.V1.ProjectController, only: [:index, :show, :create, :update, :delete]) do
+        resources("/assets", Api.V1.ProjectAssetsController, only: [:index, :create, :delete])
+      end
     end
   end
 

--- a/lib/ret_web/views/api/v1/asset_view.ex
+++ b/lib/ret_web/views/api/v1/asset_view.ex
@@ -1,0 +1,23 @@
+defmodule RetWeb.Api.V1.AssetsView do
+  use RetWeb, :view
+  alias Ret.{OwnedFile}
+
+  defp render_asset(asset) do
+    %{
+      asset_id: asset.asset_sid,
+      name: asset.name,
+      file_url: asset.asset_owned_file |> OwnedFile.uri_for() |> URI.to_string(),
+      thumbnail_url: asset.thumbnail_owned_file |> OwnedFile.uri_for() |> URI.to_string(),
+      type: asset.type,
+      content_type: asset.asset_owned_file.content_type,
+      content_length: asset.asset_owned_file.content_length
+    }
+  end
+
+  def render("show.json", %{asset: asset}) do
+    %{
+      assets: [render_asset(asset)]
+    }
+  end
+
+end

--- a/lib/ret_web/views/error_view.ex
+++ b/lib/ret_web/views/error_view.ex
@@ -1,6 +1,10 @@
 defmodule RetWeb.ErrorView do
   use RetWeb, :view
 
+  def render("error.json", %{ error: error }) do
+    %{error: error}
+  end
+
   def render("404.html", _assigns) do
     "Page not found"
   end

--- a/test/ret_web/controllers/api/assets_controller_test.exs
+++ b/test/ret_web/controllers/api/assets_controller_test.exs
@@ -1,0 +1,74 @@
+defmodule RetWeb.AssetsControllerTest do
+  use RetWeb.ConnCase
+  import Ret.TestHelpers
+
+  alias Ret.{Asset, Repo, Account}
+
+  setup [:create_account, :create_thumbnail_owned_file, :create_asset]
+
+  setup do
+    on_exit(fn ->
+      clear_all_stored_files()
+    end)
+  end
+
+  test "assets create 401's when not logged in", %{conn: conn, thumbnail_owned_file: thumbnail_owned_file} do
+    params = asset_create_params(thumbnail_owned_file, thumbnail_owned_file)
+    conn |> post(api_v1_assets_path(conn, :create), params) |> response(401)
+  end
+
+  @tag :authenticated
+  test "assets create works when logged in", %{conn: conn, thumbnail_owned_file: thumbnail_owned_file} do
+    # Asset file needs to be an image, video, or model so use the thumbnail_owned_file for both the asset and thumbnail
+    params = asset_create_params(thumbnail_owned_file, thumbnail_owned_file)
+
+    response = conn |> post(api_v1_assets_path(conn, :create), params) |> json_response(200)
+    %{"assets" => [%{"asset_id" => asset_id}]} = response
+
+    created_asset = Asset |> Repo.get_by(asset_sid: asset_id)
+
+    assert created_asset.name == "Name"
+  end
+
+  test "assets delete 401's when not logged in", %{conn: conn, asset: asset} do
+    conn |> delete(api_v1_assets_path(conn, :delete, asset.asset_sid)) |> response(401)
+  end
+
+  @tag :authenticated
+  test "assets delete works when logged in", %{conn: conn, asset: asset} do
+    conn |> delete(api_v1_assets_path(conn, :delete, asset.asset_sid)) |> response(200)
+
+    deleted_asset = Asset |> Repo.get_by(asset_sid: asset.asset_sid)
+
+    assert deleted_asset == nil
+  end
+
+  @tag :authenticated
+  test "assets delete shows a 404 when the user does not own the asset", %{conn: conn, thumbnail_owned_file: thumbnail_owned_file} do
+    other_account = Account.account_for_email("test2@mozilla.com")
+
+    {:ok, asset} = %Asset{}
+      |> Asset.changeset(other_account, thumbnail_owned_file, thumbnail_owned_file, %{
+        name: "Test Asset"
+      })
+      |> Repo.insert_or_update()
+
+    conn |> delete(api_v1_assets_path(conn, :delete, asset.asset_sid)) |> response(404)
+
+    deleted_asset = Asset |> Repo.get_by(asset_sid: asset.asset_sid)
+
+    assert deleted_asset != nil
+  end
+
+  defp asset_create_params(owned_file, thumbnail_owned_file, name \\ "Name") do
+    %{
+      "asset" => %{
+        "name" => name,
+        "file_id" => owned_file.owned_file_uuid,
+        "access_token" => owned_file.key,
+        "thumbnail_file_id" => thumbnail_owned_file.owned_file_uuid,
+        "thumbnail_access_token" => thumbnail_owned_file.key
+      }
+    }
+  end
+end

--- a/test/ret_web/controllers/api/project_assets_controller_test.exs
+++ b/test/ret_web/controllers/api/project_assets_controller_test.exs
@@ -2,9 +2,9 @@ defmodule RetWeb.ProjectAssetsControllerTest do
   use RetWeb.ConnCase
   import Ret.TestHelpers
 
-  alias Ret.{Asset, Repo}
+  alias Ret.{Account, Asset, Project, ProjectAsset, Repo}
 
-  setup [:create_account, :create_project_owned_file, :create_thumbnail_owned_file, :create_project, :create_owned_file, :create_project_asset]
+  setup [:create_account, :create_project_owned_file, :create_thumbnail_owned_file, :create_project, :create_owned_file, :create_asset, :create_project_asset]
 
   setup do
     on_exit(fn ->
@@ -13,12 +13,12 @@ defmodule RetWeb.ProjectAssetsControllerTest do
   end
 
   test "project assets index 401's when not logged in", %{conn: conn, project: project} do
-    conn |> get(api_v1_project_assets_path(conn, :index, project.project_sid)) |> response(401)
+    conn |> get(api_v1_project_project_assets_path(conn, :index, project.project_sid)) |> response(401)
   end
 
   @tag :authenticated
   test "project assets index shows assets", %{conn: conn, project: project} do
-    response = conn |> get(api_v1_project_assets_path(conn, :index, project.project_sid)) |> json_response(200)
+    response = conn |> get(api_v1_project_project_assets_path(conn, :index, project.project_sid)) |> json_response(200)
 
 
     %{
@@ -35,7 +35,7 @@ defmodule RetWeb.ProjectAssetsControllerTest do
     } = response
 
     assert asset_id != nil
-    assert asset_name == "Test Asset"
+    assert asset_name == "Test Project Asset"
     assert asset_file_url != nil
     assert asset_thumbnail_url != nil
     assert asset_content_type == "image/png"
@@ -44,7 +44,18 @@ defmodule RetWeb.ProjectAssetsControllerTest do
 
   test "project assets create 401's when not logged in", %{conn: conn, project: project, thumbnail_owned_file: thumbnail_owned_file} do
     params = project_asset_create_or_update_params(thumbnail_owned_file, thumbnail_owned_file)
-    conn |> post(api_v1_project_assets_path(conn, :create, project.project_sid), params) |> response(401)
+    conn |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params) |> response(401)
+  end
+
+  @tag :authenticated
+  test "project asset create adds an asset to a project when passed an asset id", %{conn: conn, project: project, asset: asset} do
+    params = %{ "asset_id" => asset.asset_sid }
+    response = conn |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params) |> json_response(200)
+    %{"assets" => [%{"asset_id" => asset_id}]} = response
+
+    created_asset = Asset |> Repo.get_by(asset_sid: asset_id)
+
+    assert created_asset.name == "Test Asset"
   end
 
   @tag :authenticated
@@ -52,12 +63,59 @@ defmodule RetWeb.ProjectAssetsControllerTest do
     # Asset file needs to be an image, video, or model so use the thumbnail_owned_file for both the asset and thumbnail
     params = project_asset_create_or_update_params(thumbnail_owned_file, thumbnail_owned_file)
 
-    response = conn |> post(api_v1_project_assets_path(conn, :create, project.project_sid), params) |> json_response(200)
+    response = conn |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params) |> json_response(200)
     %{"assets" => [%{"asset_id" => asset_id}]} = response
 
     created_asset = Asset |> Repo.get_by(asset_sid: asset_id)
 
     assert created_asset.name == "Name"
+  end
+
+  test "project assets delete 401's when not logged in", %{conn: conn, project_asset: project_asset} do
+    project = project_asset.project
+    asset = project_asset.asset
+    conn |> delete(api_v1_project_project_assets_path(conn, :delete, project.project_sid, asset.asset_sid)) |> response(401)
+  end
+
+  @tag :authenticated
+  test "project assets delete works when logged in", %{conn: conn, project_asset: project_asset} do
+    project = project_asset.project
+    asset = project_asset.asset
+
+    conn |> delete(api_v1_project_project_assets_path(conn, :delete, project.project_sid, asset.asset_sid)) |> response(200)
+
+    deleted_asset = Asset |> Repo.get_by(asset_sid: asset.asset_sid)
+    deleted_project = Project |> Repo.get_by(project_sid: project.project_sid)
+    deleted_project_asset = ProjectAsset |> Repo.get_by([project_id: project.project_id, asset_id: asset.asset_id])
+
+    assert deleted_asset != nil
+    assert deleted_project != nil
+    assert deleted_project_asset == nil
+  end
+
+  @tag :authenticated
+  test "project assets delete shows a 404 when the user does not own the asset", %{conn: conn, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+    other_account = Account.account_for_email("test2@mozilla.com")
+
+    {:ok, project} = %Project{}
+      |> Project.changeset(other_account, project_owned_file, thumbnail_owned_file, %{
+        name: "Test Scene"
+      })
+      |> Repo.insert_or_update()
+
+    {:ok, asset} =
+      %Asset{}
+      |> Asset.changeset(other_account, thumbnail_owned_file, thumbnail_owned_file, %{
+        name: "Test Project Asset"
+      })
+      |> Repo.insert_or_update()
+
+    {:ok, project_asset} =
+      %ProjectAsset{}
+      |> ProjectAsset.changeset(project, asset)
+      |> Repo.insert_or_update()
+
+    conn |> delete(api_v1_project_project_assets_path(conn, :delete, project_asset.project.project_sid, project_asset.asset.asset_sid)) |> response(404)
   end
 
   defp project_asset_create_or_update_params(owned_file, thumbnail_owned_file, name \\ "Name") do

--- a/test/ret_web/controllers/api/projects_controller_test.exs
+++ b/test/ret_web/controllers/api/projects_controller_test.exs
@@ -1,0 +1,44 @@
+defmodule RetWeb.ProjectsControllerTest do
+  use RetWeb.ConnCase
+  import Ret.TestHelpers
+
+  alias Ret.{Project, Repo, Account}
+
+  setup [:create_account, :create_project_owned_file, :create_thumbnail_owned_file, :create_project]
+
+  setup do
+    on_exit(fn ->
+      clear_all_stored_files()
+    end)
+  end
+
+  test "projects delete 401's when not logged in", %{conn: conn, project: project} do
+    conn |> delete(api_v1_project_path(conn, :delete, project.project_sid)) |> response(401)
+  end
+
+  @tag :authenticated
+  test "projects delete works when logged in", %{conn: conn, project: project} do
+    conn |> delete(api_v1_project_path(conn, :delete, project.project_sid)) |> response(200)
+
+    deleted_project = Project |> Repo.get_by(project_sid: project.project_sid)
+
+    assert deleted_project == nil
+  end
+
+  @tag :authenticated
+  test "projects delete shows a 404 when the user does not own the project", %{conn: conn, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+    other_account = Account.account_for_email("test2@mozilla.com")
+
+    {:ok, project} = %Project{}
+      |> Project.changeset(other_account, project_owned_file, thumbnail_owned_file, %{
+        name: "Test Scene"
+      })
+      |> Repo.insert_or_update()
+
+    conn |> delete(api_v1_project_path(conn, :delete, project.project_sid)) |> response(404)
+
+    deleted_project = Project |> Repo.get_by(project_sid: project.project_sid)
+
+    assert deleted_project != nil
+  end
+end

--- a/test/ret_web/controllers/api/projects_controller_test.exs
+++ b/test/ret_web/controllers/api/projects_controller_test.exs
@@ -12,6 +12,17 @@ defmodule RetWeb.ProjectsControllerTest do
     end)
   end
 
+  test "projects create 401's when not logged in", %{conn: conn} do
+    params = %{ project: %{ name: "Test Project" } }
+    conn |> post(api_v1_project_path(conn, :create)) |> response(401)
+  end
+
+  @tag :authenticated
+  test "projects create works when logged in", %{conn: conn} do
+    params = %{ project: %{ name: "Test Project" } }
+    conn |> post(api_v1_project_path(conn, :create, params)) |> response(200)
+  end
+
   test "projects delete 401's when not logged in", %{conn: conn, project: project} do
     conn |> delete(api_v1_project_path(conn, :delete, project.project_sid)) |> response(401)
   end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -91,11 +91,22 @@ defmodule Ret.TestHelpers do
     {:ok, project: project}
   end
 
-  def create_project_asset(%{account: account, project: project, thumbnail_owned_file: owned_file}) do
+  def create_asset(%{account: account, thumbnail_owned_file: owned_file}) do
     {:ok, asset} =
       %Asset{}
       |> Asset.changeset(account, owned_file, owned_file, %{
         name: "Test Asset"
+      })
+      |> Repo.insert_or_update()
+
+    {:ok, asset: asset}
+  end
+
+  def create_project_asset(%{account: account, project: project, thumbnail_owned_file: owned_file}) do
+    {:ok, asset} =
+      %Asset{}
+      |> Asset.changeset(account, owned_file, owned_file, %{
+        name: "Test Project Asset"
       })
       |> Repo.insert_or_update()
 


### PR DESCRIPTION
- Added POST `/api/v1/assets` route which creates a new user owned asset and accepts an owned file id and access token
- Added DELETE`/api/v1/assets/:id` route which deletes a user owned asset and all ProjectAsset relations
- Added DELETE `/api/v1/projects/:id` for deleting a project
- Added an additional POST `/api/v1/projects/:project_id/assets` route for adding an existing asset to a project by creating a ProjectAsset relation
- Added DELETE `/api/v1/projects/:project_id/assets/:id` for removing an asset from a project by deleting the ProjectAsset relation