### PR TITLE
Avatar listings

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -30,27 +30,24 @@ defmodule Ret.Avatar do
   schema "avatars" do
     field(:avatar_sid, :string)
     field(:slug, AvatarSlug.Type)
-    belongs_to(:parent_avatar, Avatar, references: :avatar_id)
 
     field(:name, :string)
     field(:description, :string)
     field(:attributions, :map)
 
+    belongs_to(:account, Account, references: :account_id)
+    belongs_to(:parent_avatar, Avatar, references: :avatar_id)
+    belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id)
+
     field(:allow_remixing, :boolean)
     field(:allow_promotion, :boolean)
-    belongs_to(:account, Account, references: :account_id)
 
     belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:bin_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:thumbnail_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 
     belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-
-    belongs_to(:emissive_map_owned_file, OwnedFile,
-      references: :owned_file_id,
-      on_replace: :nilify
-    )
-
+    belongs_to(:emissive_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:normal_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -53,6 +53,7 @@ defmodule Ret.Avatar do
 
     field(:state, Avatar.State)
 
+    field(:reviewed_at, :utc_datetime)
     timestamps()
   end
 

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -10,7 +10,7 @@ defmodule Ret.Avatar do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Ret.{Avatar, Repo, OwnedFile, Account, Sids}
+  alias Ret.{Avatar, AvatarListing, Repo, OwnedFile, Account, Sids}
   alias Ret.Avatar.{AvatarSlug}
 
   @schema_prefix "ret0"
@@ -115,15 +115,17 @@ defmodule Ret.Avatar do
         account,
         owned_files_map,
         parent_avatar,
+        parent_avatar_listing,
         attrs \\ %{}
       ) do
     avatar
-    |> cast(attrs, [:name])
+    |> cast(attrs, [:name, :description, :attributions, :allow_remixing, :allow_promotion])
     |> validate_required([])
     |> maybe_add_avatar_sid_to_changeset
     |> unique_constraint(:avatar_sid)
     |> put_assoc(:account, account)
     |> put_assoc(:parent_avatar, parent_avatar)
+    |> put_assoc(:parent_avatar_listing, parent_avatar_listing)
     |> put_owned_files(owned_files_map)
     |> AvatarSlug.maybe_generate_slug()
     |> AvatarSlug.unique_constraint()

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -11,7 +11,7 @@ defmodule Ret.AvatarListing do
   import Ecto.Changeset
 
   alias Ret.{AvatarListing}
-  alias Ret.AvatarListing.{AvatarListingSlug}
+  alias AvatarListing.{AvatarListingSlug}
 
   @schema_prefix "ret0"
   @primary_key {:avatar_listing_id, :id, autogenerate: true}

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -43,6 +43,23 @@ defmodule Ret.AvatarListing do
     belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
   end
 
