### PR TITLE
Add base_gltf_url to avatar to support preview

### DIFF
--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -66,7 +66,8 @@ defmodule RetWeb.Router do
       resources("/media", Api.V1.MediaController, only: [:create])
       resources("/scenes", Api.V1.SceneController, only: [:show])
       resources("/avatars", Api.V1.AvatarController, only: [:show])
-      get("/avatars/:id/avatar.gltf", Api.V1.AvatarController, :show_gltf)
+      get("/avatars/:id/base.gltf", Api.V1.AvatarController, :show_base_gltf)
+      get("/avatars/:id/avatar.gltf", Api.V1.AvatarController, :show_avatar_gltf)
       get("/oauth/:type", Api.V1.OAuthController, :show)
 
       scope "/support" do

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -28,6 +28,7 @@ defmodule RetWeb.Api.V1.AvatarView do
       allow_remixing: avatar.allow_remixing,
       allow_promotion: avatar.allow_promotion,
       gltf_url: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}/avatar.gltf?v=#{version}",
+      base_gltf_url: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}/base.gltf?v=#{version}",
       files:
         for col <- Avatar.file_columns(), into: %{} do
           key = col |> Atom.to_string() |> String.replace_suffix("_owned_file", "")


### PR DESCRIPTION
This is a version of the avatar with none of the local texture overrides applied, which is used in the client as the basis for preview (so that clearing maps can be previewed correctly)