### PR TITLE
Hub object permissions

### DIFF
--- a/lib/ret/bit_field_utils.ex
+++ b/lib/ret/bit_field_utils.ex
@@ -1,0 +1,15 @@
+defmodule Ret.BitFieldUtils do
+  use Bitwise
+
+  def permissions_to_map(nil = bit_field, permissions) do
+    0 |> permissions_to_map(permissions)
+  end
+
+  # Convert a permissions bit field integer into a {:permission_name => boolean} map
+  def permissions_to_map(bit_field, permissions) do
+    0..31
+    |> Enum.map(&bsl(1, &1))
+    |> Enum.map(&{permissions[&1], (bit_field &&& &1) == &1})
+    |> Map.new()
+  end
+end

--- a/lib/ret/bit_field_utils.ex
+++ b/lib/ret/bit_field_utils.ex
@@ -1,13 +1,15 @@
 defmodule Ret.BitFieldUtils do
   use Bitwise
 
-  def permissions_to_map(nil = bit_field, permissions) do
+  def permissions_to_map(nil = _bit_field, permissions) do
     0 |> permissions_to_map(permissions)
   end
 
   # Convert a permissions bit field integer into a {:permission_name => boolean} map
   def permissions_to_map(bit_field, permissions) do
-    0..31
+    num_permissions = (permissions |> Enum.count()) - 1
+
+    0..num_permissions
     |> Enum.map(&bsl(1, &1))
     |> Enum.map(&{permissions[&1], (bit_field &&& &1) == &1})
     |> Map.new()

--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -89,8 +89,8 @@ defmodule Ret.DiscordClient do
     |> Poison.decode!()
   end
 
-  @none 0
-  @all (1 <<< 32) - 1
+  @none 0x0000_0000
+  @all 0xFFFF_FFFF
   @administrator 1 <<< 3
   @permissions %{
     (1 <<< 0) => :create_instant_invite,

--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -1,5 +1,6 @@
 defmodule Ret.DiscordClient do
   use Bitwise
+  alias Ret.{BitFieldUtils}
 
   @oauth_scope "identify email"
   @discord_api_base "https://discordapp.com/api/v6"
@@ -126,12 +127,8 @@ defmodule Ret.DiscordClient do
     0x8000_0000 => :unused
   }
 
-  # Convert a permissions bit field integer into a {:permission_name => boolean} map
-  defp permissions_to_map(permissions) do
-    0..31
-    |> Enum.map(&bsl(1, &1))
-    |> Enum.map(&{@permissions[&1], (permissions &&& &1) == &1})
-    |> Map.new()
+  defp permissions_to_map(bit_field) do
+    bit_field |> BitFieldUtils.permissions_to_map(@permissions)
   end
 
   # compute_base_permissions and compute_overwrites based on pseudo-code at 

--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -89,42 +89,42 @@ defmodule Ret.DiscordClient do
     |> Poison.decode!()
   end
 
-  @none 0x0000_0000
-  @all 0xFFFF_FFFF
-  @administrator 0x0000_0008
+  @none 0
+  @all (1 <<< 32) - 1
+  @administrator 1 <<< 3
   @permissions %{
-    0x0000_0001 => :create_instant_invite,
-    0x0000_0002 => :kick_members,
-    0x0000_0004 => :ban_members,
-    0x0000_0008 => :administrator,
-    0x0000_0010 => :manage_channels,
-    0x0000_0020 => :manage_guild,
-    0x0000_0040 => :add_reactions,
-    0x0000_0080 => :view_audit_log,
-    0x0000_0100 => :priority_speaker,
-    0x0000_0200 => :unused,
-    0x0000_0400 => :view_channel,
-    0x0000_0800 => :send_messages,
-    0x0000_1000 => :send_tts_messages,
-    0x0000_2000 => :manage_messages,
-    0x0000_4000 => :emded_links,
-    0x0000_8000 => :attach_files,
-    0x0001_0000 => :read_message_history,
-    0x0002_0000 => :mention_everyone,
-    0x0004_0000 => :use_external_emojis,
-    0x0008_0000 => :unused,
-    0x0010_0000 => :connect,
-    0x0020_0000 => :speak,
-    0x0040_0000 => :mute_members,
-    0x0080_0000 => :deafen_members,
-    0x0100_0000 => :move_members,
-    0x0200_0000 => :use_vad,
-    0x0400_0000 => :change_nickname,
-    0x0800_0000 => :manage_nicknames,
-    0x1000_0000 => :manage_roles,
-    0x2000_0000 => :manage_webhooks,
-    0x4000_0000 => :manage_emojis,
-    0x8000_0000 => :unused
+    (1 <<< 0) => :create_instant_invite,
+    (1 <<< 1) => :kick_members,
+    (1 <<< 2) => :ban_members,
+    (1 <<< 3) => :administrator,
+    (1 <<< 4) => :manage_channels,
+    (1 <<< 5) => :manage_guild,
+    (1 <<< 6) => :add_reactions,
+    (1 <<< 7) => :view_audit_log,
+    (1 <<< 8) => :priority_speaker,
+    (1 <<< 9) => :unused,
+    (1 <<< 10) => :view_channel,
+    (1 <<< 11) => :send_messages,
+    (1 <<< 12) => :send_tts_messages,
+    (1 <<< 13) => :manage_messages,
+    (1 <<< 14) => :emded_links,
+    (1 <<< 15) => :attach_files,
+    (1 <<< 16) => :read_message_history,
+    (1 <<< 17) => :mention_everyone,
+    (1 <<< 18) => :use_external_emojis,
+    (1 <<< 19) => :unused,
+    (1 <<< 20) => :connect,
+    (1 <<< 21) => :speak,
+    (1 <<< 22) => :mute_members,
+    (1 <<< 23) => :deafen_members,
+    (1 <<< 24) => :move_members,
+    (1 <<< 25) => :use_vad,
+    (1 <<< 26) => :change_nickname,
+    (1 <<< 27) => :manage_nicknames,
+    (1 <<< 28) => :manage_roles,
+    (1 <<< 29) => :manage_webhooks,
+    (1 <<< 30) => :manage_emojis,
+    (1 <<< 31) => :unused
   }
 
   defp permissions_to_map(bit_field) do

