### PR TITLE
Add Avatar landing pages

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -96,12 +96,16 @@ defmodule Ret.Avatar do
   def version(%t{} = a) when t in [Avatar, AvatarListing],
     do: a.updated_at |> NaiveDateTime.to_erl() |> :calendar.datetime_to_gregorian_seconds()
 
-  def url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
-  def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
+  def url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/avatars/#{avatar.avatar_sid}"
+  def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/avatars/#{avatar.avatar_listing_sid}"
 
-  def gltf_url(%t{} = a) when t in [Avatar, AvatarListing], do: "#{Avatar.url(a)}/avatar.gltf?v=#{Avatar.version(a)}"
+  defp api_base_url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
+  defp api_base_url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
 
-  def base_gltf_url(%t{} = a) when t in [Avatar, AvatarListing], do: "#{Avatar.url(a)}/base.gltf?v=#{Avatar.version(a)}"
+  def gltf_url(%t{} = a) when t in [Avatar, AvatarListing], do: "#{api_base_url(a)}/avatar.gltf?v=#{Avatar.version(a)}"
+
+  def base_gltf_url(%t{} = a) when t in [Avatar, AvatarListing],
+    do: "#{api_base_url(a)}/base.gltf?v=#{Avatar.version(a)}"
 
   def file_url_or_nil(%t{} = a, column) when t in [Avatar, AvatarListing] do
     case a |> Map.get(column) do

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -1,6 +1,6 @@
 defmodule RetWeb.PageController do
   use RetWeb, :controller
-  alias Ret.{Repo, Hub, Scene, SceneListing}
+  alias Ret.{Repo, Hub, Scene, SceneListing, Avatar, AvatarListing}
 
   def call(conn, _params) do
     render_for_path(conn.request_path, conn)
@@ -23,6 +23,23 @@ defmodule RetWeb.PageController do
     conn |> send_resp(404, "")
   end
 
+  defp render_avatar_content(%t{} = avatar, conn) when t in [Avatar, AvatarListing] do
+    avatar_meta_tags =
+      Phoenix.View.render_to_string(RetWeb.PageView, "avatar-meta.html", avatar: avatar, ret_meta: Ret.Meta.get_meta())
+
+    chunks =
+      chunks_for_page("avatar.html", :hubs)
+      |> List.insert_at(1, avatar_meta_tags)
+
+    conn
+    |> put_resp_header("content-type", "text/html; charset=utf-8")
+    |> send_resp(200, chunks)
+  end
+
+  defp render_avatar_content(nil, conn) do
+    conn |> send_resp(404, "")
+  end
+
   def render_for_path("/", conn), do: conn |> render_page("index.html")
 
   def render_for_path("/scenes/" <> path, conn) do
@@ -32,6 +49,15 @@ defmodule RetWeb.PageController do
     |> Scene.scene_or_scene_listing_by_sid()
     |> Repo.preload([:screenshot_owned_file])
     |> render_scene_content(conn)
+  end
+
+  def render_for_path("/avatars/" <> path, conn) do
+    path
+    |> String.split("/")
+    |> Enum.at(0)
+    |> Avatar.avatar_or_avatar_listing_by_sid()
+    |> Repo.preload([:thumbnail_owned_file])
+    |> render_avatar_content(conn)
   end
 
   def render_for_path("/link", conn), do: conn |> render_page("link.html")

--- a/lib/ret_web/templates/page/avatar-meta.html.eex
+++ b/lib/ret_web/templates/page/avatar-meta.html.eex
@@ -1,12 +1,12 @@
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= @avatar |> Ret.Avatar.url %>" />
 <meta property="og:title" content="<%= @avatar.name %> | Hubs by Mozilla" />
-<meta property="og:description" content="<%= @avatar.description %>" />
+<meta property="og:description" content="&quot;<%= @avatar.name %>&quot; is an avatar you can use in Hubs." />
 <meta property="og:image" content="<%= @avatar.thumbnail_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
 <meta name="twitter:title" value="<%= @avatar.name %> | Hubs by Mozilla" />
-<meta name="twitter:description" content="<%= @avatar.name %> is an avatar you can use in Hubs." />
+<meta name="twitter:description" content="&quot;<%= @avatar.name %>&quot; is an avatar you can use in Hubs." />
 <meta property="twitter:image" content="<%= @avatar.thumbnail_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
 <meta name="twitter:url" value="<%= @avatar |> Ret.Avatar.url %>" />
 <meta name="ret:version" value="<%= @ret_meta[:version] %>" />

--- a/lib/ret_web/templates/page/avatar-meta.html.eex
+++ b/lib/ret_web/templates/page/avatar-meta.html.eex
@@ -1,0 +1,16 @@
+<meta property="og:type" content="website" />
+<meta property="og:url" content="<%= @avatar |> Ret.Avatar.url %>" />
+<meta property="og:title" content="<%= @avatar.name %> | Hubs by Mozilla" />
+<meta property="og:description" content="<%= @avatar.description %>" />
+<meta property="og:image" content="<%= @avatar.thumbnail_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
+<meta name="twitter:title" value="<%= @avatar.name %> | Hubs by Mozilla" />
+<meta name="twitter:description" content="<%= @avatar.name %> is an avatar you can use in Hubs." />
+<meta property="twitter:image" content="<%= @avatar.thumbnail_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
+<meta name="twitter:url" value="<%= @avatar |> Ret.Avatar.url %>" />
+<meta name="ret:version" value="<%= @ret_meta[:version] %>" />
+<meta name="ret:phx_host" value="<%= @ret_meta[:phx_host] %>" />
+<meta name="ret:phx_port" value="<%= @ret_meta[:phx_port] %>" />
+<meta name="ret:pool" value="<%= @ret_meta[:pool] %>" />
+<title><%= @avatar.name %> | Hubs by Mozilla</title>


### PR DESCRIPTION
Adds routes + meta for avatar landing pages. Avatar responses now point to these pages in their `url` property.