### PR TITLE
Friendly display name

### DIFF
--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -59,6 +59,12 @@ defmodule Ret.DiscordClient do
 
   def fetch_display_name(%Ret.OAuthProvider{source: :discord, provider_account_id: provider_account_id}) do
     case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
+      {status, result} when status in [:commit, :ok] -> "#{result["username"]}"
+    end
+  end
+
+  def fetch_community_identifier(%Ret.OAuthProvider{source: :discord, provider_account_id: provider_account_id}) do
+    case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
       {status, result} when status in [:commit, :ok] -> "#{result["username"]}##{result["discriminator"]}"
     end
   end

--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -57,9 +57,21 @@ defmodule Ret.DiscordClient do
     permissions[permission]
   end
 
-  def fetch_display_name(%Ret.OAuthProvider{source: :discord, provider_account_id: provider_account_id}) do
-    case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
-      {status, result} when status in [:commit, :ok] -> "#{result["username"]}"
+  def fetch_display_name(
+        %Ret.OAuthProvider{source: :discord, provider_account_id: provider_account_id},
+        %Ret.HubBinding{community_id: community_id}
+      ) do
+    nickname =
+      case Cachex.fetch(:discord_api, "/guilds/#{community_id}/members/#{provider_account_id}") do
+        {status, result} when status in [:commit, :ok] -> "#{result["nick"]}"
+      end
+
+    if nickname == "" do
+      case Cachex.fetch(:discord_api, "/users/#{provider_account_id}") do
+        {status, result} when status in [:commit, :ok] -> "#{result["username"]}"
+      end
+    else
+      nickname
     end
   end
 

--- a/lib/ret/hub_binding.ex
+++ b/lib/ret/hub_binding.ex
@@ -46,11 +46,11 @@ defmodule Ret.HubBinding do
 
   def member_of_channel?(_, _), do: false
 
-  def fetch_display_name(%Ret.OAuthProvider{source: :discord} = oauth_provider) do
-    Ret.DiscordClient.fetch_display_name(oauth_provider)
+  def fetch_display_name(%Ret.OAuthProvider{source: :discord} = oauth_provider, %Ret.HubBinding{} = hub_binding) do
+    Ret.DiscordClient.fetch_display_name(oauth_provider, hub_binding)
   end
 
-  def fetch_display_name(_), do: nil
+  def fetch_display_name(_, _), do: nil
 
   def fetch_community_identifier(%Ret.OAuthProvider{source: :discord} = oauth_provider) do
     Ret.DiscordClient.fetch_community_identifier(oauth_provider)

--- a/lib/ret/hub_binding.ex
+++ b/lib/ret/hub_binding.ex
@@ -52,6 +52,12 @@ defmodule Ret.HubBinding do
 
   def fetch_display_name(_), do: nil
 
+  def fetch_community_identifier(%Ret.OAuthProvider{source: :discord} = oauth_provider) do
+    Ret.DiscordClient.fetch_community_identifier(oauth_provider)
+  end
+
+  def fetch_community_identifier(_), do: nil
+
   defp matching_oauth_provider(account, hub_binding) do
     account.oauth_providers |> Enum.find(&(&1.source == hub_binding.type))
   end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -529,13 +529,14 @@ defmodule RetWeb.HubChannel do
     display_name = oauth_provider |> Ret.HubBinding.fetch_display_name(hub_binding)
     community_identifier = oauth_provider |> Ret.HubBinding.fetch_community_identifier()
 
-    assigns
-    |> Map.merge(%{
-      profile: %{
+    overriden =
+      assigns.profile
+      |> Map.merge(%{
         "displayName" => display_name,
         "communityIdentifier" => community_identifier
-      }
-    })
+      })
+
+    assigns |> Map.put(:profile, overriden)
   end
 
   defp join_with_hub(nil, _account, _socket, _params) do

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -490,7 +490,7 @@ defmodule RetWeb.HubChannel do
       provider_account_id: oauth_account_id
     }
 
-    assigns |> override_display_name(oauth_provider, hub_binding)
+    assigns |> override_display_name_via_binding(oauth_provider, hub_binding)
   end
 
   # If there isn't an oauth account id on the socket, we expect the user to have an account
@@ -513,7 +513,7 @@ defmodule RetWeb.HubChannel do
     oauth_provider =
       account.oauth_providers |> Enum.filter(fn provider -> hub_binding.type == provider.source end) |> Enum.at(0)
 
-    assigns |> override_display_name(oauth_provider, hub_binding)
+    assigns |> override_display_name_via_binding(oauth_provider, hub_binding)
   end
 
   # We don't override display names for unbound hubs
@@ -525,7 +525,7 @@ defmodule RetWeb.HubChannel do
        ),
        do: assigns
 
-  defp override_display_name(assigns, oauth_provider, hub_binding) do
+  defp override_display_name_via_binding(assigns, oauth_provider, hub_binding) do
     display_name = oauth_provider |> Ret.HubBinding.fetch_display_name(hub_binding)
     community_identifier = oauth_provider |> Ret.HubBinding.fetch_community_identifier()
 


### PR DESCRIPTION
- Discord displayNames no longer contain the discriminator number
- We also now lookup the server-specific "nickname" and use that if available
- Injects a new communityIdentifier field into the presence profile that includes the discord discriminator