--- a/lib/ret/gltf_utils.ex
+++ b/lib/ret/gltf_utils.ex
@@ -44,4 +44,10 @@ defmodule Ret.GLTFUtils do
         end)
     end
   end
+
+  def json_from_glb(glb) do
+    <<_header::binary-12, json_length::unsigned-integer-little-32, _type::binary-4, glb_body::binary>> = glb
+    <<json::binary-size(json_length), _rest::binary>> = glb_body
+    json
+  end
 end

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -308,10 +308,6 @@ defmodule Ret.Hub do
 
   @hub_perms_keys @hub_perms |> Map.values()
 
-  def hub_perms_keys do
-    @hub_perms_keys
-  end
-
   def hub_perms_to_int!(%{} = perms) do
     invalid_perms = perms |> Map.drop(@hub_perms_keys) |> Map.keys()
 

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -290,9 +290,9 @@ defmodule Ret.Hub do
 
   defp add_default_perms_to_changeset(changeset) do
     default_perms = %{
-      create_media: true,
-      create_camera: true,
-      create_drawing: true,
+      spawn_and_move_media: true,
+      spawn_camera: true,
+      spawn_drawing: true,
       pin_objects: true
     }
 

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -431,7 +431,8 @@ defimpl Canada.Can, for: Ret.OAuthProvider do
   end
 
   # Object permissions for OAuthProvider users are based on perms settings
-  def can?(_account, action, hub) when action in [:spawn_and_move_media, :spawn_camera, :spawn_drawing, :pin_objects] do
+  def can?(%Ret.OAuthProvider{} = oauth_provider, action, %Ret.Hub{hub_bindings: hub_bindings} = hub)
+      when action in [:spawn_and_move_media, :spawn_camera, :spawn_drawing, :pin_objects] do
     is_member = hub_bindings |> Enum.any?(&(oauth_provider |> Ret.HubBinding.member_of_channel?(&1)))
     is_member and hub |> Hub.has_perm!(action)
   end

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -87,7 +87,7 @@ defmodule Ret.Hub do
     |> HubSlug.maybe_generate_slug()
   end
 
-  def add_perms_to_changeset(changeset, attrs) do
+  def add_member_permissions_to_changeset(changeset, attrs) do
     member_permissions =
       attrs["member_permissions"] |> Map.new(fn {k, v} -> {String.to_atom(k), v} end) |> member_permissions_to_int
 

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -284,9 +284,7 @@ defmodule Ret.Hub do
     0x0000_0001 => :spawn_and_manipulate_media,
     0x0000_0002 => :spawn_camera,
     0x0000_0004 => :spawn_drawing,
-    0x0000_0008 => :pin_own_object,
-    0x0000_0010 => :pin_any_object,
-    0x0000_0020 => :manipulate_any_object
+    0x0000_0008 => :pin_objects
   }
 
   @hub_perms_keys @hub_perms |> Map.values()

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -432,7 +432,8 @@ defimpl Canada.Can, for: Ret.OAuthProvider do
 
   # Object permissions for OAuthProvider users are based on perms settings
   def can?(_account, action, hub) when action in [:spawn_and_move_media, :spawn_camera, :spawn_drawing, :pin_objects] do
-    hub |> Hub.has_perm!(action)
+    is_member = hub_bindings |> Enum.any?(&(oauth_provider |> Ret.HubBinding.member_of_channel?(&1)))
+    is_member and hub |> Hub.has_perm!(action)
   end
 
   def can?(_, _, _), do: false

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -86,6 +86,13 @@ defmodule Ret.Hub do
     |> HubSlug.maybe_generate_slug()
   end
 
