### PR TITLE
Make the project create route take additional parameters

### DIFF
--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -46,12 +46,6 @@ defmodule Ret.Project do
     |> Repo.insert
   end
 
-  def create_project(account, params) do
-    with {:ok, project} <- %Project{} |> Project.changeset(account, params) |> Repo.insert() do
-      {:ok, Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])}
-    end
-  end
-
   # Create a Project
   def changeset(%Project{} = project, account, params \\ %{}) do
     project

--- a/test/ret_web/controllers/api/projects_controller_test.exs
+++ b/test/ret_web/controllers/api/projects_controller_test.exs
@@ -63,8 +63,17 @@ defmodule RetWeb.ProjectsControllerTest do
   end
 
   @tag :authenticated
-  test "projects create works when logged in", %{conn: conn} do
-    params = %{project: %{name: "Test Project"}}
+  test "projects create works when logged in", %{conn: conn, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+    params = %{
+      project: %{
+        name: "Test Project",
+        thumbnail_file_id: thumbnail_owned_file.owned_file_uuid,
+        thumbnail_file_token: thumbnail_owned_file.key,
+        project_file_id: project_owned_file.owned_file_uuid,
+        project_file_token: project_owned_file.key
+      }
+    }
+
     response = conn |> post(api_v1_project_path(conn, :create, params)) |> json_response(200)
 
     %{
@@ -75,8 +84,8 @@ defmodule RetWeb.ProjectsControllerTest do
     } = response
 
     assert name == "Test Project"
-    assert thumbnail_url == nil
-    assert project_url == nil
+    assert thumbnail_url != nil
+    assert project_url != nil
     assert project_id != nil
   end
 


### PR DESCRIPTION
The project create route doesn't allow you to specify the project file or thumbnail file. This PR adds support for those parameters. This is a breaking change for Spoke and should be merged along with the [Spoke onboarding branch](https://github.com/MozillaReality/Spoke/pull/501/)