### PR TITLE
Feature/creator assign tokens

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -92,14 +92,14 @@ defmodule Ret.Hub do
 
   def changeset_for_new_scene(%Hub{} = hub, %Scene{} = scene) do
     hub
-    |> cast(%{}, [])
+    |> change()
     |> put_change(:scene_id, scene.scene_id)
     |> put_change(:scene_listing_id, nil)
   end
 
   def changeset_for_new_scene(%Hub{} = hub, %SceneListing{} = scene_listing) do
     hub
-    |> cast(%{}, [])
+    |> change()
     |> put_change(:scene_listing_id, scene_listing.scene_listing_id)
     |> put_change(:scene_id, nil)
   end
@@ -131,10 +131,10 @@ defmodule Ret.Hub do
         token
       )
       when expected_token != nil and expected_token == token do
-    hub |> cast(%{}, []) |> add_account_to_changeset(account)
+    hub |> change() |> add_account_to_changeset(account)
   end
 
-  def changeset_for_creator_assignment(hub, _, _), do: hub |> cast(%{}, [])
+  def changeset_for_creator_assignment(hub, _, _), do: hub |> change()
 
   def add_account_to_changeset(changeset, nil), do: changeset
 

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -29,6 +29,7 @@ defmodule Ret.Hub do
     field(:host, :string)
     field(:entry_code, :integer)
     field(:entry_code_expires_at, :utc_datetime)
+    field(:creator_assignment_token, :string)
     field(:default_environment_gltf_bundle_url, :string)
     field(:slug, HubSlug.Type)
     field(:max_occupant_count, :integer, default: 0)
@@ -67,6 +68,7 @@ defmodule Ret.Hub do
     |> cast(attrs, [:default_environment_gltf_bundle_url])
     |> add_name_to_changeset(attrs)
     |> add_hub_sid_to_changeset
+    |> add_creator_assignment_token_to_changeset
     |> add_entry_code_to_changeset
     |> unique_constraint(:hub_sid)
     |> unique_constraint(:entry_code)
@@ -126,7 +128,7 @@ defmodule Ret.Hub do
   def add_account_to_changeset(changeset, nil), do: changeset
 
   def add_account_to_changeset(changeset, %Account{} = account) do
-    changeset |> put_assoc(:created_by_account, account)
+    changeset |> put_assoc(:created_by_account, account) |> put_change(:creator_assignment_token, nil)
   end
 
   def send_push_messages_for_join(%Hub{web_push_subscriptions: subscriptions} = hub, endpoint_to_skip \\ nil) do
@@ -213,6 +215,11 @@ defmodule Ret.Hub do
   defp add_hub_sid_to_changeset(changeset) do
     hub_sid = Ret.Sids.generate_sid()
     changeset |> put_change(:hub_sid, hub_sid)
+  end
+
+  defp add_creator_assignment_token_to_changeset(changeset) do
+    creator_assignment_token = SecureRandom.hex()
+    changeset |> put_change(:creator_assignment_token, creator_assignment_token)
   end
 
   defp add_entry_code_to_changeset(changeset) do

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -125,6 +125,17 @@ defmodule Ret.Hub do
 
   def changeset_for_new_host(%Hub{} = hub, host), do: hub |> cast(%{host: host}, [:host])
 
+  def changeset_for_creator_assignment(
+        %Ret.Hub{creator_assignment_token: expected_token} = hub,
+        account,
+        token
+      )
+      when expected_token != nil and expected_token == token do
+    hub |> cast(%{}, []) |> add_account_to_changeset(account)
+  end
+
+  def changeset_for_creator_assignment(hub, _, _), do: hub |> cast(%{}, [])
+
   def add_account_to_changeset(changeset, nil), do: changeset
 
   def add_account_to_changeset(changeset, %Account{} = account) do

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -196,7 +196,7 @@ defmodule RetWeb.HubChannel do
         hub = socket |> hub_for_socket |> Repo.preload(@hub_preloads)
 
         hub =