+  def add_perms_to_changeset(changeset, attrs) do
+    permissions_bit_field = attrs["perms"] |> Map.new(fn {k, v} -> {String.to_atom(k), v} end) |> hub_perms_to_int!
+
+    changeset
+    |> put_change(:permissions, permissions_bit_field)
+  end
+
   def changeset_for_new_seen_occupant_count(%Hub{} = hub, occupant_count) do
     new_max_occupant_count = max(hub.max_occupant_count, occupant_count)
 

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -300,10 +300,10 @@ defmodule Ret.Hub do
   end
 
   @hub_perms %{
-    0x0000_0001 => :spawn_and_move_media,
-    0x0000_0002 => :spawn_camera,
-    0x0000_0004 => :spawn_drawing,
-    0x0000_0008 => :pin_objects
+    (1 <<< 0) => :spawn_and_move_media,
+    (1 <<< 1) => :spawn_camera,
+    (1 <<< 2) => :spawn_drawing,
+    (1 <<< 3) => :pin_objects
   }
 
   @hub_perms_keys @hub_perms |> Map.values()

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -14,7 +14,7 @@ defmodule Ret.Hub do
   import Ecto.Query
   import Canada, only: [can?: 2]
 
-  alias Ret.{Account, Hub, Repo, Scene, SceneListing, WebPushSubscription, RoomAssigner}
+  alias Ret.{Account, Hub, Repo, Scene, SceneListing, WebPushSubscription, RoomAssigner, BitFieldUtils}
   alias Ret.Hub.{HubSlug}
 
   @schema_prefix "ret0"
@@ -33,6 +33,7 @@ defmodule Ret.Hub do
     field(:creator_assignment_token, :string)
     field(:embed_token, :string)
     field(:embedded, :boolean)
+    field(:permissions, :integer)
     field(:default_environment_gltf_bundle_url, :string)
     field(:slug, HubSlug.Type)
     field(:max_occupant_count, :integer, default: 0)
@@ -305,6 +306,10 @@ defmodule Ret.Hub do
       nil -> raise ArgumentError, "Invalid permission #{perm}"
       {val, _} -> (hub_perms_bit_field &&& val) > 0
     end
+  end
+
+  def perms_for_hub(%Hub{} = hub) do
+    hub.permissions |> BitFieldUtils.permissions_to_map(@hub_perms)
   end
 
   def perms_for_account(%Ret.Hub{} = hub, account) do

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -404,7 +404,7 @@ defimpl Canada.Can, for: Ret.Account do
   # Unbound hubs - Anyone can join an unbound hub
   def can?(_account, :join_hub, %Ret.Hub{hub_bindings: []}), do: true
 
-  # Unbound hubs - Creators can perform special actions
+  # Unbound hubs - Owners can perform special actions
   def can?(%Ret.Account{account_id: account_id}, action, %Ret.Hub{created_by_account_id: account_id})
       when account_id != nil and action in @special_actions,
       do: true

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -405,12 +405,12 @@ defimpl Canada.Can, for: Ret.Account do
   def can?(_account, :join_hub, %Ret.Hub{hub_bindings: []}), do: true
 
   # Unbound hubs - Owners can perform special actions
-  def can?(%Ret.Account{account_id: account_id}, action, %Ret.Hub{created_by_account_id: account_id})
+  def can?(%Ret.Account{account_id: account_id}, action, %Ret.Hub{created_by_account_id: account_id, hub_bindings: []})
       when account_id != nil and action in @special_actions,
       do: true
 
   # Unbound hubs - Object permissions for regular users are based on member permission settings
-  def can?(_account, action, hub) when action in @object_actions do
+  def can?(_account, action, %Hub{hub_bindings: []} = hub) when action in @object_actions do
     hub |> Hub.has_member_permission(action)
   end
 

--- a/lib/ret/room_object.ex
+++ b/lib/ret/room_object.ex
@@ -58,6 +58,12 @@ defmodule Ret.RoomObject do
     }
   end
 
+  def objects_for_hub(hub) do
+    RoomObject
+    |> where([o], o.hub_id == ^hub.hub_id)
+    |> Repo.all()
+  end
+
   defp changeset(%RoomObject{} = room_object, %Hub{} = hub, %Account{} = account, attrs) do
     room_object
     |> cast(attrs, [:object_id, :gltf_node])

--- a/lib/ret/room_object.ex
+++ b/lib/ret/room_object.ex
@@ -58,7 +58,7 @@ defmodule Ret.RoomObject do
     }
   end
 
-  def objects_for_hub(hub) do
+  def room_objects_for_hub(hub) do
     RoomObject
     |> where([o], o.hub_id == ^hub.hub_id)
     |> Repo.all()

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -87,32 +87,24 @@ defmodule Ret.Scene do
     put_change(changeset, :scene_sid, scene_sid)
   end
 
