### PR TITLE
Endpoints for Avatar Listings

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -70,24 +70,41 @@ defmodule Ret.Avatar do
     end)
   end
 
+  defp avatar_listing_to_collapsed_files(%{parent_avatar_listing: nil} = listing),
+    do: listing |> Map.take(Avatar.file_columns())
+
+  defp avatar_listing_to_collapsed_files(%{parent_avatar_listing: parent} = listing) do
+    parent
+    |> Repo.preload(Avatar.file_columns())
+    |> Map.take(Avatar.file_columns())
+    |> Map.merge(listing |> Map.take(Avatar.file_columns()), fn
+      _k, v1, nil -> v1
+      _k, _v1, v2 -> v2
+    end)
+  end
+
   def collapsed_files(%Avatar{} = avatar) do
     avatar
     |> Repo.preload([:parent_avatar, :parent_avatar_listing] ++ @file_columns)
     |> avatar_to_collapsed_files()
   end
 
-  def version(%Avatar{} = avatar) do
-    avatar.updated_at |> NaiveDateTime.to_erl() |> :calendar.datetime_to_gregorian_seconds()
+  def collapsed_files(%AvatarListing{} = listing) do
+    listing |> Repo.preload([:parent_avatar_listing] ++ Avatar.file_columns()) |> avatar_listing_to_collapsed_files()
   end
 
+  def version(%t{} = a) when t in [Avatar, AvatarListing],
+    do: a.updated_at |> NaiveDateTime.to_erl() |> :calendar.datetime_to_gregorian_seconds()
+
   def url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
+  def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
 
-  def gltf_url(%Avatar{} = avatar), do: "#{Avatar.url(avatar)}/avatar.gltf?v=#{Avatar.version(avatar)}"
+  def gltf_url(%t{} = a) when t in [Avatar, AvatarListing], do: "#{Avatar.url(a)}/avatar.gltf?v=#{Avatar.version(a)}"
 
-  def base_gltf_url(%Avatar{} = avatar), do: "#{Avatar.url(avatar)}/base.gltf?v=#{Avatar.version(avatar)}"
+  def base_gltf_url(%t{} = a) when t in [Avatar, AvatarListing], do: "#{Avatar.url(a)}/base.gltf?v=#{Avatar.version(a)}"
 
-  def file_url_or_nil(%Avatar{} = avatar, column) do
-    case avatar |> Map.get(column) do
+  def file_url_or_nil(%t{} = a, column) when t in [Avatar, AvatarListing] do
+    case a |> Map.get(column) do
       nil -> nil
       owned_file -> owned_file |> OwnedFile.uri_for() |> URI.to_string()
     end

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -75,9 +75,9 @@ defmodule Ret.Avatar do
 
   defp avatar_listing_to_collapsed_files(%{parent_avatar_listing: parent} = listing) do
     parent
