### PR TITLE
Add close_hub permission and verbs

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -258,7 +258,7 @@ end
 
 defimpl Canada.Can, for: Ret.Account do
   # Always deny access to non-enterable hubs
-  def can?(_account, :join_hub, %Ret.Hub{entry_mode: :deny}), do: false
+  def can?(%Ret.Account{}, :join_hub, %Ret.Hub{entry_mode: :deny}), do: false
 
   def can?(%Ret.Account{} = account, :join_hub, %Ret.Hub{hub_bindings: hub_bindings})
       when hub_bindings |> length > 0 do
@@ -266,8 +266,7 @@ defimpl Canada.Can, for: Ret.Account do
   end
 
   def can?(%Ret.Account{} = account, action, %Ret.Hub{hub_bindings: hub_bindings})
-      when action in [:update_hub, :close_hub]
-      when hub_bindings |> length > 0 do
+      when action in [:update_hub, :close_hub] and hub_bindings |> length > 0 do
     hub_bindings |> Enum.any?(&(account |> Ret.HubBinding.can_manage_channel?(&1)))
   end
 
@@ -289,6 +288,9 @@ end
 
 # Perms for oauth users that do not have a hubs account
 defimpl Canada.Can, for: Ret.OAuthProvider do
+  # Always deny access to non-enterable hubs
+  def can?(%Ret.OAuthProvider{}, :join_hub, %Ret.Hub{entry_mode: :deny}), do: false
+
   # OAuthProvider users cannot perform special actions
   def can?(%Ret.OAuthProvider{}, action, %Ret.Hub{}) when action in [:update_hub, :close_hub, :kick_users, :mute_users],
     do: false
@@ -303,6 +305,9 @@ end
 
 # Permissions for un-authenticated clients
 defimpl Canada.Can, for: Atom do
+  # Always deny access to non-enterable hubs
+  def can?(_, :join_hub, %Ret.Hub{entry_mode: :deny}), do: false
+
   # Anyone can join an unbound hub
   def can?(_, :join_hub, %Ret.Hub{hub_bindings: []}), do: true
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -369,7 +369,7 @@ defmodule RetWeb.HubChannel do
       hub
       |> Hub.changeset_for_entry_mode(entry_mode)
       |> Repo.update!()
-      |> Repo.preload(@hub_preloads, force: true)
+      |> Repo.preload(@hub_preloads)
       |> broadcast_hub_refresh!(socket, ["entry_mode"])
     end
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -290,10 +290,6 @@ defmodule RetWeb.HubChannel do
     socket |> handle_entry_mode_change(:deny)
   end
 
-  def handle_in("open_hub", _payload, socket) do
-    socket |> handle_entry_mode_change(:allow)
-  end
-
   def handle_in("update_scene", %{"url" => url}, socket) do
     hub = socket |> hub_for_socket |> Repo.preload([:scene, :scene_listing])
     account = Guardian.Phoenix.Socket.current_resource(socket)

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -38,7 +38,7 @@ defmodule RetWeb.Api.V1.HubController do
   def delete(conn, %{"id" => hub_sid}) do
     Hub
     |> Repo.get_by(hub_sid: hub_sid)
-    |> Hub.changeset_to_deny_entry()
+    |> Hub.changeset_for_entry_mode(:deny)
     |> Repo.update!()
 
     conn |> send_resp(200, "OK")

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -31,6 +31,7 @@ defmodule RetWeb.Api.V1.HubView do
           name: hub.name,
           slug: hub.slug,
           entry_code: hub.entry_code,
+          entry_mode: hub.entry_mode,
           host: hub.host,
           scene: RetWeb.Api.V1.SceneView.render_scene(hub.scene || hub.scene_listing)
         }
@@ -47,6 +48,7 @@ defmodule RetWeb.Api.V1.HubView do
           name: hub.name,
           slug: hub.slug,
           entry_code: hub.entry_code,
+          entry_mode: hub.entry_mode,
           host: hub.host,
           topics: [
             %{

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -27,13 +27,13 @@ defmodule Ret.HubTest do
   test "should deny permissions for non-creator", %{scene: scene} do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
 
-    %{update_hub: false, mute_users: false} =
+    %{update_hub: false, close_hub: false, mute_users: false} =
       hub |> Hub.perms_for_account(Ret.Account.account_for_email("non-creator@mozilla.com"))
   end
 
   test "should deny permissions for anon", %{scene: scene} do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
-    %{update_hub: false, mute_users: false} = hub |> Hub.perms_for_account(nil)
+    %{update_hub: false, close_hub: false, mute_users: false} = hub |> Hub.perms_for_account(nil)
   end
 
   test "should grant permssions for hub creator", %{account: account, scene: scene} do
@@ -43,6 +43,6 @@ defmodule Ret.HubTest do
       |> Hub.add_account_to_changeset(account)
       |> Repo.insert()
 
-    %{update_hub: true, mute_users: true} = hub |> Hub.perms_for_account(account)
+    %{update_hub: true, close_hub: true, mute_users: true} = hub |> Hub.perms_for_account(account)
   end
 end

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -26,14 +26,32 @@ defmodule Ret.HubTest do
 
   test "should deny permissions for non-creator", %{scene: scene} do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+    hub = hub |> Repo.preload([:hub_bindings])
 
-    %{update_hub: false, close_hub: false, mute_users: false} =
+    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false} =
       hub |> Hub.perms_for_account(Ret.Account.account_for_email("non-creator@mozilla.com"))
   end
 
   test "should deny permissions for anon", %{scene: scene} do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
-    %{update_hub: false, close_hub: false, mute_users: false} = hub |> Hub.perms_for_account(nil)
+    hub = hub |> Repo.preload([:hub_bindings])
+
+    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false} = hub |> Hub.perms_for_account(nil)
+  end
+
+  test "should deny entry for closed hub, allow entry for re-opened hub", %{scene: scene} do
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+    hub = hub |> Repo.preload([:hub_bindings])
+
+    %{join_hub: true} = hub |> Hub.perms_for_account(nil)
+
+    hub = hub |> Hub.changeset_for_entry_mode(:deny) |> Repo.update!()
+
+    %{join_hub: false} = hub |> Hub.perms_for_account(nil)
+
+    hub = hub |> Hub.changeset_for_entry_mode(:allow) |> Repo.update!()
+
+    %{join_hub: true} = hub |> Hub.perms_for_account(nil)
   end
 
   test "should grant permssions for hub creator", %{account: account, scene: scene} do
