### PR TITLE
Avatar search and thumbnails

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -22,7 +22,7 @@ defmodule Ret.Avatar do
     :normal_map_owned_file,
     :orm_map_owned_file
   ]
-  @file_columns [:gltf_owned_file, :bin_owned_file] ++ @image_columns
+  @file_columns [:gltf_owned_file, :bin_owned_file, :thumbnail_owned_file] ++ @image_columns
 
   def image_columns, do: @image_columns
   def file_columns, do: @file_columns
@@ -42,6 +42,7 @@ defmodule Ret.Avatar do
 
     belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:bin_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:thumbnail_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 
     belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -98,17 +98,11 @@ defmodule Ret.Avatar do
     avatar.updated_at |> NaiveDateTime.to_erl |> :calendar.datetime_to_gregorian_seconds
   end
 
-  def url(%Avatar{} = avatar) do
-    "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
-  end
+  def url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
 
-  def gltf_url(%Avatar{} = avatar) do
-    "#{Avatar.url(avatar)}/avatar.gltf?v=#{Avatar.version(avatar)}"
-  end
+  def gltf_url(%Avatar{} = avatar), do: "#{Avatar.url(avatar)}/avatar.gltf?v=#{Avatar.version(avatar)}"
 
-  def base_gltf_url(%Avatar{} = avatar) do
-    "#{Avatar.url(avatar)}/base.gltf?v=#{Avatar.version(avatar)}"
-  end
+  def base_gltf_url(%Avatar{} = avatar), do: "#{Avatar.url(avatar)}/base.gltf?v=#{Avatar.version(avatar)}"
 
   def file_url_or_nil(%Avatar{} = avatar, column) do
     case avatar |> Map.get(column) do

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -95,7 +95,7 @@ defmodule Ret.Avatar do
   end
 
   def version(%Avatar{} = avatar) do
-    avatar.updated_at |> NaiveDateTime.to_erl |> :calendar.datetime_to_gregorian_seconds
+    avatar.updated_at |> NaiveDateTime.to_erl() |> :calendar.datetime_to_gregorian_seconds()
   end
 
   def url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -94,6 +94,29 @@ defmodule Ret.Avatar do
     |> avatar_to_collapsed_files()
   end
 