-    |> Repo.preload(Avatar.file_columns())
-    |> Map.take(Avatar.file_columns())
-    |> Map.merge(listing |> Map.take(Avatar.file_columns()), fn
+    |> Repo.preload(@file_columns)
+    |> Map.take(@file_columns)
+    |> Map.merge(listing |> Map.take(@file_columns), fn
       _k, v1, nil -> v1
       _k, _v1, v2 -> v2
     end)

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -43,41 +43,6 @@ defmodule Ret.AvatarListing do
     belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
   end
 
-  def version(%AvatarListing{} = avatar) do
-    avatar.updated_at |> NaiveDateTime.to_erl() |> :calendar.datetime_to_gregorian_seconds()
-  end
-
-  def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
-
-  def gltf_url(%AvatarListing{} = avatar),
-    do: "#{AvatarListing.url(avatar)}/avatar.gltf?v=#{AvatarListing.version(avatar)}"
-
-  def base_gltf_url(%AvatarListing{} = avatar),
-    do: "#{AvatarListing.url(avatar)}/base.gltf?v=#{AvatarListing.version(avatar)}"
-
-  def file_url_or_nil(%AvatarListing{} = avatar, column) do
-    case avatar |> Map.get(column) do
-      nil -> nil
-      owned_file -> owned_file |> OwnedFile.uri_for() |> URI.to_string()
-    end
-  end
-
-  defp avatar_listing_to_collapsed_files(%{parent_avatar_listing: nil} = a), do: a |> Map.take(Avatar.file_columns())
-
-  defp avatar_listing_to_collapsed_files(%{parent_avatar_listing: p} = a) do
-    p
-    |> Repo.preload(Avatar.file_columns())
-    |> Map.take(Avatar.file_columns())
-    |> Map.merge(a |> Map.take(Avatar.file_columns()), fn
-      _k, v1, nil -> v1
-      _k, _v1, v2 -> v2
-    end)
-  end
-
-  def collapsed_files(%AvatarListing{} = a) do
-    a |> Repo.preload([:parent_avatar_listing] ++ Avatar.file_columns()) |> avatar_listing_to_collapsed_files()
-  end
-
   def changeset_for_listing_for_avatar(
         %AvatarListing{} = listing,
         avatar,

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -10,7 +10,7 @@ defmodule Ret.AvatarListing do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Ret.{AvatarListing, OwnedFile}
+  alias Ret.{AvatarListing, OwnedFile, Repo, Avatar}
   alias AvatarListing.{AvatarListingSlug}
 
   @schema_prefix "ret0"
@@ -49,15 +49,33 @@ defmodule Ret.AvatarListing do
 
   def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
 
-  def gltf_url(%AvatarListing{} = avatar), do: "#{AvatarListing.url(avatar)}/avatar.gltf?v=#{AvatarListing.version(avatar)}"
+  def gltf_url(%AvatarListing{} = avatar),
+    do: "#{AvatarListing.url(avatar)}/avatar.gltf?v=#{AvatarListing.version(avatar)}"
 
-  def base_gltf_url(%AvatarListing{} = avatar), do: "#{AvatarListing.url(avatar)}/base.gltf?v=#{AvatarListing.version(avatar)}"
+  def base_gltf_url(%AvatarListing{} = avatar),
+    do: "#{AvatarListing.url(avatar)}/base.gltf?v=#{AvatarListing.version(avatar)}"
 
   def file_url_or_nil(%AvatarListing{} = avatar, column) do
     case avatar |> Map.get(column) do
       nil -> nil
       owned_file -> owned_file |> OwnedFile.uri_for() |> URI.to_string()
     end
+  end
+
+  defp avatar_listing_to_collapsed_files(%{parent_avatar_listing: nil} = a), do: a |> Map.take(Avatar.file_columns())
+
+  defp avatar_listing_to_collapsed_files(%{parent_avatar_listing: p} = a) do
+    p
+    |> Repo.preload(Avatar.file_columns())
+    |> Map.take(Avatar.file_columns())
+    |> Map.merge(a |> Map.take(Avatar.file_columns()), fn
+      _k, v1, nil -> v1
+      _k, _v1, v2 -> v2
+    end)
+  end
+
+  def collapsed_files(%AvatarListing{} = a) do
+    a |> Repo.preload([:parent_avatar_listing] ++ Avatar.file_columns()) |> avatar_listing_to_collapsed_files()
   end
 
   def changeset_for_listing_for_avatar(
@@ -70,22 +88,17 @@ defmodule Ret.AvatarListing do
     |> maybe_add_avatar_listing_sid_to_changeset
     |> unique_constraint(:avatar_listing_sid)
     |> put_assoc(:avatar, avatar)
-
     |> put_change(:name, params[:name] || avatar.name)
     |> put_change(:description, params[:description] || avatar.description)
     |> put_change(:attributions, avatar.attributions)
-
     |> put_change(:parent_avatar_listing_id, avatar.parent_avatar_listing_id)
-
     |> put_change(:gltf_owned_file_id, avatar.gltf_owned_file_id)
     |> put_change(:bin_owned_file_id, avatar.bin_owned_file_id)
     |> put_change(:thumbnail_owned_file_id, avatar.thumbnail_owned_file_id)
-
     |> put_change(:base_map_owned_file_id, avatar.base_map_owned_file_id)
     |> put_change(:emissive_map_owned_file_id, avatar.emissive_map_owned_file_id)
     |> put_change(:normal_map_owned_file_id, avatar.normal_map_owned_file_id)
     |> put_change(:orm_map_owned_file_id, avatar.orm_map_owned_file_id)
-
     |> AvatarListingSlug.maybe_generate_slug()
     |> AvatarListingSlug.unique_constraint()
   end

--- a/lib/ret/enums.ex
+++ b/lib/ret/enums.ex
@@ -6,6 +6,6 @@ defenum(Ret.OAuthProvider.Source, :oauth_provider_source, [:discord, :slack], sc
 defenum(Ret.OwnedFile.State, :owned_file_state, [:active, :inactive, :removed], schema: "ret0")
 defenum(Ret.Scene.State, :scene_state, [:active, :removed], schema: "ret0")
 defenum(Ret.SceneListing.State, :scene_listing_state, [:active, :delisted], schema: "ret0")
-defenum(Ret.Avatar.State, :avatar_state, [:active], schema: "ret0")
+defenum(Ret.Avatar.State, :avatar_state, [:active, :removed], schema: "ret0")
 defenum(Ret.AvatarListing.State, :avatar_listing_state, [:active, :delisted], schema: "ret0")
 defenum(Ret.Asset.Type, :asset_type, [:image, :video, :model], schema: "ret0")

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -551,12 +551,12 @@ defmodule Ret.MediaSearch do
   end
 
   defp avatar_listing_to_entry(avatar_listing) do
-    thumbnail = avatar_listing |> AvatarListing.file_url_or_nil(:thumbnail_owned_file)
+    thumbnail = avatar_listing |> Avatar.file_url_or_nil(:thumbnail_owned_file)
 
     %{
       id: avatar_listing.avatar_listing_sid,
       type: "avatar_listing",
-      url: avatar_listing |> AvatarListing.url(),
+      url: avatar_listing |> Avatar.url(),
       name: avatar_listing.name,
       description: avatar_listing.description,
       attributions: avatar_listing.attributions,
@@ -568,8 +568,8 @@ defmodule Ret.MediaSearch do
         }
       },
       gltfs: %{
-        avatar: avatar_listing |> AvatarListing.gltf_url(),
-        base: avatar_listing |> AvatarListing.base_gltf_url()
+        avatar: avatar_listing |> Avatar.gltf_url(),
+        base: avatar_listing |> Avatar.base_gltf_url()
       }
     }
   end

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -107,14 +107,9 @@ defmodule RetWeb.Api.V1.AvatarController do
     conn |> send_resp(404, "")
   end
 
-  def show(conn, %Avatar{} = avatar) do
+  def show(conn, %t{} = avatar) when t in [Avatar, AvatarListing] do
     account = conn |> Guardian.Plug.current_resource()
     conn |> render("show.json", avatar: avatar, account: account)
-  end
-
-  def show(conn, %AvatarListing{} = avatar_listing) do
-    account = conn |> Guardian.Plug.current_resource()
-    conn |> render("show.json", avatar: avatar_listing, account: account)
   end
 
   def show_avatar_gltf(conn, %{"id" => avatar_sid}) do
@@ -129,11 +124,8 @@ defmodule RetWeb.Api.V1.AvatarController do
     conn |> send_resp(404, "Avatar not found")
   end
 
-  def show_gltf(conn, %Avatar{} = a, apply_overrides),
+  def show_gltf(conn, %t{} = a, apply_overrides) when t in [Avatar, AvatarListing],
     do: conn |> show_gltf(a |> Avatar.collapsed_files(), apply_overrides)
-
-  def show_gltf(conn, %AvatarListing{} = a, apply_overrides),
-    do: conn |> show_gltf(a |> AvatarListing.collapsed_files(), apply_overrides)
 
   def show_gltf(conn, avatar_files, apply_overrides) do
     case Storage.fetch(avatar_files.gltf_owned_file) do

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -112,6 +112,9 @@ defmodule RetWeb.Api.V1.AvatarController do
     conn |> render("show.json", avatar: avatar, account: account)
   end
 
+  def show(conn, %Avatar{state: :removed}), do: conn |> send_resp(404, "Avatar not found")
+  def show(conn, %AvatarListing{state: :delisted}), do: conn |> send_resp(404, "Avatar not found")
+
   def show_avatar_gltf(conn, %{"id" => avatar_sid}) do
     conn |> show_gltf(avatar_sid |> get_avatar(), true)
   end

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -85,7 +85,7 @@ defmodule RetWeb.Api.V1.AvatarController do
 
         case result do
           :ok ->
-            conn |> render("create.json", avatar: avatar)
+            conn |> render("create.json", avatar: avatar, account: account)
 
           :error ->
             conn |> send_resp(422, "invalid avatar")
@@ -108,11 +108,13 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   def show(conn, %Avatar{} = avatar) do
-    conn |> render("show.json", avatar: avatar)
+    account = conn |> Guardian.Plug.current_resource()
+    conn |> render("show.json", avatar: avatar, account: account)
   end
 
   def show(conn, %AvatarListing{} = avatar_listing) do
-    conn |> render("show.json", avatar: avatar_listing)
+    account = conn |> Guardian.Plug.current_resource()
+    conn |> render("show.json", avatar: avatar_listing, account: account)
   end
 
   def show_avatar_gltf(conn, %{"id" => avatar_sid}) do

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -127,6 +127,9 @@ defmodule RetWeb.Api.V1.AvatarController do
     conn |> send_resp(404, "Avatar not found")
   end
 
+  def show_gltf(conn, %Avatar{state: :removed}, _overrides), do: conn |> send_resp(404, "Avatar not found")
+  def show_gltf(conn, %AvatarListing{state: :delisted}, _overrides), do: conn |> send_resp(404, "Avatar not found")
+
   def show_gltf(conn, %t{} = a, apply_overrides) when t in [Avatar, AvatarListing],
     do: conn |> show_gltf(a |> Avatar.collapsed_files(), apply_overrides)
 

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -8,9 +8,17 @@ defmodule RetWeb.Api.V1.AvatarController do
   @primary_material_name "Bot_PBS"
 
   defp get_avatar(avatar_sid) do
-    Avatar
-    |> Repo.get_by(avatar_sid: avatar_sid)
-    |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :account]])
+    avatar_sid
+    |> Avatar.avatar_or_avatar_listing_by_sid()
+    |> preload()
+  end
+
+  defp preload(%Avatar{} = a) do
+    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :account]])
+  end
+
+  defp preload(%AvatarListing{} = a) do
+    a |> Repo.preload([Avatar.file_columns() ++ [:avatar, :parent_avatar_listing, :account]])
   end
 
   def create(conn, %{"avatar" => params}) do
