### PR TITLE
OAuth error handling

### DIFF
--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -10,7 +10,7 @@ defmodule Ret.AvatarListing do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Ret.{AvatarListing, OwnedFile, Repo}
+  alias Ret.{AvatarListing, OwnedFile}
   alias AvatarListing.{AvatarListingSlug}
 
   @schema_prefix "ret0"

--- a/lib/ret/oauth_token.ex
+++ b/lib/ret/oauth_token.ex
@@ -17,7 +17,7 @@ defmodule Ret.OAuthToken do
         nil,
         %{hub_sid: hub_sid, aud: :ret_oauth},
         allowed_algos: ["HS512"],
-        ttl: {5, :minutes},
+        ttl: {10, :minutes},
         allowed_drift: 60 * 1000
       )
 


### PR DESCRIPTION
Fixes a couple of errors caught by sentry.
- Handle expired oauth tokens
- Handle denied oauth
- Extend oauth token expiry from 5 minutes to 10 minutes