### PR TITLE
Add mute message

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -21,6 +21,8 @@ defmodule RetWeb.HubChannel do
   alias RetWeb.{Presence}
   alias RetWeb.Api.V1.{HubView}
 
+  intercept(["mute"])
+
   @hub_preloads [
     scene: [:model_owned_file, :screenshot_owned_file, :scene_owned_file],
     scene_listing: [:model_owned_file, :screenshot_owned_file, :scene_owned_file, :scene],
@@ -148,6 +150,17 @@ defmodule RetWeb.HubChannel do
       context: socket.assigns,
       payload: payload
     })
+
+    {:noreply, socket}
+  end
+
+  def handle_in("mute" = event, payload, socket) do
+    hub = socket |> hub_for_socket
+    account = Guardian.Phoenix.Socket.current_resource(socket)
+
+    if account |> can?(mute_users(hub)) do
+      broadcast_from!(socket, event, payload)
+    end
 
     {:noreply, socket}
   end
@@ -324,6 +337,16 @@ defmodule RetWeb.HubChannel do
   def handle_in(_message, _payload, socket) do
     {:noreply, socket}
   end
+
+  def handle_out("mute" = event, %{"session_id" => session_id} = payload, socket) do
+    if socket.assigns.session_id == session_id do
+      push(socket, event, payload)
+    end
+
+    {:noreply, socket}
+  end
+
+  def handle_out("mute", _payload, socket), do: {:noreply, socket}
 
   defp with_account(socket, handler) do
     case Guardian.Phoenix.Socket.current_resource(socket) do

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -26,12 +26,14 @@ defmodule Ret.HubTest do
 
   test "should deny permissions for non-creator", %{scene: scene} do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
-    %{update_hub: false} = hub |> Hub.perms_for_account(Ret.Account.account_for_email("non-creator@mozilla.com"))
+
+    %{update_hub: false, mute_users: false} =
+      hub |> Hub.perms_for_account(Ret.Account.account_for_email("non-creator@mozilla.com"))
   end
 
   test "should deny permissions for anon", %{scene: scene} do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
-    %{update_hub: false} = hub |> Hub.perms_for_account(nil)
+    %{update_hub: false, mute_users: false} = hub |> Hub.perms_for_account(nil)
   end
 
   test "should grant permssions for hub creator", %{account: account, scene: scene} do
@@ -41,6 +43,6 @@ defmodule Ret.HubTest do
       |> Hub.add_account_to_changeset(account)
       |> Repo.insert()
 
-    %{update_hub: true} = hub |> Hub.perms_for_account(account)
+    %{update_hub: true, mute_users: true} = hub |> Hub.perms_for_account(account)
   end
 end


### PR DESCRIPTION
Adds the `mute` message for user soft muting, which requires `mute_users` permission to deliver to the specific session.