@@ -103,21 +111,29 @@ defmodule RetWeb.Api.V1.AvatarController do
     conn |> render("show.json", avatar: avatar)
   end
 
+  def show(conn, %AvatarListing{} = avatar_listing) do
+    conn |> render("show.json", avatar: avatar_listing)
+  end
+
   def show_avatar_gltf(conn, %{"id" => avatar_sid}) do
-    conn |> show_gltf(Avatar |> Repo.get_by(avatar_sid: avatar_sid), true)
+    conn |> show_gltf(avatar_sid |> get_avatar(), true)
   end
 
   def show_base_gltf(conn, %{"id" => avatar_sid}) do
-    conn |> show_gltf(Avatar |> Repo.get_by(avatar_sid: avatar_sid), false)
+    conn |> show_gltf(avatar_sid |> get_avatar(), false)
   end
 
   def show_gltf(conn, nil = _avatar, _apply_overrides) do
     conn |> send_resp(404, "Avatar not found")
   end
 
-  def show_gltf(conn, %Avatar{} = avatar, apply_overrides) do
-    avatar_files = avatar |> Avatar.collapsed_files()
+  def show_gltf(conn, %Avatar{} = a, apply_overrides),
+    do: conn |> show_gltf(a |> Avatar.collapsed_files(), apply_overrides)
 