-  def static_controlled_media_for_scene(nil) do
+  def networked_objects_for_scene(nil) do
     []
   end
 
   def networked_objects_for_scene(%Scene{model_owned_file: model_owned_file}) do
     case Storage.fetch(model_owned_file) do
       {:ok, _meta, stream} ->
-        json =
-          stream
-          |> Enum.join("")
-
-        IO.inspect(["BPDEBUG json", json])
-
-        networked_objects =
-          json
-          |> Poison.decode!()
-          |> Map.get("nodes")
-          |> Enum.filter(fn node ->
-            node["extras"]["gltfExtensions"]["MOZ_hubs_components"]["networked"]["id"] != nil
-          end)
-          |> Enum.map(fn node ->
-            node["extras"]["gltfExtensions"]["MOZ_hubs_components"]
-          end)
-
-        IO.inspect(["BPDEBUG networked_objects", networked_objects])
-        networked_objects
+        stream
+        |> Enum.join("")
+        |> Ret.GLTFUtils.json_from_glb()
+        |> Poison.decode!()
+        |> Map.get("nodes")
+        |> Enum.filter(fn node ->
+          node["extras"]["gltfExtensions"]["MOZ_hubs_components"]["networked"]["id"] != nil
+        end)
+        |> Enum.map(fn node ->
+          node["extras"]["gltfExtensions"]["MOZ_hubs_components"]
+        end)
 
       {:error, _} ->
         []

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -344,8 +344,10 @@ defmodule RetWeb.HubChannel do
 
     case Guardian.Phoenix.Socket.current_resource(socket) do
       %Account{} = account ->
-        RoomObject.perform_unpin(hub, object_id)
-        OwnedFile.set_inactive(file_id, account.account_id)
+        if account |> can?(pin_objects(hub)) do
+          RoomObject.perform_unpin(hub, object_id)
+          OwnedFile.set_inactive(file_id, account.account_id)
+        end
 
       _ ->
         nil
@@ -358,8 +360,10 @@ defmodule RetWeb.HubChannel do
     hub = socket |> hub_for_socket
 
     case Guardian.Phoenix.Socket.current_resource(socket) do
-      %Account{} = _account ->
-        RoomObject.perform_unpin(hub, object_id)
+      %Account{} = account ->
+        if account |> can?(pin_objects(hub)) do
+          RoomObject.perform_unpin(hub, object_id)
+        end
 
       _ ->
         nil

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -140,12 +140,33 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  def handle_in("naf" = event, %{"data" => %{"isFirstSync" => true}} = payload, socket) do
-    data =
-      payload["data"] |> Map.put("creator", socket.assigns.session_id) |> Map.put("owner", socket.assigns.session_id)
+  def handle_in("naf" = event, %{"data" => %{"isFirstSync" => true, "template" => naf_template}} = payload, socket) do
+    account = Guardian.Phoenix.Socket.current_resource(socket)
+    hub = socket |> hub_for_socket
 
-    payload = payload |> Map.put("data", data)
-    broadcast_from!(socket, event, payload)
+    should_broadcast =
+      case naf_template do
+        "#interactable-media" -> account |> can?(spawn_and_move_media(hub))
+        "#static-media" -> account |> can?(spawn_and_move_media(hub))
+        "#static-controlled-media" -> account |> can?(spawn_and_move_media(hub))
+        "#interactable-media" -> account |> can?(spawn_and_move_media(hub))
+        "#interactable-camera" -> account |> can?(spawn_camera(hub))
+        "#interactable-drawing" -> account |> can?(spawn_drawing(hub))
+        "#pen-interactable" -> account |> can?(spawn_drawing(hub))
+        _ -> true
+      end
+
+    if shoud_broadcast do
+      data =
+        payload["data"]
+        |> Map.put("creator", socket.assigns.session_id)
+        |> Map.put("owner", socket.assigns.session_id)
+
+      payload = payload |> Map.put("data", data)
+
+      broadcast_from!(socket, event, payload)
+    end
+
     {:noreply, socket}
   end
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -372,7 +372,7 @@ defmodule RetWeb.HubChannel do
 
     name_changed = hub.name != payload["name"]
 
-    stale_fields = if name_changed, do: ["perms", "name"], else: ["perms"]
+    stale_fields = if name_changed, do: ["member_permissions", "name"], else: ["member_permissions"]
 
     if account |> can?(update_hub(hub)) do
       hub

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -370,13 +370,17 @@ defmodule RetWeb.HubChannel do
     hub = socket |> hub_for_socket
     account = Guardian.Phoenix.Socket.current_resource(socket)
 
+    name_changed = hub.name != payload["name"]
+
+    stale_fields = if name_changed, do: ["perms", "name"], else: ["perms"]
+
     if account |> can?(update_hub(hub)) do
       hub
       |> Hub.add_name_to_changeset(payload)
       |> Hub.add_perms_to_changeset(payload)
       |> Repo.update!()
       |> Repo.preload(@hub_preloads)