+  def version(%Avatar{} = avatar) do
+    avatar.updated_at |> NaiveDateTime.to_erl |> :calendar.datetime_to_gregorian_seconds
+  end
+
+  def url(%Avatar{} = avatar) do
+    "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
+  end
+
+  def gltf_url(%Avatar{} = avatar) do
+    "#{Avatar.url(avatar)}/avatar.gltf?v=#{Avatar.version(avatar)}"
+  end
+
+  def base_gltf_url(%Avatar{} = avatar) do
+    "#{Avatar.url(avatar)}/base.gltf?v=#{Avatar.version(avatar)}"
+  end
+
+  def file_url_or_nil(%Avatar{} = avatar, column) do
+    case avatar |> Map.get(column) do
+      nil -> nil
+      owned_file -> owned_file |> OwnedFile.uri_for() |> URI.to_string()
+    end
+  end
+
   @doc false
   def changeset(
         %Avatar{} = avatar,

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -532,7 +532,7 @@ defmodule Ret.MediaSearch do
       attributions: avatar.attributions,
       images: %{
         preview: %{
-          url: thumbnail || "https://placekitten.com/720/1280",
+          url: thumbnail || "https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png",
           width: 720,
           height: 1280
         }

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -280,8 +280,7 @@ defmodule Ret.MediaSearch do
         res ->
           decoded_res = res |> Map.get(:body) |> Poison.decode!()
 
-          entries =
-            decoded_res |> Map.get("results") |> Enum.map(&sketchfab_api_result_to_entry/1)
+          entries = decoded_res |> Map.get("results") |> Enum.map(&sketchfab_api_result_to_entry/1)
 
           cursors = decoded_res |> Map.get("cursors")
 
@@ -370,8 +369,7 @@ defmodule Ret.MediaSearch do
           decoded_res = res |> Map.get(:body) |> Poison.decode!()
           next_cursor = decoded_res |> Map.get("nextOffset")
 
-          entries =
-            decoded_res |> Map.get("value") |> Enum.map(&bing_api_result_to_entry(type, &1))
+          entries = decoded_res |> Map.get("value") |> Enum.map(&bing_api_result_to_entry(type, &1))
 
           suggestions =
             if decoded_res["relatedSearches"] do
@@ -533,13 +531,11 @@ defmodule Ret.MediaSearch do
       description: avatar.description,
       attributions: avatar.attributions,
       images: %{
-        preview:
-          thumbnail &&
-            %{
-              url: thumbnail,
-              width: 720,
-              height: 1280
-            }
+        preview: %{
+          url: thumbnail || "https://placekitten.com/720/1280",
+          width: 720,
+          height: 1280
+        }
       },
       gltfs: %{
         avatar: avatar |> Avatar.gltf_url(),

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -470,7 +470,9 @@ defmodule Ret.MediaSearch do
       name: scene_listing.name,
       description: scene_listing.description,
       attributions: scene_listing.attributions,
-      images: %{preview: %{url: scene_listing.screenshot_owned_file |> OwnedFile.uri_for() |> URI.to_string()}}
+      images: %{
+        preview: %{url: scene_listing.screenshot_owned_file |> OwnedFile.uri_for() |> URI.to_string()}
+      }
     }
   end
 

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -19,7 +19,7 @@ defmodule Ret.MediaSearch do
   import Ret.HttpUtils
   import Ecto.Query
 
-  alias Ret.{Repo, OwnedFile, Scene, SceneListing, Asset}
+  alias Ret.{Repo, OwnedFile, Scene, SceneListing, Asset, Avatar}
 
   @page_size 24
   @max_face_count 60000
@@ -40,6 +40,16 @@ defmodule Ret.MediaSearch do
         q: query
       }) do
     scene_listing_search(cursor, query, filter)
+  end
+
+  def search(%Ret.MediaSearchQuery{
+        source: "avatars",
+        cursor: cursor,
+        filter: filter,
+        user: account_id,
+        q: query
+      }) do
+    avatar_search(cursor, query, filter, account_id)
   end
 
   def search(%Ret.MediaSearchQuery{
@@ -435,6 +445,20 @@ defmodule Ret.MediaSearch do
     }
   end
 
+  defp avatar_search(cursor, query, filter, account_id, order \\ [desc: :updated_at]) do
+    page_number = (cursor || "1") |> Integer.parse() |> elem(0)
+
+    results =
+      Avatar
+      |> where([a], a.account_id == ^account_id)
+      |> preload([:thumbnail_owned_file])
+      |> order_by(^order)
+      |> Repo.paginate(%{page: page_number, page_size: @page_size})
+      |> result_for_page(page_number, :avatar, &avatar_to_entry/1)
+
+    {:commit, results}
+  end
+
   defp scene_listing_search(cursor, query, filter, order \\ [desc: :updated_at]) do
     page_number = (cursor || "1") |> Integer.parse() |> elem(0)
 
@@ -450,7 +474,7 @@ defmodule Ret.MediaSearch do
       |> preload([:screenshot_owned_file, :model_owned_file, :scene_owned_file])
       |> order_by(^order)
       |> Repo.paginate(%{page: page_number, page_size: @page_size})
-      |> result_for_scene_listing_page(page_number)
+      |> result_for_page(page_number, :scene_listings, &scene_listing_to_entry/1)
 
     {:commit, results}
   end
@@ -465,7 +489,7 @@ defmodule Ret.MediaSearch do
   defp add_tag_to_listing_search_query(query, tag),
     do: query |> where(fragment("tags->'tags' \\? ?", ^tag))
 
-  defp result_for_scene_listing_page(page, page_number) do
+  defp result_for_page(page, page_number, source, entry_fn) do
     %Ret.MediaSearchResult{
       meta: %Ret.MediaSearchResultMeta{
         next_cursor:
@@ -474,11 +498,11 @@ defmodule Ret.MediaSearch do
           else
             nil
           end,
-        source: :scene_listings
+        source: source
       },
       entries:
         page.entries
-        |> Enum.map(&scene_listing_to_entry/1)
+        |> Enum.map(entry_fn)
     }
   end
 
@@ -494,6 +518,32 @@ defmodule Ret.MediaSearch do
         preview: %{
           url: scene_listing.screenshot_owned_file |> OwnedFile.uri_for() |> URI.to_string()
         }
+      }
+    }
+  end
+
+  defp avatar_to_entry(avatar) do
+    thumbnail = avatar |> Avatar.file_url_or_nil(:thumbnail_owned_file)
+
+    %{
+      id: avatar.avatar_sid,
+      type: "avatar",
+      url: avatar |> Avatar.url(),
+      name: avatar.name,
+      description: avatar.description,
+      attributions: avatar.attributions,
+      images: %{
+        preview:
+          thumbnail &&
+            %{
+              url: thumbnail,
+              width: 720,
+              height: 1280
+            }
+      },
+      gltfs: %{
+        avatar: avatar |> Avatar.gltf_url(),
+        base: avatar |> Avatar.base_gltf_url()
       }
     }
   end

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -24,15 +24,31 @@ defmodule Ret.MediaSearch do
   @page_size 24
   @max_face_count 60000
 