+  def show_gltf(conn, %AvatarListing{} = a, apply_overrides),
+    do: conn |> show_gltf(a |> AvatarListing.collapsed_files(), apply_overrides)
+
+  def show_gltf(conn, avatar_files, apply_overrides) do
     case Storage.fetch(avatar_files.gltf_owned_file) do
       {:ok, _meta, stream} ->
         gltf =

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -107,13 +107,13 @@ defmodule RetWeb.Api.V1.AvatarController do
     conn |> send_resp(404, "")
   end
 
+  def show(conn, %Avatar{state: :removed}), do: conn |> send_resp(404, "Avatar not found")
+  def show(conn, %AvatarListing{state: :delisted}), do: conn |> send_resp(404, "Avatar not found")
+
   def show(conn, %t{} = avatar) when t in [Avatar, AvatarListing] do
     account = conn |> Guardian.Plug.current_resource()
     conn |> render("show.json", avatar: avatar, account: account)
   end
-
-  def show(conn, %Avatar{state: :removed}), do: conn |> send_resp(404, "Avatar not found")
-  def show(conn, %AvatarListing{state: :delisted}), do: conn |> send_resp(404, "Avatar not found")
 
   def show_avatar_gltf(conn, %{"id" => avatar_sid}) do
     conn |> show_gltf(avatar_sid |> get_avatar(), true)

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -50,7 +50,6 @@ defmodule RetWeb.Router do
       get("/meta", Api.V1.MetaController, :show)
       resources("/media", Api.V1.MediaController, only: [:create])
       resources("/scenes", Api.V1.SceneController, only: [:show])