+  def version(%AvatarListing{} = avatar) do
+    avatar.updated_at |> NaiveDateTime.to_erl() |> :calendar.datetime_to_gregorian_seconds()
+  end
+
+  def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
+
+  def gltf_url(%AvatarListing{} = avatar), do: "#{AvatarListing.url(avatar)}/avatar.gltf?v=#{AvatarListing.version(avatar)}"
+
+  def base_gltf_url(%AvatarListing{} = avatar), do: "#{AvatarListing.url(avatar)}/base.gltf?v=#{AvatarListing.version(avatar)}"
+
+  def file_url_or_nil(%AvatarListing{} = avatar, column) do
+    case avatar |> Map.get(column) do
+      nil -> nil
+      owned_file -> owned_file |> OwnedFile.uri_for() |> URI.to_string()
+    end
+  end
+
   def changeset_for_listing_for_avatar(
         %AvatarListing{} = listing,
         avatar,

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -1,0 +1,80 @@
+defmodule Ret.AvatarListing.AvatarListingSlug do
+  use EctoAutoslugField.Slug, from: :name, to: :slug
+
+  def get_sources(_changeset, _opts) do
+    [:avatar_listing_sid, :name]
+  end
+end
+
+defmodule Ret.AvatarListing do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Ret.{AvatarListing}
+  alias Ret.AvatarListing.{AvatarListingSlug}
+
+  @schema_prefix "ret0"
+  @primary_key {:avatar_listing_id, :id, autogenerate: true}
+
+  schema "avatar_listings" do
+    field(:avatar_listing_sid, :string)
+    field(:slug, AvatarListingSlug.Type)
+    field(:order, :integer)
+    field(:state, AvatarListing.State)
+    field(:tags, :map)
+    belongs_to(:avatar, Ret.Avatar, references: :avatar_id)
+    timestamps()
+
+    # Properties cloned from avatars
+    field(:name, :string)
+    field(:description, :string)
+    field(:attributions, :map)
+
+    has_one(:account, through: [:avatar, :account])
+    belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id)
+
+    belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:bin_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:thumbnail_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+
+    belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:emissive_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:normal_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+  end
+
+  def changeset_for_listing_for_avatar(
+        %AvatarListing{} = listing,
+        avatar,
+        params \\ %{}
+      ) do
+    listing
+    |> cast(params, [:name, :description, :order, :tags])
+    |> maybe_add_avatar_listing_sid_to_changeset
+    |> unique_constraint(:avatar_listing_sid)
+    |> put_assoc(:avatar, avatar)
+
+    |> put_change(:name, params[:name] || avatar.name)
+    |> put_change(:description, params[:description] || avatar.description)
+    |> put_change(:attributions, avatar.attributions)
+
+    |> put_change(:parent_avatar_listing_id, avatar.parent_avatar_listing_id)
+
+    |> put_change(:gltf_owned_file_id, avatar.gltf_owned_file_id)
+    |> put_change(:bin_owned_file_id, avatar.bin_owned_file_id)
+    |> put_change(:thumbnail_owned_file_id, avatar.thumbnail_owned_file_id)
+
+    |> put_change(:base_map_owned_file_id, avatar.base_map_owned_file_id)
+    |> put_change(:emissive_map_owned_file_id, avatar.emissive_map_owned_file_id)
+    |> put_change(:normal_map_owned_file_id, avatar.normal_map_owned_file_id)
+    |> put_change(:orm_map_owned_file_id, avatar.orm_map_owned_file_id)
+
+    |> AvatarListingSlug.maybe_generate_slug()
+    |> AvatarListingSlug.unique_constraint()
+  end
+
+  defp maybe_add_avatar_listing_sid_to_changeset(changeset) do
+    avatar_listing_sid = changeset |> get_field(:avatar_listing_sid) || Ret.Sids.generate_sid()
+    put_change(changeset, :avatar_listing_sid, "#{avatar_listing_sid}")
+  end
+end

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -10,7 +10,7 @@ defmodule Ret.AvatarListing do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Ret.{AvatarListing}
+  alias Ret.{AvatarListing, OwnedFile}
   alias AvatarListing.{AvatarListingSlug}
 
   @schema_prefix "ret0"

--- a/lib/ret/enums.ex
+++ b/lib/ret/enums.ex
@@ -7,4 +7,5 @@ defenum(Ret.OwnedFile.State, :owned_file_state, [:active, :inactive, :removed], 
 defenum(Ret.Scene.State, :scene_state, [:active, :removed], schema: "ret0")
 defenum(Ret.SceneListing.State, :scene_listing_state, [:active, :delisted], schema: "ret0")
 defenum(Ret.Avatar.State, :avatar_state, [:active], schema: "ret0")
+defenum(Ret.AvatarListing.State, :avatar_listing_state, [:active, :delisted], schema: "ret0")
 defenum(Ret.Asset.Type, :asset_type, [:image, :video, :model], schema: "ret0")

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -416,7 +416,7 @@ defmodule Ret.MediaSearch do
     }
   end
 
-  defp avatar_search(cursor, query, filter, account_id, order \\ [desc: :updated_at]) do
+  defp avatar_search(cursor, _query, _filter, account_id, order \\ [desc: :updated_at]) do
     page_number = (cursor || "1") |> Integer.parse() |> elem(0)
 
     results =

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -1,7 +1,7 @@
 defmodule RetWeb.Api.V1.AvatarController do
   use RetWeb, :controller
 
-  alias Ret.{Account, Repo, Avatar, Storage, GLTFUtils}
+  alias Ret.{Account, Repo, Avatar, AvatarListing, Storage, GLTFUtils}
 
   plug(RetWeb.Plugs.RateLimit when action in [:create, :update])
 
@@ -10,7 +10,7 @@ defmodule RetWeb.Api.V1.AvatarController do
   defp get_avatar(avatar_sid) do
     Avatar
     |> Repo.get_by(avatar_sid: avatar_sid)
-    |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :account]])
+    |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :account]])
   end
 
   def create(conn, %{"avatar" => params}) do
@@ -68,9 +68,13 @@ defmodule RetWeb.Api.V1.AvatarController do
           params["parent_avatar_id"] &&
             Repo.get_by(Avatar, avatar_sid: params["parent_avatar_id"])
 
+        parent_avatar_listing =
+          params["parent_avatar_listing_id"] &&
+            Repo.get_by(AvatarListing, avatar_listing_sid: params["parent_avatar_listing_id"])
+
         {result, avatar} =
           avatar
