### PR TITLE
Feature/blue green deploy prep

### DIFF
--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -1,3 +1,6 @@
+[ret."Elixir.Ret"]
+pool = "{{ cfg.ret.pool }}"
+
 [ret."Elixir.RetWeb.Plugs.HeaderAuthorization"]
 header_value = "{{ cfg.phx.admin_access_key }}"
 

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,3 +1,6 @@
+[ret]
+pool = "default"
+
 [phx]
 port = 4000
 ip = "127.0.0.1"

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=reticulum
 pkg_origin=mozillareality
-pkg_version="0.0.2"
+pkg_version="1.0.0"
 pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
 pkg_upstream_url="http://github.com/mozilla/reticulum"
 pkg_license=('MPL-2.0')
@@ -48,7 +48,7 @@ do_build() {
 }
 
 do_install() {
-    mix release --env=prod
+    RET_USE_VERSION=${pkg_version} mix release --env=prod
     cp -a _build/prod/rel/ret/* ${pkg_prefix}
 
     for f in $(find ${pkg_prefix} -name '*.sh')

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -48,7 +48,8 @@ do_build() {
 }
 
 do_install() {
-    RET_USE_VERSION=${pkg_version} mix release --env=prod
+    VERSION_PATH=$(echo $pkg_prefix | cut -d '/' -f 6,7)
+    RELEASE_VERSION="${VERSION_PATH/\//.}" mix release --env=prod
     cp -a _build/prod/rel/ret/* ${pkg_prefix}
 
     for f in $(find ${pkg_prefix} -name '*.sh')

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -32,6 +32,7 @@ do_verify() {
 do_prepare() {
     export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
     export MIX_ENV=prod
+    export RELEASE_VERSION="1.0.$(echo $pkg_prefix | cut -d '/' -f 7)" 
 
     # Rebar3 will hate us otherwise because it looks for
     # /usr/bin/env when it does some of its compiling
@@ -48,8 +49,7 @@ do_build() {
 }
 
 do_install() {
-    VERSION_PATH=$(echo $pkg_prefix | cut -d '/' -f 6,7)
-    RELEASE_VERSION="${VERSION_PATH/\//.}" mix release --env=prod
+    mix release --env=prod
     cp -a _build/prod/rel/ret/* ${pkg_prefix}
 
     for f in $(find ${pkg_prefix} -name '*.sh')

--- a/lib/ret/meta.ex
+++ b/lib/ret/meta.ex
@@ -1,7 +1,10 @@
 defmodule Ret.Meta do
+  # Evaluate at build time
+  @version Mix.Project.config()[:version]
+
   def get_meta do
     %{
-      version: :application.get_key(:ret, :vsn) |> elem(1) |> to_string,
+      version: @version,
       phx_host: :inet.gethostname() |> elem(1) |> to_string,
       pool: Application.get_env(:ret, Ret)[:pool]
     }

--- a/lib/ret/meta.ex
+++ b/lib/ret/meta.ex
@@ -1,0 +1,9 @@
+defmodule Ret.Meta do
+  def get_meta do
+    %{
+      version: :application.get_key(:ret, :vsn) |> elem(1) |> to_string,
+      phx_host: :inet.gethostname() |> elem(1) |> to_string,
+      pool: Application.get_env(:ret, Ret)[:pool]
+    }
+  end
+end

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -6,7 +6,7 @@ defmodule RetWeb.Api.V1.HubController do
   # Limit to 1 TPS
   plug(RetWeb.Plugs.RateLimit)
 
-  # Only allow access with secret header
+  # Only allow access to remove hubs with secret header
   plug(RetWeb.Plugs.HeaderAuthorization when action in [:delete])
 
   def create(conn, %{"hub" => %{"scene_id" => scene_id}} = params) do

--- a/lib/ret_web/controllers/api/v1/ret_notice_controller.ex
+++ b/lib/ret_web/controllers/api/v1/ret_notice_controller.ex
@@ -1,0 +1,14 @@
+defmodule RetWeb.Api.V1.RetNoticeController do
+  use RetWeb, :controller
+
+  # Limit to 1 TPS
+  plug(RetWeb.Plugs.RateLimit)
+
+  # Only allow access to send ret notifications via admin secret
+  plug(RetWeb.Plugs.HeaderAuthorization when action in [:create])
+
+  def create(conn, payload) do
+    RetWeb.Endpoint.broadcast("ret", "notice", payload)
+    conn |> send_resp(200, "")
+  end
+end

--- a/lib/ret_web/controllers/meta_controller.ex
+++ b/lib/ret_web/controllers/meta_controller.ex
@@ -1,0 +1,10 @@
+defmodule RetWeb.Api.V1.MetaController do
+  use RetWeb, :controller
+
+  plug(RetWeb.Plugs.RateLimit when action in [:show])
+
+  def show(conn, _params) do
+    meta = Ret.Meta.get_meta()
+    conn |> send_resp(200, meta |> Poison.encode!())
+  end
+end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -7,7 +7,7 @@ defmodule RetWeb.PageController do
   end
 
   defp render_scene_content(%t{} = scene, conn) when t in [Scene, SceneListing] do
-    scene_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "scene-meta.html", scene: scene)
+    scene_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "scene-meta.html", scene: scene, ret_meta: Ret.Meta.get_meta)
 
     chunks =
       chunks_for_page("scene.html", :hubs)
@@ -79,7 +79,7 @@ defmodule RetWeb.PageController do
 
   def render_hub_content(conn, hub, _slug) do
     hub = hub |> Repo.preload(scene: [:screenshot_owned_file])
-    hub_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "hub-meta.html", hub: hub, scene: hub.scene)
+    hub_meta_tags = Phoenix.View.render_to_string(RetWeb.PageView, "hub-meta.html", hub: hub, scene: hub.scene, ret_meta: Ret.Meta.get_meta)
 
     chunks =
       chunks_for_page("hub.html", :hubs)

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -59,6 +59,8 @@ defmodule RetWeb.Router do
         resources("/subscriptions", Api.V1.SupportSubscriptionController, only: [:create, :delete])
         resources("/availability", Api.V1.SupportSubscriptionController, only: [:index])
       end
+
+      resources("/ret_notices", Api.V1.RetNoticeController, only: [:create])
     end
 
     scope "/v1", as: :api_v1 do

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -47,6 +47,7 @@ defmodule RetWeb.Router do
     pipe_through([:secure_headers, :api] ++ if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: []))
 
     scope "/v1", as: :api_v1 do
+      get("/meta", Api.V1.MetaController, :show)
       resources("/media", Api.V1.MediaController, only: [:create])
       resources("/scenes", Api.V1.SceneController, only: [:show])
       resources("/avatars", Api.V1.AvatarController, only: [:show])

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -9,4 +9,7 @@
 <meta name="twitter:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
 <meta property="twitter:image" content="<%= @hub |> Ret.Hub.image_url_for %>"/>
 <meta name="twitter:url" value="<%= @hub |> Ret.Hub.url_for %>" />
+<meta name="ret:version" value="<%= @ret_meta[:version] %>" />
+<meta name="ret:phx_host" value="<%= @ret_meta[:phx_host] %>" />
+<meta name="ret:pool" value="<%= @ret_meta[:pool] %>" />
 <title><%= @hub.name %> | Hubs by Mozilla</title>

--- a/lib/ret_web/templates/page/scene-meta.html.eex
+++ b/lib/ret_web/templates/page/scene-meta.html.eex
@@ -10,5 +10,8 @@
 <meta name="twitter:description" content="Join others in <%= @scene.name %>, right in your browser." />
 <meta property="twitter:image" content="<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
 <meta name="twitter:url" value="<%= @scene |> Ret.Scene.to_url %>" />
+<meta name="ret:version" value="<%= @ret_meta[:version] %>" />
+<meta name="ret:phx_host" value="<%= @ret_meta[:phx_host] %>" />
+<meta name="ret:pool" value="<%= @ret_meta[:pool] %>" />
 <title><%= @scene.name %> | Hubs by Mozilla</title>
 <% end %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ret.Mixfile do
   def project do
     [
       app: :ret,
-      version: System.get_env("RET_USE_VERSION") || "1.0.0",
+      version: "1.0.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ret.Mixfile do
   def project do
     [
       app: :ret,
-      version: "1.0.0",
+      version: System.get_env("RELEASE_VERSION") || "1.0.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ret.Mixfile do
   def project do
     [
       app: :ret,
-      version: "0.0.1",
+      version: System.get_env("RET_USE_VERSION") || "1.0.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -47,7 +47,7 @@ end
 # will be used by default
 
 release :ret do
-  set(version: current_version(:ret))
+  set(version: System.get_env("RELEASE_VERSION") || current_version(:ret))
 
   set(
     applications: [


### PR DESCRIPTION
Adds a few features to reticulum to support blue/green deploys:

- Properly bakes in the habitat package version into the build
- Adds the idea of a `pool` that is in the config that the server can self report
- Pool, version, and host information can be queried via the `/meta` api and also is returned in `meta` tags in pages
- Adds a controller to broadcast a message over the `ret` channel to all connected users via the admin shared secret. (This will be used to inform clients that they need to reconnect)