### PR TITLE
Add high poly search

### DIFF
--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -107,7 +107,8 @@ defmodule RetWeb.Api.V1.MediaSearchController do
       cursor: params["cursor"],
       q: params["q"],
       filter: params["filter"],
-      locale: params["locale"]
+      locale: params["locale"],
+      type: params["type"]
     }
 
     case Cachex.fetch(cache_for_query(query), query) do


### PR DESCRIPTION
Adds `type=models_high` to poly and sketchfab search to remove poly count limit.