### PR TITLE
Skip cachex cache for pages in dev

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -178,3 +178,5 @@ config :ret, Ret.Habitat, ip: "127.0.0.1", http_port: 9631
 config :ret, Ret.JanusLoadStatus, default_janus_host: dev_janus_host
 
 config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
+
+config :ret, RetWeb.PageController, skip_cache: true

--- a/lib/ret/page_origin_warmer.ex
+++ b/lib/ret/page_origin_warmer.ex
@@ -28,6 +28,10 @@ defmodule Ret.PageOriginWarmer do
     end
   end
 
+  def chunks_for_page(source, page) do
+    {:ok, page_to_cache_entry(source, page) |> elem(1)}
+  end
+
   defp page_to_cache_entry(source, page) do
     config_key =
       if source == :hubs do


### PR DESCRIPTION
This speeds up local development by not using the warmed cache for pages in dev, so when you refresh the page you always have the latest running version.