-          if hub.creator_assignment_token && creator_assignment_token do
+          if creator_assignment_token do
             hub
             |> Hub.changeset_for_creator_assignment(account, creator_assignment_token)
             |> Repo.update!()

--- a/lib/ret_web/controllers/meta_controller.ex
+++ b/lib/ret_web/controllers/meta_controller.ex
@@ -1,8 +1,6 @@
 defmodule RetWeb.Api.V1.MetaController do
   use RetWeb, :controller
 
-  plug(RetWeb.Plugs.RateLimit when action in [:show])
-
   def show(conn, _params) do
     meta = Ret.Meta.get_meta()
     conn |> send_resp(200, meta |> Poison.encode!())

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -6,7 +6,8 @@ defmodule RetWeb.Api.V1.HubView do
     %{
       status: :ok,
       hub_id: hub.hub_sid,
-      url: hub |> Hub.url_for()
+      url: hub |> Hub.url_for(),
+      creator_assignment_token: hub.creator_assignment_token
     }
   end
 

--- a/priv/repo/migrations/20190503170158_add_creator_assignment_token.exs
+++ b/priv/repo/migrations/20190503170158_add_creator_assignment_token.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddCreatorAssignmentToken do
+  use Ecto.Migration
+
+  def change do
+    alter table("hubs") do
+      add(:creator_assignment_token, :string)
+    end
+  end
+end

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -65,4 +65,72 @@ defmodule Ret.HubTest do
 
     %{join_hub: true, update_hub: true, close_hub: true, mute_users: true} = hub |> Hub.perms_for_account(account)
   end
+
+  test "should have creator assignment token if no account assigned", %{scene: scene} do
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+
+    assert hub.creator_assignment_token != nil
+  end
+
+  test "show allow creator assignment if token is correct", %{scene: scene, account: account} do
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+
+    hub =
+      hub
+      |> Repo.preload(created_by_account: [])
+      |> Hub.changeset_for_creator_assignment(account, hub.creator_assignment_token)
+      |> Repo.update!()
+
+    assert hub.created_by_account_id == account.account_id
+  end
+
+  test "show disallow creator assignment if token is incorrect", %{scene: scene, account: account} do
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+
+    hub =
+      hub
+      |> Repo.preload(created_by_account: [])
+      |> Hub.changeset_for_creator_assignment(account, "bad token")
+      |> Repo.update!()
+
+    assert hub.created_by_account_id == nil
+  end
+
+  test "show disallow creator assignment if token is already used", %{
+    scene: scene,
+    account: account,
+    account2: account2
+  } do
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+
+    hub =
+      hub
+      |> Repo.preload(created_by_account: [])
+      |> Hub.changeset_for_creator_assignment(account, hub.creator_assignment_token)
+      |> Repo.update!()
+
+    hub =
+      hub
+      |> Repo.preload(created_by_account: [])
+      |> Hub.changeset_for_creator_assignment(account2, hub.creator_assignment_token)
+      |> Repo.update!()
+
+    hub =
+      hub
+      |> Repo.preload(created_by_account: [])
+      |> Hub.changeset_for_creator_assignment(account2, nil)
+      |> Repo.update!()
+
+    assert hub.created_by_account_id == account.account_id
+  end
+
+  test "should have creator assignment token if account assigned", %{account: account, scene: scene} do
+    {:ok, hub} =
+      %Hub{}
+      |> Hub.changeset(scene, %{name: "Test Hub"})
+      |> Hub.add_account_to_changeset(account)
+      |> Repo.insert()
+
+    assert hub.creator_assignment_token == nil
+  end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -26,7 +26,7 @@ defmodule Ret.TestHelpers do
   end
 
   def create_account(_) do
-    {:ok, account: create_account()}
+    {:ok, account: create_account(), account2: create_account()}
   end
 
   def create_owned_file(%{account: account}) do


### PR DESCRIPTION
Adds a one-time `creator_assignment_token` to new hubs, which is returned from the create API when a hub is created when signed out. This token can be passed in when calling `sign_in` on a `hub_channel` in order to assign the ownership of the hub to the newly logged in user.