@@ -43,6 +61,8 @@ defmodule Ret.HubTest do
       |> Hub.add_account_to_changeset(account)
       |> Repo.insert()
 
-    %{update_hub: true, close_hub: true, mute_users: true} = hub |> Hub.perms_for_account(account)
+    hub = hub |> Repo.preload([:hub_bindings])
+
+    %{join_hub: true, update_hub: true, close_hub: true, mute_users: true} = hub |> Hub.perms_for_account(account)
   end
 end

--- a/test/ret_web/controllers/api/projects_controller_test.exs
+++ b/test/ret_web/controllers/api/projects_controller_test.exs
@@ -17,7 +17,7 @@ defmodule RetWeb.ProjectsControllerTest do
   end
 
   @tag :authenticated
-  test "projects index works when logged in", %{conn: conn, project: project} do
+  test "projects index works when logged in", %{conn: conn, project: _project} do
     response = conn |> get(api_v1_project_path(conn, :index)) |> json_response(200)
 
     %{
@@ -59,13 +59,12 @@ defmodule RetWeb.ProjectsControllerTest do
   end
 
   test "projects create 401's when not logged in", %{conn: conn} do
-    params = %{ project: %{ name: "Test Project" } }
     conn |> post(api_v1_project_path(conn, :create)) |> response(401)
   end
 
   @tag :authenticated
   test "projects create works when logged in", %{conn: conn} do
-    params = %{ project: %{ name: "Test Project" } }
+    params = %{project: %{name: "Test Project"}}
     response = conn |> post(api_v1_project_path(conn, :create, params)) |> json_response(200)
 
     %{
@@ -81,7 +80,12 @@ defmodule RetWeb.ProjectsControllerTest do
     assert project_id != nil
   end
 
-  test "projects update 401's when not logged in", %{conn: conn, project: project, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+  test "projects update 401's when not logged in", %{
+    conn: conn,
+    project: project,
+    project_owned_file: project_owned_file,
+    thumbnail_owned_file: thumbnail_owned_file
+  } do
     params = %{
       project: %{
         name: "Test Project 2",
@@ -96,7 +100,12 @@ defmodule RetWeb.ProjectsControllerTest do
   end
 
   @tag :authenticated
-  test "projects update works when logged in", %{conn: conn, project: project, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+  test "projects update works when logged in", %{
+    conn: conn,
+    project: project,
+    project_owned_file: project_owned_file,
+    thumbnail_owned_file: thumbnail_owned_file
+  } do
     params = %{
       project: %{
         name: "Test Project 2",
@@ -106,7 +115,7 @@ defmodule RetWeb.ProjectsControllerTest do
         project_file_token: project_owned_file.key
       }
     }
-    
+
     response = conn |> patch(api_v1_project_path(conn, :update, project.project_sid, params)) |> json_response(200)
 
     %{
@@ -136,10 +145,15 @@ defmodule RetWeb.ProjectsControllerTest do
   end
 
   @tag :authenticated
-  test "projects delete shows a 404 when the user does not own the project", %{conn: conn, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+  test "projects delete shows a 404 when the user does not own the project", %{
+    conn: conn,
+    project_owned_file: project_owned_file,
+    thumbnail_owned_file: thumbnail_owned_file
+  } do
     other_account = Account.account_for_email("test2@mozilla.com")
 
-    {:ok, project} = %Project{}
+    {:ok, project} =
+      %Project{}
       |> Project.changeset(other_account, project_owned_file, thumbnail_owned_file, %{
         name: "Test Scene"
       })


### PR DESCRIPTION
Adds the ability to close a hub if you have owner permissions.

Also updates `join_hub` permission to be denied to all users when the hub's `entry_mode`' is `deny`.

I carved out a new permission for this, vs using `update_hub` permission -- somewhat subjective but it felt like this could theoretically be conferred to different roles in the future. (Eg a community member running an event may be able to rename the room or change the scene, but not be allowed to shut down the room, which is destructive.)

Goes with https://github.com/mozilla/hubs/pull/1260