-      |> broadcast_hub_refresh!(socket, ["name"])
+      |> broadcast_hub_refresh!(socket, stale_fields)
     end
 
     {:noreply, socket}

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -184,7 +184,9 @@ defmodule RetWeb.HubChannel do
         # If we have a secure_template for this object, it's a pinned or scene object for which we want to
         # allow ownership transfer and syncing.
         secure_template |> String.ends_with?("-media") ->
-          data |> sanitize_with_authorized_schemas(secure_template, socket)
+          if account |> can?(spawn_and_move_media(hub)),
+            do: data,
+            else: data |> sanitize_with_authorized_schemas(secure_template, socket)
 
         template |> String.ends_with?("-media") ->
           if account |> can?(spawn_and_move_media(hub)), do: data, else: nil

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -269,15 +269,23 @@ defmodule RetWeb.HubChannel do
         socket
       ) do
     with_account(socket, fn account ->
-      perform_pin!(object_id, gltf_node, account, socket)
-      Storage.promote(file_id, file_access_token, promotion_token, account)
-      OwnedFile.set_active(file_id, account.account_id)
+      hub = socket |> hub_for_socket
+
+      if account |> can?(pin_objects(hub)) do
+        perform_pin!(object_id, gltf_node, account, socket)
+        Storage.promote(file_id, file_access_token, promotion_token, account)
+        OwnedFile.set_active(file_id, account.account_id)
+      end
     end)
   end
 
   def handle_in("pin", %{"id" => object_id, "gltf_node" => gltf_node}, socket) do
     with_account(socket, fn account ->
-      perform_pin!(object_id, gltf_node, account, socket)
+      hub = socket |> hub_for_socket
+
+      if account |> can?(pin_objects(hub)) do
+        perform_pin!(object_id, gltf_node, account, socket)
+      end
     end)
   end
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -157,11 +157,12 @@ defmodule RetWeb.HubChannel do
 
     should_broadcast =
       cond do
+        naf_template |> String.ends_with?("-avatar") -> true
         naf_template |> String.ends_with?("-media") -> account |> can?(spawn_and_move_media(hub))
         naf_template |> String.ends_with?("-camera") -> account |> can?(spawn_camera(hub))
         naf_template |> String.ends_with?("-drawing") -> account |> can?(spawn_drawing(hub))
         naf_template |> String.ends_with?("-pen") -> account |> can?(spawn_drawing(hub))
-        true -> true
+        true -> false
       end
 
     if should_broadcast do
@@ -490,10 +491,11 @@ defmodule RetWeb.HubChannel do
     is_creator = socket.assigns.created_objects |> Enum.member?(network_id)
 
     cond do
+      naf_template |> String.ends_with?("-avatar") -> true
       naf_template |> String.ends_with?("-media") -> is_creator or account |> can?(spawn_and_move_media(hub))
       naf_template |> String.ends_with?("-camera") -> account |> can?(spawn_camera(hub))
       naf_template |> String.ends_with?("-pen") -> account |> can?(spawn_drawing(hub))
-      true -> true
+      true -> false
     end
   end
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -31,6 +31,7 @@ defmodule RetWeb.HubChannel do
     hub_bindings: [],
     created_by_account: []
   ]
+  @drawing_confirm_connect 0
 
   def join("hub:" <> hub_sid, %{"profile" => profile, "context" => context} = params, socket) do
     hub =
@@ -273,7 +274,7 @@ defmodule RetWeb.HubChannel do
     if secure_scene_object != nil do
       is_creator = secure_scene_object.creator == socket.assigns.session_id
 
-      if is_creator or account |> can?(spawn_drawing(hub)) do
+      if payload["data"]["type"] == @drawing_confirm_connect or is_creator or account |> can?(spawn_drawing(hub)) do
         broadcast_from!(socket, event, payload)
       end
     end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -388,7 +388,7 @@ defmodule RetWeb.HubChannel do
     if account |> can?(update_hub(hub)) do
       hub
       |> Hub.add_name_to_changeset(payload)
-      |> Hub.add_perms_to_changeset(payload)
+      |> Hub.add_member_permissions_to_changeset(payload)
       |> Repo.update!()
       |> Repo.preload(@hub_preloads)
       |> broadcast_hub_refresh!(socket, stale_fields)

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -149,14 +149,13 @@ defmodule RetWeb.HubChannel do
         "#interactable-media" -> account |> can?(spawn_and_move_media(hub))
         "#static-media" -> account |> can?(spawn_and_move_media(hub))
         "#static-controlled-media" -> account |> can?(spawn_and_move_media(hub))
-        "#interactable-media" -> account |> can?(spawn_and_move_media(hub))
         "#interactable-camera" -> account |> can?(spawn_camera(hub))
         "#interactable-drawing" -> account |> can?(spawn_drawing(hub))
         "#pen-interactable" -> account |> can?(spawn_drawing(hub))
         _ -> true
       end
 
