### PR TITLE
Return session id for link codes

### DIFF
--- a/lib/ret_web/channels/auth_channel.ex
+++ b/lib/ret_web/channels/auth_channel.ex
@@ -15,7 +15,7 @@ defmodule RetWeb.AuthChannel do
     :timer.sleep(500)
 
     Statix.increment("ret.channels.auth.joins.ok")
-    {:ok, "{}", socket}
+    {:ok, %{session_id: socket.assigns.session_id}, socket}
   end
 
   def handle_in("auth_request", %{"email" => email, "origin" => origin}, socket) do

--- a/lib/ret_web/channels/link_channel.ex
+++ b/lib/ret_web/channels/link_channel.ex
@@ -19,7 +19,7 @@ defmodule RetWeb.LinkChannel do
       send(self(), {:begin_tracking, socket.assigns.session_id, link_code})
 
       Statix.increment("ret.channels.link.joins.ok")
-      {:ok, "{}", socket}
+      {:ok, %{session_id: socket.assigns.session_id}, socket}
     else
       {:error, %{event: "Invalid link code"}}
     end

--- a/lib/ret_web/channels/ret_channel.ex
+++ b/lib/ret_web/channels/ret_channel.ex
@@ -61,6 +61,6 @@ defmodule RetWeb.RetChannel do
     vapid_public_key = Application.get_env(:web_push_encryption, :vapid_details)[:public_key]
 
     send(self(), {:begin_tracking, socket.assigns.session_id, hub_id})
-    {:ok, %{vapid_public_key: vapid_public_key}, socket}
+    {:ok, %{vapid_public_key: vapid_public_key, session_id: socket.assigns.session_id}, socket}
   end
 end


### PR DESCRIPTION
Add session id in join responses for all channels, in part to fix link codes. Goes with https://github.com/mozilla/hubs/pull/1304