### PR TITLE
Remove characters from sids that are difficult to distinguish

### DIFF
--- a/lib/ret/sids.ex
+++ b/lib/ret/sids.ex
@@ -1,11 +1,11 @@
 defmodule Ret.Sids do
-  @num_random_bits_for_sid 16
+  @num_random_bits_for_sid 32
 
   def generate_sid() do
     @num_random_bits_for_sid
     |> :crypto.strong_rand_bytes()
     |> Base.url_encode64()
+    |> String.replace(~r/[1IlO0_-]/, "")
     |> String.slice(0, 7)
-    |> String.replace(~r/[_-]/, (:rand.uniform(10) - 1) |> Integer.to_string())
   end
 end


### PR DESCRIPTION
Add `1Il` and `O0` to list of undesirable characters, since they are hard to distinguish in most fonts. This also changes the algorithm to draw from a longer list of crypto random characters, instead of simply replacing characters with random digits.