-    if shoud_broadcast do
+    if should_broadcast do
       data =
         payload["data"]
         |> Map.put("creator", socket.assigns.session_id)

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -236,7 +236,7 @@ defmodule RetWeb.HubChannel do
 
     created_object = socket.assigns.created_objects |> Enum.find(&(&1.network_id == drawing_network_id))
 
-    # if created_objects is nil,  we've received a message for a drawing that has not received a first sync yet,
+    # If created_object is nil, we've received a message for a drawing that has not received a first sync yet,
     # or was denied creation. so just ignore it.
     if created_object != nil do
       is_creator = created_object.creator == socket.assigns.session_id

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -207,12 +207,10 @@ defmodule RetWeb.HubChannel do
   end
 
   # Captures inbound NAF removal messages
-  def handle_in("naf" = event, %{"dataType" => "r", "data" => %{"networkId" => network_id}} = payload, socket) do
+  def handle_in("naf" = event, %{"dataType" => "r"} = payload, socket) do
     account = Guardian.Phoenix.Socket.current_resource(socket)
-    hub = socket |> hub_for_socket
-    is_creator = socket.assigns.created_objects |> Enum.member?(network_id)
 
-    if account |> can?(spawn_and_move_media(hub)) or is_creator do
+    if payload["data"] |> should_broadcast(socket) do
       broadcast_from!(socket, event, payload)
     end
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -157,12 +157,24 @@ defmodule RetWeb.HubChannel do
 
     should_broadcast =
       cond do
-        template |> String.ends_with?("-avatar") -> true
-        template |> String.ends_with?("-media") -> account |> can?(spawn_and_move_media(hub))
-        template |> String.ends_with?("-camera") -> account |> can?(spawn_camera(hub))
-        template |> String.ends_with?("-drawing") -> account |> can?(spawn_drawing(hub))
-        template |> String.ends_with?("-pen") -> account |> can?(spawn_drawing(hub))
-        true -> false
+        template |> String.ends_with?("-avatar") ->
+          true
+
+        template |> String.ends_with?("-media") ->
+          account |> can?(spawn_and_move_media(hub))
+
+        template |> String.ends_with?("-camera") ->
+          account |> can?(spawn_camera(hub))
+
+        template |> String.ends_with?("-drawing") ->
+          account |> can?(spawn_drawing(hub))
+
+        template |> String.ends_with?("-pen") ->
+          account |> can?(spawn_drawing(hub))
+
+        true ->
+          # We want to forbid messages if they fall through the above list of template suffixes
+          false
       end
 
     if should_broadcast do
@@ -539,11 +551,24 @@ defmodule RetWeb.HubChannel do
       template = created_object.template
 
       cond do
-        template |> String.ends_with?("-avatar") -> true
-        template |> String.ends_with?("-media") -> is_creator or account |> can?(spawn_and_move_media(hub))
-        template |> String.ends_with?("-camera") -> is_creator or account |> can?(spawn_camera(hub))
-        template |> String.ends_with?("-pen") -> is_creator or account |> can?(spawn_drawing(hub))
-        true -> false
+        template |> String.ends_with?("-avatar") ->
+          true
+
+        template |> String.ends_with?("-media") ->
+          is_pinned = Repo.get_by(RoomObject, object_id: network_id) != nil
+
+          (!is_pinned or account |> can?(pin_objects(hub))) and
+            (is_creator or account |> can?(spawn_and_move_media(hub)))
+
+        template |> String.ends_with?("-camera") ->
+          is_creator or account |> can?(spawn_camera(hub))
+
+        template |> String.ends_with?("-pen") ->
+          is_creator or account |> can?(spawn_drawing(hub))
+
+        true ->
+          # We want to forbid messages if they fall through the above list of template suffixes
+          false
       end
     end
   end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -302,6 +302,7 @@ defmodule RetWeb.HubChannel do
     if account |> can?(update_hub(hub)) do
       hub
       |> Hub.add_name_to_changeset(payload)
+      |> Hub.add_perms_to_changeset(payload)
       |> Repo.update!()
       |> Repo.preload(@hub_preloads)
       |> broadcast_hub_refresh!(socket, ["name"])

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -243,8 +243,13 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  def handle_in("message" = event, payload, socket) do
-    broadcast!(socket, event, payload |> Map.put(:session_id, socket.assigns.session_id))
+  def handle_in("message" = event, %{"type" => type} = payload, socket) do
+    account = Guardian.Phoenix.Socket.current_resource(socket)
+    hub = socket |> hub_for_socket
+
+    if type != "photo" or account |> can?(spawn_camera(hub)) do
+      broadcast!(socket, event, payload |> Map.put(:session_id, socket.assigns.session_id))
+    end
 
     {:noreply, socket}
   end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -141,6 +141,7 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