-          |> Avatar.changeset(account, owned_files, parent_avatar, params)
+          |> Avatar.changeset(account, owned_files, parent_avatar, parent_avatar_listing, params)
           |> Repo.insert_or_update()
 
         avatar = avatar |> Repo.preload(Avatar.file_columns())

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -56,13 +56,11 @@ defmodule RetWeb.Api.V1.AvatarController do
       end)
       |> Enum.into(%{})
 
-    promotion_error =
-      owned_file_results |> Map.values() |> Enum.filter(&(elem(&1, 0) == :error)) |> Enum.at(0)
+    promotion_error = owned_file_results |> Map.values() |> Enum.filter(&(elem(&1, 0) == :error)) |> Enum.at(0)
 
     case promotion_error do
       nil ->
-        owned_files =
-          owned_file_results |> Enum.map(fn {k, {:ok, file}} -> {k, file} end) |> Enum.into(%{})
+        owned_files = owned_file_results |> Enum.map(fn {k, {:ok, file}} -> {k, file} end) |> Enum.into(%{})
 
         parent_avatar =
           params["parent_avatar_id"] &&

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -29,6 +29,30 @@ defmodule RetWeb.Api.V1.MediaSearchController do
     conn |> render("index.json", results: results)
   end
 
+
+  def index(conn, %{"source" => "avatar_listings", "filter" => "featured"} = params) do
+    {:commit, results} =
+      %Ret.MediaSearchQuery{source: "avatar_listings", cursor: params["cursor"] || "1", filter: "featured"}
+      |> Ret.MediaSearch.search()
+
+    conn |> render("index.json", results: results)
+  end
+
+  def index(conn, %{"source" => "avatar_listings", "q" => q} = params) do
+    {:commit, results} =
+      %Ret.MediaSearchQuery{source: "avatar_listings", cursor: params["cursor"] || "1", q: q} |> Ret.MediaSearch.search()
+
+    conn |> render("index.json", results: results)
+  end
+
+  def index(conn, %{"source" => "avatar_listings"} = params) do
+    {:commit, results} =
+      %Ret.MediaSearchQuery{source: "avatar_listings", cursor: params["cursor"] || "1"} |> Ret.MediaSearch.search()
+
+    conn |> render("index.json", results: results)
+  end
+
+
   def index(conn, %{"source" => "avatars", "user" => user} = params) do
     account = conn |> Guardian.Plug.current_resource()
 

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -77,7 +77,7 @@ defmodule RetWeb.Router do
     scope "/v1", as: :api_v1 do
       pipe_through([:auth_required])
       resources("/scenes", Api.V1.SceneController, only: [:create, :update])