-      resources("/avatars", Api.V1.AvatarController, only: [:show])
       get("/avatars/:id/base.gltf", Api.V1.AvatarController, :show_base_gltf)
       get("/avatars/:id/avatar.gltf", Api.V1.AvatarController, :show_avatar_gltf)
       get("/oauth/:type", Api.V1.OAuthController, :show)
@@ -72,6 +71,7 @@ defmodule RetWeb.Router do
       pipe_through([:auth_optional])
       resources("/hubs", Api.V1.HubController, only: [:create, :delete])
       resources("/media/search", Api.V1.MediaSearchController, only: [:index])
+      resources("/avatars", Api.V1.AvatarController, only: [:show])
     end
 
     scope "/v1", as: :api_v1 do

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -2,15 +2,15 @@ defmodule RetWeb.Api.V1.AvatarView do
   use RetWeb, :view
   alias Ret.{Avatar, AvatarListing}
 
-  def render("create.json", %{avatar: avatar}) do
-    %{avatars: [render_avatar(avatar)]}
+  def render("create.json", %{avatar: avatar, account: account}) do
+    %{avatars: [render_avatar(avatar, account)]}
   end
 
-  def render("show.json", %{avatar: avatar}) do
-    %{avatars: [render_avatar(avatar)]}
+  def render("show.json", %{avatar: avatar, account: account}) do
+    %{avatars: [render_avatar(avatar, account)]}
   end
 
-  def render_avatar(%Avatar{} = a) do
+  def render_avatar(%Avatar{} = a, account) do
     %{
       avatar_id: a.avatar_sid,
       parent_avatar_id: unless(is_nil(a.parent_avatar), do: a.parent_avatar.avatar_sid),
@@ -20,6 +20,7 @@ defmodule RetWeb.Api.V1.AvatarView do
       attributions: if(is_nil(a.attributions), do: %{}, else: a.attributions),
       allow_remixing: a.allow_remixing,
       allow_promotion: a.allow_promotion,
+      account_id: account && a.account_id == account.account_id && a.account_id |> Integer.to_string(), # Only include account id on your own avatars
       gltf_url: a |> Avatar.gltf_url(),
       base_gltf_url: a |> Avatar.base_gltf_url(),
       files:
@@ -30,7 +31,7 @@ defmodule RetWeb.Api.V1.AvatarView do
     }
   end
 