-  def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: "featured", q: query}) do
+  def search(%Ret.MediaSearchQuery{
+        source: "scene_listings",
+        cursor: cursor,
+        filter: "featured",
+        q: query
+      }) do
     scene_listing_search(cursor, query, "featured", asc: :order)
   end
 
-  def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: filter, q: query}) do
+  def search(%Ret.MediaSearchQuery{
+        source: "scene_listings",
+        cursor: cursor,
+        filter: filter,
+        q: query
+      }) do
     scene_listing_search(cursor, query, filter)
   end
 
-  def search(%Ret.MediaSearchQuery{source: "assets", type: type, cursor: cursor, user: account_id, q: query}) do
+  def search(%Ret.MediaSearchQuery{
+        source: "assets",
+        type: type,
+        cursor: cursor,
+        user: account_id,
+        q: query
+      }) do
     assets_search(cursor, type, account_id, query)
   end
 
@@ -216,7 +232,8 @@ defmodule Ret.MediaSearch do
         )
 
       res =
-        "https://api.twitch.tv/kraken/search/streams?#{query}" |> retry_get_until_success([{"Client-ID", client_id}])
+        "https://api.twitch.tv/kraken/search/streams?#{query}"
+        |> retry_get_until_success([{"Client-ID", client_id}])
 
       case res do
         :error ->
@@ -252,7 +269,10 @@ defmodule Ret.MediaSearch do
 
         res ->
           decoded_res = res |> Map.get(:body) |> Poison.decode!()