-      resources("/avatars", Api.V1.AvatarController, only: [:create, :update])
+      resources("/avatars", Api.V1.AvatarController, only: [:create, :update, :delete])
       resources("/hubs", Api.V1.HubController, only: [:update])
       resources("/assets", Api.V1.AssetsController, only: [:create, :delete])
 

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -15,9 +15,10 @@ defmodule RetWeb.Api.V1.AvatarView do
     %{
       avatar_id: avatar.avatar_sid,
       parent_avatar_id: unless(is_nil(avatar.parent_avatar), do: avatar.parent_avatar.avatar_sid),
+      parent_avatar_listing_id: unless(is_nil(avatar.parent_avatar_listing), do: avatar.parent_avatar_listing.avatar_listing_sid),
       name: avatar.name,
       description: avatar.description,
-      attributions: if(is_nil(avatar.attributions), do: [], else: avatar.attributions),
+      attributions: if(is_nil(avatar.attributions), do: %{}, else: avatar.attributions),
       allow_remixing: avatar.allow_remixing,
       allow_promotion: avatar.allow_promotion,
       gltf_url: avatar |> Avatar.gltf_url,

--- a/priv/repo/migrations/20190501221754_create_avatar_listings.exs
+++ b/priv/repo/migrations/20190501221754_create_avatar_listings.exs
@@ -34,7 +34,9 @@ defmodule Ret.Repo.Migrations.CreateAvatarListings do
 
     alter table(:avatars) do
       add(:parent_avatar_listing_id, references(:avatar_listings, column: :avatar_listing_id))
+      add(:reviewed_at, :utc_datetime, null: true)
     end
+    create(index(:avatars, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at"))
     drop constraint(:avatars, :gltf_or_parent)
     create constraint(:avatars, :gltf_or_parent_or_parent_listing, check: "parent_avatar_id is not null or parent_avatar_listing_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)")
   end

--- a/priv/repo/migrations/20190501221754_create_avatar_listings.exs
+++ b/priv/repo/migrations/20190501221754_create_avatar_listings.exs
@@ -6,7 +6,7 @@ defmodule Ret.Repo.Migrations.CreateAvatarListings do
 
     create table(:avatar_listings, prefix: "ret0", primary_key: false) do
       add(:avatar_listing_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:avatar_listing_sid, :string)
+      add(:avatar_listing_sid, :string, null: false)
       add(:slug, :string, null: false)
       add(:order, :integer)
       add(:state, :avatar_listing_state, null: false, default: "active")

--- a/priv/repo/migrations/20190501221754_create_avatar_listings.exs
+++ b/priv/repo/migrations/20190501221754_create_avatar_listings.exs
@@ -1,0 +1,41 @@
+defmodule Ret.Repo.Migrations.CreateAvatarListings do
+  use Ecto.Migration
+
+  def change do
+    Ret.AvatarListing.State.create_type()
+
+    create table(:avatar_listings, prefix: "ret0", primary_key: false) do
+      add(:avatar_listing_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+      add(:avatar_listing_sid, :string)
+      add(:slug, :string, null: false)
+      add(:order, :integer)
+      add(:state, :avatar_listing_state, null: false, default: "active")
+      add(:tags, :jsonb)
+      add(:avatar_id, :bigint, null: false)
+      timestamps()
+
+      add(:name, :string, null: false)
+      add(:description, :string)
+      add(:attributions, :jsonb)
+
+      add(:parent_avatar_listing_id, references(:avatar_listings, column: :avatar_listing_id))
+
+      add(:gltf_owned_file_id, references(:owned_files, column: :owned_file_id))
+      add(:bin_owned_file_id, references(:owned_files, column: :owned_file_id))
+      add(:thumbnail_owned_file_id, references(:owned_files, column: :owned_file_id))
+
+      add(:base_map_owned_file_id, references(:owned_files, column: :owned_file_id))
+      add(:emissive_map_owned_file_id, references(:owned_files, column: :owned_file_id))
+      add(:normal_map_owned_file_id, references(:owned_files, column: :owned_file_id))
+      add(:orm_map_owned_file_id, references(:owned_files, column: :owned_file_id))
+    end
+
+    create(index(:avatar_listings, [:avatar_listing_sid], unique: true))
+
+    alter table(:avatars) do
+      add(:parent_avatar_listing_id, references(:avatar_listings, column: :avatar_listing_id))
+    end
+    drop constraint(:avatars, :gltf_or_parent)
+    create constraint(:avatars, :gltf_or_parent_or_parent_listing, check: "parent_avatar_id is not null or parent_avatar_listing_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)")
+  end
+end

--- a/priv/repo/migrations/20190501221754_create_avatar_listings.exs
+++ b/priv/repo/migrations/20190501221754_create_avatar_listings.exs
@@ -29,7 +29,6 @@ defmodule Ret.Repo.Migrations.CreateAvatarListings do
       add(:normal_map_owned_file_id, references(:owned_files, column: :owned_file_id))
       add(:orm_map_owned_file_id, references(:owned_files, column: :owned_file_id))
     end
-
     create(index(:avatar_listings, [:avatar_listing_sid], unique: true))
 
     alter table(:avatars) do
@@ -37,7 +36,5 @@ defmodule Ret.Repo.Migrations.CreateAvatarListings do
       add(:reviewed_at, :utc_datetime, null: true)
     end
     create(index(:avatars, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at"))
-    drop constraint(:avatars, :gltf_or_parent)
-    create constraint(:avatars, :gltf_or_parent_or_parent_listing, check: "parent_avatar_id is not null or parent_avatar_listing_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)")
   end
 end

--- a/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
+++ b/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
@@ -1,0 +1,13 @@
+defmodule Ret.Repo.Migrations.UpdateAvatarConstraints do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:avatars, :gltf_or_parent)
+    create constraint(:avatars, :gltf_or_parent_or_parent_listing, check: "parent_avatar_id is not null or parent_avatar_listing_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)")
+  end
+
+  def down do
+    drop constraint(:avatars, :gltf_or_parent_or_parent_listing)
+    create constraint(:avatars, :gltf_or_parent, check: "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)")
+  end
+end


### PR DESCRIPTION
This PR adds the AvatarListings model as and updates the Avatars model to support listings (with the reviewed_at and parent_avatar_listing fields).

It also expands the functionality of the AvatarController to support setting the other avatar fields (description, allow_promotion, parent_avatar_listing, etc) as well as deleting avatars.

The plan is to push this out along with the admin panel for avatars, set up the base bot as a AvatarListing, and then make a PR to update existing avatars pointing at the base bot avatar to point at the base bot avatar listing instead, using it for cascading instead of parent_avatar when available.