### PR TITLE
Preload project and thumb files

### DIFF
--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -30,7 +30,7 @@ defmodule Ret.Project do
   def project_by_sid_for_account(project_sid, account) do
     from(p in Project,
       where: p.project_sid == ^project_sid and p.created_by_account_id == ^account.account_id,
-      preload: [:created_by_account, assets: [:asset_owned_file, :thumbnail_owned_file]])
+      preload: [:created_by_account, :project_owned_file, :thumbnail_owned_file, assets: [:asset_owned_file, :thumbnail_owned_file]])
     |> Repo.one
   end
 

--- a/test/ret_web/controllers/api/projects_controller_test.exs
+++ b/test/ret_web/controllers/api/projects_controller_test.exs
@@ -12,6 +12,52 @@ defmodule RetWeb.ProjectsControllerTest do
     end)
   end
 
+  test "projects index 401's when not logged in", %{conn: conn} do
+    conn |> get(api_v1_project_path(conn, :index)) |> response(401)
+  end
+
+  @tag :authenticated
+  test "projects index works when logged in", %{conn: conn, project: project} do
+    response = conn |> get(api_v1_project_path(conn, :index)) |> json_response(200)
+
+    %{
+      "projects" => [
+        %{
+          "thumbnail_url" => thumbnail_url,
+          "project_url" => project_url,
+          "project_id" => project_id,
+          "name" => name
+        }
+      ]
+    } = response
+
+    assert name == "Test Scene"
+    assert thumbnail_url != nil
+    assert project_url != nil
+    assert project_id != nil
+  end
+
+  test "projects show 401's when not logged in", %{conn: conn, project: project} do
+    conn |> get(api_v1_project_path(conn, :show, project.project_sid)) |> response(401)
+  end
+
+  @tag :authenticated
+  test "projects show works when logged in", %{conn: conn, project: project} do
+    response = conn |> get(api_v1_project_path(conn, :show, project.project_sid)) |> json_response(200)
+
+    %{
+      "thumbnail_url" => thumbnail_url,
+      "project_url" => project_url,
+      "project_id" => project_id,
+      "name" => name
+    } = response
+
+    assert name == "Test Scene"
+    assert thumbnail_url != nil
+    assert project_url != nil
+    assert project_id != nil
+  end
+
   test "projects create 401's when not logged in", %{conn: conn} do
     params = %{ project: %{ name: "Test Project" } }
     conn |> post(api_v1_project_path(conn, :create)) |> response(401)
@@ -20,7 +66,60 @@ defmodule RetWeb.ProjectsControllerTest do
   @tag :authenticated
   test "projects create works when logged in", %{conn: conn} do
     params = %{ project: %{ name: "Test Project" } }
-    conn |> post(api_v1_project_path(conn, :create, params)) |> response(200)
+    response = conn |> post(api_v1_project_path(conn, :create, params)) |> json_response(200)
+
+    %{
+      "thumbnail_url" => thumbnail_url,
+      "project_url" => project_url,
+      "project_id" => project_id,
+      "name" => name
+    } = response
+
+    assert name == "Test Project"
+    assert thumbnail_url == nil
+    assert project_url == nil
+    assert project_id != nil
+  end
+
+  test "projects update 401's when not logged in", %{conn: conn, project: project, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+    params = %{
+      project: %{
+        name: "Test Project 2",
+        thumbnail_file_id: thumbnail_owned_file.owned_file_uuid,
+        thumbnail_file_token: thumbnail_owned_file.key,
+        project_file_id: project_owned_file.owned_file_uuid,
+        project_file_token: project_owned_file.key
+      }
+    }
+
+    conn |> patch(api_v1_project_path(conn, :update, project.project_sid, params)) |> response(401)
+  end
+
+  @tag :authenticated
+  test "projects update works when logged in", %{conn: conn, project: project, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+    params = %{
+      project: %{
+        name: "Test Project 2",
+        thumbnail_file_id: thumbnail_owned_file.owned_file_uuid,
+        thumbnail_file_token: thumbnail_owned_file.key,
+        project_file_id: project_owned_file.owned_file_uuid,
+        project_file_token: project_owned_file.key
+      }
+    }
+    
+    response = conn |> patch(api_v1_project_path(conn, :update, project.project_sid, params)) |> json_response(200)
+
+    %{
+      "thumbnail_url" => thumbnail_url,
+      "project_url" => project_url,
+      "project_id" => project_id,
+      "name" => name
+    } = response
+
+    assert name == "Test Project 2"
+    assert thumbnail_url != nil
+    assert project_url != nil
+    assert project_id != nil
   end
 
   test "projects delete 401's when not logged in", %{conn: conn, project: project} do


### PR DESCRIPTION
Fixed a nasty bug in Spoke where projects were being overwritten because the project show path was returning a null project url.