-          entries = decoded_res |> Map.get("results") |> Enum.map(&sketchfab_api_result_to_entry/1)
+
+          entries =
+            decoded_res |> Map.get("results") |> Enum.map(&sketchfab_api_result_to_entry/1)
+
           cursors = decoded_res |> Map.get("cursors")
 
           {:commit,
@@ -266,7 +286,8 @@ defmodule Ret.MediaSearch do
     end
   end
 
-  def bing_search(%Ret.MediaSearchQuery{source: "bing_videos", q: q, locale: locale}) when q == nil or q == "" do
+  def bing_search(%Ret.MediaSearchQuery{source: "bing_videos", q: q, locale: locale})
+      when q == nil or q == "" do
     with api_key when is_binary(api_key) <- resolver_config(:bing_search_api_key) do
       query =
         URI.encode_query(
@@ -307,7 +328,13 @@ defmodule Ret.MediaSearch do
     end
   end
 
-  def bing_search(%Ret.MediaSearchQuery{source: source, cursor: cursor, filter: _filter, q: q, locale: locale}) do
+  def bing_search(%Ret.MediaSearchQuery{
+        source: source,
+        cursor: cursor,
+        filter: _filter,
+        q: q,
+        locale: locale
+      }) do
     with api_key when is_binary(api_key) <- resolver_config(:bing_search_api_key) do
       query =
         URI.encode_query(
@@ -332,7 +359,9 @@ defmodule Ret.MediaSearch do
         res ->
           decoded_res = res |> Map.get(:body) |> Poison.decode!()
           next_cursor = decoded_res |> Map.get("nextOffset")
-          entries = decoded_res |> Map.get("value") |> Enum.map(&bing_api_result_to_entry(type, &1))
+
+          entries =
+            decoded_res |> Map.get("value") |> Enum.map(&bing_api_result_to_entry(type, &1))
 
           suggestions =
             if decoded_res["relatedSearches"] do
@@ -372,7 +401,9 @@ defmodule Ret.MediaSearch do
   defp add_type_to_asset_search_query(query, nil), do: query
   defp add_type_to_asset_search_query(query, type), do: query |> where([a], a.type == ^type)
   defp add_query_to_asset_search_query(query, nil), do: query
-  defp add_query_to_asset_search_query(query, q), do: query |> where([a], ilike(a.name, ^"%#{q}%"))
+
+  defp add_query_to_asset_search_query(query, q),
+    do: query |> where([a], ilike(a.name, ^"%#{q}%"))
 
   defp result_for_assets_page(page, page_number) do
     %Ret.MediaSearchResult{
@@ -410,7 +441,10 @@ defmodule Ret.MediaSearch do
     results =
       SceneListing
       |> join(:inner, [l], s in assoc(l, :scene))
-      |> where([l, s], l.state == ^"active" and s.state == ^"active" and s.allow_promotion == ^true)
+      |> where(
+        [l, s],
+        l.state == ^"active" and s.state == ^"active" and s.allow_promotion == ^true
+      )
       |> add_query_to_listing_search_query(query)
       |> add_tag_to_listing_search_query(filter)
       |> preload([:screenshot_owned_file, :model_owned_file, :scene_owned_file])
@@ -422,10 +456,14 @@ defmodule Ret.MediaSearch do
   end
 
   defp add_query_to_listing_search_query(query, nil), do: query
-  defp add_query_to_listing_search_query(query, q), do: query |> where([l, s], ilike(l.name, ^"%#{q}%"))
+
+  defp add_query_to_listing_search_query(query, q),
+    do: query |> where([l, s], ilike(l.name, ^"%#{q}%"))
 
   defp add_tag_to_listing_search_query(query, nil), do: query
-  defp add_tag_to_listing_search_query(query, tag), do: query |> where(fragment("tags->'tags' \\? ?", ^tag))
+
+  defp add_tag_to_listing_search_query(query, tag),
+    do: query |> where(fragment("tags->'tags' \\? ?", ^tag))
 
   defp result_for_scene_listing_page(page, page_number) do
     %Ret.MediaSearchResult{
@@ -453,7 +491,9 @@ defmodule Ret.MediaSearch do
       description: scene_listing.description,
       attributions: scene_listing.attributions,
       images: %{
-        preview: %{url: scene_listing.screenshot_owned_file |> OwnedFile.uri_for() |> URI.to_string()}
+        preview: %{
+          url: scene_listing.screenshot_owned_file |> OwnedFile.uri_for() |> URI.to_string()
+        }
       }
     }
   end
@@ -481,7 +521,9 @@ defmodule Ret.MediaSearch do
       id: result["uid"],
       type: "sketchfab_model",
       name: result["name"],
-      attributions: %{creator: %{name: result["user"]["username"], url: result["user"]["profileUrl"]}},
+      attributions: %{
+        creator: %{name: result["user"]["username"], url: result["user"]["profileUrl"]}
+      },
       url: "https://sketchfab.com/models/#{result["uid"]}",
       images: images
     }

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -29,6 +29,13 @@ defmodule RetWeb.Api.V1.MediaSearchController do
     conn |> render("index.json", results: results)
   end
 
+  def index(conn, %{"source" => "avatars", "user" => user} = params) do
+    {:commit, results} =
+      %Ret.MediaSearchQuery{source: "avatars", cursor: params["cursor"] || "1", user: user |> String.to_integer} |> Ret.MediaSearch.search()
+
+    conn |> render("index.json", results: results)
+  end
+
   def index(conn, %{"source" => "assets", "user" => user} = params) do
     account = conn |> Guardian.Plug.current_resource()
 

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -10,13 +10,6 @@ defmodule RetWeb.Api.V1.AvatarView do
     %{avatars: [render_avatar(avatar)]}
   end
 
-  defp file_url_or_nil(avatar, column) do
-    case avatar |> Map.get(column) do
-      nil -> nil
-      owned_file -> owned_file |> OwnedFile.uri_for() |> URI.to_string()
-    end
-  end
-
   def render_avatar(avatar) do
     version = avatar.updated_at |> NaiveDateTime.to_erl |> :calendar.datetime_to_gregorian_seconds
     %{
@@ -27,12 +20,12 @@ defmodule RetWeb.Api.V1.AvatarView do
       attributions: if(is_nil(avatar.attributions), do: [], else: avatar.attributions),
       allow_remixing: avatar.allow_remixing,
       allow_promotion: avatar.allow_promotion,
-      gltf_url: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}/avatar.gltf?v=#{version}",
-      base_gltf_url: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}/base.gltf?v=#{version}",
+      gltf_url: avatar |> Avatar.gltf_url,
+      base_gltf_url: avatar |> Avatar.base_gltf_url,
       files:
         for col <- Avatar.file_columns(), into: %{} do
           key = col |> Atom.to_string() |> String.replace_suffix("_owned_file", "")
-          {key, avatar |> file_url_or_nil(col)}
+          {key, avatar |> Avatar.file_url_or_nil(col)}
         end
     }
   end

--- a/priv/repo/migrations/20190424010558_add_thumbnail_to_avatar.exs
+++ b/priv/repo/migrations/20190424010558_add_thumbnail_to_avatar.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddThumbnailToAvatar do
+  use Ecto.Migration
+
+  def change do
+    alter table(:avatars) do
+      add(:thumbnail_owned_file_id, references(:owned_files, column: :owned_file_id))
+    end
+  end
+end

--- a/test/ret_web/controllers/api/media_search_controller_test.exs
+++ b/test/ret_web/controllers/api/media_search_controller_test.exs
@@ -1,0 +1,44 @@
+defmodule RetWeb.SceneControllerTest do
+  use RetWeb.ConnCase
+  import Ret.TestHelpers
+
+  setup [:create_account, :create_owned_file, :create_avatar]
+
+  setup do
+    on_exit(fn ->
+      clear_all_stored_files()
+    end)
+  end
+
+  @tag :authenticated
+  test "Search for avatar by user works for a user's own avatars", %{conn: conn, account: account, avatar: avatar} do
+    resp =
+      conn
+      |> get(api_v1_media_search_path(conn, :index), %{
+        source: "avatars",
+        user: account.account_id |> Integer.to_string()
+      })
+      |> json_response(200)
+
+    # there should only be one entry
+    [entry] = resp["entries"]
+
+    # and it should be the avatar we just created
+    assert entry["id"] == avatar.avatar_sid
+  end
+
+  test "Search for avatar by user does not work another user's avatars", %{conn: conn, account: account} do
+    {:ok, token, _claims} =
+      "test2@mozilla.com"
+      |> Ret.Account.account_for_email()
+      |> Ret.Guardian.encode_and_sign()
+
+    conn
+    |> Plug.Conn.put_req_header("authorization", "bearer: " <> token)
+    |> get(api_v1_media_search_path(conn, :index), %{
+      source: "avatars",
+      user: account.account_id |> Integer.to_string()
+    })
+    |> response(401)
+  end
+end

--- a/test/ret_web/controllers/api/media_search_controller_test.exs
+++ b/test/ret_web/controllers/api/media_search_controller_test.exs
@@ -2,7 +2,7 @@ defmodule RetWeb.SceneControllerTest do
   use RetWeb.ConnCase
   import Ret.TestHelpers
 
-  setup [:create_account, :create_owned_file, :create_avatar]
+  alias Ret.Account
 
   setup do
     on_exit(fn ->
@@ -10,34 +10,74 @@ defmodule RetWeb.SceneControllerTest do
     end)
   end
 
-  @tag :authenticated
-  test "Search for avatar by user works for a user's own avatars", %{conn: conn, account: account, avatar: avatar} do
+  setup _context do
+    account_1 = Account.account_for_email("test@mozilla.com")
+    account_2 = Account.account_for_email("test2@mozilla.com")
+    account_3 = Account.account_for_email("test3@mozilla.com")
+
+    %{
+      account_1: account_1,
+      account_2: account_2,
+      account_3: account_3,
+      avatar_1: create_avatar(account_1),
+      avatar_2: create_avatar(account_2)
+    }
+  end
+
+  defp search_avatars_for_account_id(conn, account_id) do
+    conn
+    |> get(api_v1_media_search_path(conn, :index), %{
+      source: "avatars",
+      user: account_id |> Integer.to_string()
+    })
+  end
+
+  test "Search for a user's own avatars should return results if they have avatars", %{
+    conn: conn,
+    account_1: account,
+    avatar_1: avatar
+  } do
     resp =
       conn
+      |> auth_with_account(account)
+      |> search_avatars_for_account_id(avatar.account_id)
+      |> json_response(200)
+
+    # there should only be one entry
+    [entry] = resp["entries"]
+
+    # and the avatar should beelong to the account we authed as
+    assert entry["id"] == avatar.avatar_sid
+    assert avatar.account_id == account.account_id
+  end
+
+  test "Search for a user's own avatars should return an empty list if they have no avatars", %{
+    conn: conn,
+    account_3: account
+  } do
+    resp =
+      conn
+      |> auth_with_account(account)
       |> get(api_v1_media_search_path(conn, :index), %{
         source: "avatars",
         user: account.account_id |> Integer.to_string()
       })
       |> json_response(200)
 
-    # there should only be one entry
-    [entry] = resp["entries"]
-
-    # and it should be the avatar we just created
-    assert entry["id"] == avatar.avatar_sid
+    # There should be no entries
+    assert resp["entries"] == []
   end
 
-  test "Search for avatar by user does not work another user's avatars", %{conn: conn, account: account} do
-    {:ok, token, _claims} =
-      "test2@mozilla.com"
-      |> Ret.Account.account_for_email()
-      |> Ret.Guardian.encode_and_sign()
-
+  test "Search for another user's avatars should return a 401", %{
+    conn: conn,
+    avatar_1: avatar_1,
+    account_2: account
+  } do
     conn
-    |> Plug.Conn.put_req_header("authorization", "bearer: " <> token)
+    |> auth_with_account(account)
     |> get(api_v1_media_search_path(conn, :index), %{
       source: "avatars",
-      user: account.account_id |> Integer.to_string()
+      user: avatar_1.account_id |> Integer.to_string()
     })
     |> response(401)
   end


### PR DESCRIPTION
Adds a thumbnail owned file to avatar records and an "avatars" source to the search API. The avatars source currently only supports returning results by user. Also, the only user you are currently authorized to search for is the one you are authenticated as.

todo:
- [x] decide if its ok to get a listing of other people's avatars, restrict it if not
- [x] decide what to call the source, and if we want a "filter"
- [x] come up with a real placeholder image