-  def render_avatar(%AvatarListing{} = a) do
+  def render_avatar(%AvatarListing{} = a, _account) do
     %{
       avatar_id: a.avatar_listing_sid,
       parent_avatar_listing_id: unless(is_nil(a.parent_avatar_listing), do: a.parent_avatar_listing.avatar_listing_sid),

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -1,6 +1,6 @@
 defmodule RetWeb.Api.V1.AvatarView do
   use RetWeb, :view
-  alias Ret.{Avatar}
+  alias Ret.{Avatar, AvatarListing}
 
   def render("create.json", %{avatar: avatar}) do
     %{avatars: [render_avatar(avatar)]}
@@ -10,23 +10,41 @@ defmodule RetWeb.Api.V1.AvatarView do
     %{avatars: [render_avatar(avatar)]}
   end
 
-  def render_avatar(avatar) do
+  def render_avatar(%Avatar{} = a) do
     %{
-      avatar_id: avatar.avatar_sid,
-      parent_avatar_id: unless(is_nil(avatar.parent_avatar), do: avatar.parent_avatar.avatar_sid),
-      parent_avatar_listing_id:
-        unless(is_nil(avatar.parent_avatar_listing), do: avatar.parent_avatar_listing.avatar_listing_sid),
-      name: avatar.name,
-      description: avatar.description,
-      attributions: if(is_nil(avatar.attributions), do: %{}, else: avatar.attributions),
-      allow_remixing: avatar.allow_remixing,
-      allow_promotion: avatar.allow_promotion,
-      gltf_url: avatar |> Avatar.gltf_url(),
-      base_gltf_url: avatar |> Avatar.base_gltf_url(),
+      avatar_id: a.avatar_sid,
+      parent_avatar_id: unless(is_nil(a.parent_avatar), do: a.parent_avatar.avatar_sid),
+      parent_avatar_listing_id: unless(is_nil(a.parent_avatar_listing), do: a.parent_avatar_listing.avatar_listing_sid),
+      name: a.name,
+      description: a.description,
+      attributions: if(is_nil(a.attributions), do: %{}, else: a.attributions),
+      allow_remixing: a.allow_remixing,
+      allow_promotion: a.allow_promotion,
+      gltf_url: a |> Avatar.gltf_url(),
+      base_gltf_url: a |> Avatar.base_gltf_url(),
       files:
         for col <- Avatar.file_columns(), into: %{} do
           key = col |> Atom.to_string() |> String.replace_suffix("_owned_file", "")
-          {key, avatar |> Avatar.file_url_or_nil(col)}
+          {key, a |> Avatar.file_url_or_nil(col)}
+        end
+    }
+  end
+
+  def render_avatar(%AvatarListing{} = a) do
+    %{
+      avatar_id: a.avatar_listing_sid,
+      parent_avatar_listing_id: unless(is_nil(a.parent_avatar_listing), do: a.parent_avatar_listing.avatar_listing_sid),
+      name: a.name,
+      description: a.description,
+      attributions: if(is_nil(a.attributions), do: %{}, else: a.attributions),
+      allow_remixing: a.avatar.allow_remixing,
+      allow_promotion: a.avatar.allow_promotion,
+      gltf_url: a |> AvatarListing.gltf_url(),
+      base_gltf_url: a |> AvatarListing.base_gltf_url(),
+      files:
+        for col <- Avatar.file_columns(), into: %{} do
+          key = col |> Atom.to_string() |> String.replace_suffix("_owned_file", "")
+          {key, a |> AvatarListing.file_url_or_nil(col)}
         end
     }
   end


### PR DESCRIPTION
This adds endpoinds for avatar listings similar to how we handle scenes/scene_listings. `/ap1/v1/avatars` can now take either and avatar or avatar listing sid (yuck, but keeping it consistent with scenes for now).

This PR also adds support for using an avatar listing as a parent avatar, and simplifies the semantics of the collapsing behavior to only support a single level of parenting.