+  # Captures all inbound NAF messages that result in spawned objects.
   def handle_in(
         "naf" = event,
         %{"data" => %{"isFirstSync" => true, "template" => naf_template, "networkId" => network_id}} = payload,
@@ -178,6 +179,7 @@ defmodule RetWeb.HubChannel do
     end
   end
 
+  # Captures inbound NAF update messages
   def handle_in("naf" = event, %{"dataType" => "u"} = payload, socket) do
     if payload["data"] |> should_broadcast(socket) do
       broadcast_from!(socket, event, payload)
@@ -186,6 +188,7 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
+  # Captures inbound NAF multi update messages
   def handle_in("naf" = event, %{"dataType" => "um"} = payload, socket) do
     %{"data" => %{"d" => updates}} = payload
 
@@ -199,6 +202,7 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
+  # Captures inbound NAF removal messages
   def handle_in("naf" = event, %{"dataType" => "r", "data" => %{"networkId" => network_id}} = payload, socket) do
     account = Guardian.Phoenix.Socket.current_resource(socket)
     hub = socket |> hub_for_socket
@@ -211,7 +215,7 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  # Fallthrough for all other dataTypes.
+  # Fallthrough for all other dataTypes
   def handle_in("naf" = event, payload, socket) do
     broadcast_from!(socket, event, payload)
     {:noreply, socket}

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -151,14 +151,12 @@ defmodule RetWeb.HubChannel do
     hub = socket |> hub_for_socket
 
     should_broadcast =
-      case naf_template do
-        "#interactable-media" -> account |> can?(spawn_and_move_media(hub))
-        "#static-media" -> account |> can?(spawn_and_move_media(hub))
-        "#static-controlled-media" -> account |> can?(spawn_and_move_media(hub))
-        "#interactable-camera" -> account |> can?(spawn_camera(hub))
-        "#interactable-drawing" -> account |> can?(spawn_drawing(hub))
-        "#pen-interactable" -> account |> can?(spawn_drawing(hub))
-        _ -> true
+      cond do
+        naf_template |> String.ends_with?("-media") -> account |> can?(spawn_and_move_media(hub))
+        naf_template |> String.ends_with?("-camera") -> account |> can?(spawn_camera(hub))
+        naf_template |> String.ends_with?("-drawing") -> account |> can?(spawn_drawing(hub))
+        naf_template |> String.ends_with?("-pen") -> account |> can?(spawn_drawing(hub))
+        true -> true
       end
 
     if should_broadcast do
@@ -482,11 +480,11 @@ defmodule RetWeb.HubChannel do
     hub = socket |> hub_for_socket
     is_creator = socket.assigns.created_objects |> Enum.member?(network_id)
 
-    case naf_template do
-      "#interactable-media" -> is_creator or account |> can?(spawn_and_move_media(hub))
-      "#interactable-camera" -> account |> can?(spawn_camera(hub))
-      "#pen-interactable" -> account |> can?(spawn_drawing(hub))
-      _ -> true
+    cond do
+      naf_template |> String.ends_with?("-media") -> is_creator or account |> can?(spawn_and_move_media(hub))
+      naf_template |> String.ends_with?("-camera") -> account |> can?(spawn_camera(hub))
+      naf_template |> String.ends_with?("-pen") -> account |> can?(spawn_drawing(hub))
+      true -> true
     end
   end
 

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -42,7 +42,7 @@ defmodule RetWeb.Api.V1.HubView do
             else
               nil
             end,
-          perms: hub |> Hub.perms_for_hub()
+          member_permissions: hub |> Hub.member_permissions_for_hub()
         }
       ]
     }

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -41,7 +41,8 @@ defmodule RetWeb.Api.V1.HubView do
               hub.embed_token
             else
               nil
-            end
+            end,
+          perms: hub |> Hub.perms_for_hub()
         }
       ]
     }

--- a/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
+++ b/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
@@ -1,9 +1,10 @@
 defmodule Ret.Repo.Migrations.AddPermissionsToHubs do
+  use Bitwise
   use Ecto.Migration
 
   def change do
     alter table("hubs") do
-      add(:permissions, :integer)
+      add(:member_permissions, :integer, default: (1 <<< 4) - 1)
     end
   end
 end

--- a/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
+++ b/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
@@ -4,7 +4,16 @@ defmodule Ret.Repo.Migrations.AddPermissionsToHubs do
 
   def change do
     alter table("hubs") do
-      add(:member_permissions, :integer, default: (1 <<< 4) - 1)
+      add(:member_permissions, :integer,
+        default:
+          %{
+            spawn_and_move_media: true,
+            spawn_camera: true,
+            spawn_drawing: true,
+            pin_objects: true
+          }
+          |> Ret.Hub.member_permissions_to_int()
+      )
     end
   end
 end

--- a/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
+++ b/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddPermissionsToHubs do
+  use Ecto.Migration
+
+  def change do
+    alter table("hubs") do
+      add(:permissions, :integer)
+    end
+  end
+end

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -139,4 +139,25 @@ defmodule Ret.HubTest do
 
     assert hub.creator_assignment_token == nil
   end
