### PR TITLE
Add last active at telemetry

### DIFF
--- a/priv/repo/migrations/20190514175300_add_last_active_at.exs
+++ b/priv/repo/migrations/20190514175300_add_last_active_at.exs
@@ -1,0 +1,11 @@
+defmodule Ret.Repo.Migrations.AddLastActiveAt do
+  use Ecto.Migration
+
+  def change do
+    alter table("hubs") do
+      add(:last_active_at, :utc_datetime, null: true)
+    end
+
+    create(index(:hubs, [:last_active_at]))
+  end
+end


### PR DESCRIPTION
Our KPI we want to track is monthly active rooms, which was not possible to do accurately without keeping a timestamp of the last time a room became active. 