+
+  test "hub permissions map can be converted to bit field integer" do
+    hub_perms = %{spawn_and_manipulate_media: true}
+    bit_field = hub_perms |> Hub.hub_perms_to_int!()
+    assert bit_field == 1
+  end
+
+  test "invalid hub permissions map cannot be converted to bit field integer" do
+    hub_perms = %{fake_permission: false}
+    assert_raise ArgumentError, fn -> hub_perms |> Hub.hub_perms_to_int!() end
+  end
+
+  test "hub permissions bit field integer can be queried for a permission" do
+    bit_field = 1
+    assert Hub.hub_has_perm!(bit_field, :spawn_and_manipulate_media)
+  end
+
+  test "hub permissions bit field integer cannot be queried with an invalid permission" do
+    bit_field = 1
+    assert_raise ArgumentError, fn -> Hub.hub_has_perm!(bit_field, :fake_permission) end
+  end
 end

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -141,7 +141,7 @@ defmodule Ret.HubTest do
   end
 
   test "hub permissions map can be converted to bit field integer" do
-    hub_perms = %{spawn_and_manipulate_media: true}
+    hub_perms = %{spawn_media: true}
     bit_field = hub_perms |> Hub.hub_perms_to_int!()
     assert bit_field == 1
   end
@@ -153,7 +153,7 @@ defmodule Ret.HubTest do
 
   test "hub permissions bit field integer can be queried for a permission" do
     bit_field = 1
-    assert Hub.hub_has_perm!(bit_field, :spawn_and_manipulate_media)
+    assert Hub.hub_has_perm!(bit_field, :spawn_media)
   end
 
   test "hub permissions bit field integer cannot be queried with an invalid permission" do

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -141,7 +141,7 @@ defmodule Ret.HubTest do
   end
 
   test "hub permissions map can be converted to bit field integer" do
-    hub_perms = %{spawn_media: true}
+    hub_perms = %{spawn_and_move_media: true}
     bit_field = hub_perms |> Hub.hub_perms_to_int!()
     assert bit_field == 1
   end
@@ -153,11 +153,11 @@ defmodule Ret.HubTest do
 
   test "hub permissions bit field integer can be queried for a permission" do
     bit_field = 1
-    assert Hub.hub_has_perm!(bit_field, :spawn_media)
+    assert Hub.has_perm!(%Hub{permissions: bit_field}, :spawn_and_move_media)
   end
 
   test "hub permissions bit field integer cannot be queried with an invalid permission" do
     bit_field = 1
-    assert_raise ArgumentError, fn -> Hub.hub_has_perm!(bit_field, :fake_permission) end
+    assert_raise ArgumentError, fn -> Hub.has_perm!(%Hub{permissions: bit_field}, :fake_permission) end
   end
 end

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -141,23 +141,26 @@ defmodule Ret.HubTest do
   end
 
   test "hub permissions map can be converted to bit field integer" do
-    hub_perms = %{spawn_and_move_media: true}
-    bit_field = hub_perms |> Hub.hub_perms_to_int!()
+    member_permissions = %{spawn_and_move_media: true}
+    bit_field = member_permissions |> Hub.member_permissions_to_int()
     assert bit_field == 1
   end
 
   test "invalid hub permissions map cannot be converted to bit field integer" do
-    hub_perms = %{fake_permission: false}
-    assert_raise ArgumentError, fn -> hub_perms |> Hub.hub_perms_to_int!() end
+    member_permissions = %{fake_permission: false}
+    assert_raise ArgumentError, fn -> member_permissions |> Hub.member_permissions_to_int() end
   end
 
   test "hub permissions bit field integer can be queried for a permission" do
     bit_field = 1
-    assert Hub.has_perm!(%Hub{permissions: bit_field}, :spawn_and_move_media)
+    assert Hub.has_member_permission(%Hub{member_permissions: bit_field}, :spawn_and_move_media)
   end
 
   test "hub permissions bit field integer cannot be queried with an invalid permission" do
     bit_field = 1
-    assert_raise ArgumentError, fn -> Hub.has_perm!(%Hub{permissions: bit_field}, :fake_permission) end
+
+    assert_raise ArgumentError, fn ->
+      Hub.has_member_permission(%Hub{member_permissions: bit_field}, :fake_permission)
+    end
   end
 end


### PR DESCRIPTION
Adds mechanisms for object-level permissions controls on Hubs
- Adds a `permissions` integer bit field to the Hubs table
- Defines `spawn_and_move_media`, `spawn_camera`, `spawn_drawing`, and `pin_objects` permissions
- Hubs have all these permissions allowed by default
- Hubs API now accepts and returns a `perms` map in JSON
- Adds Canada capability checks for these new permissions
- Ignores associated `"naf"` and `"pin"` hub channel messages if permissions are disabled