### PR TITLE
Fix for PWA signin v2

### DIFF
--- a/lib/ret/login_token.ex
+++ b/lib/ret/login_token.ex
@@ -11,6 +11,7 @@ defmodule Ret.LoginToken do
 
   schema "login_tokens" do
     field(:token, :string)
+    field(:payload_key, :string)
     field(:identifier_hash, :string)
 
     timestamps()
@@ -23,18 +24,18 @@ defmodule Ret.LoginToken do
     login_token
     |> cast(%{}, [])
     |> put_change(:token, token)
+    |> put_change(:payload_key, SecureRandom.hex())
     |> put_change(:identifier_hash, email |> Account.identifier_hash_for_email())
     |> validate_required([:token, :identifier_hash])
   end
 
-  def new_token_for_email(email) do
+  def new_login_token_for_email(email) do
     %Ret.LoginToken{}
     |> changeset_for_email(email)
     |> Repo.insert!()
-    |> Map.get(:token)
   end
 
-  def identifier_hash_for_token(token) do
+  def lookup_by_token(token) do
     login_token =
       Ret.LoginToken
       |> where([t], t.token == ^token)
@@ -45,7 +46,7 @@ defmodule Ret.LoginToken do
       |> Repo.one()
 
     if login_token do
-      login_token.identifier_hash
+      login_token
     else
       nil
     end

--- a/lib/ret_web/channels/auth_channel.ex
+++ b/lib/ret_web/channels/auth_channel.ex
@@ -3,7 +3,7 @@ defmodule RetWeb.AuthChannel do
 
   use RetWeb, :channel
 
-  alias Ret.{Statix, LoginToken, Account}
+  alias Ret.{Statix, LoginToken, Account, Crypto}
 
   intercept(["auth_credentials"])
 
@@ -20,12 +20,14 @@ defmodule RetWeb.AuthChannel do
 
   def handle_in("auth_request", %{"email" => email, "origin" => origin}, socket) do
     if !Map.get(socket.assigns, :used) do
-      socket = socket |> assign(:used, true) |> assign(:email, email)
+      socket = socket |> assign(:used, true)
 
       # Create token + send email
-      token = LoginToken.new_token_for_email(email)
-      signin_args = %{auth_topic: socket.topic, auth_token: token, auth_origin: origin}
+      %LoginToken{token: token, payload_key: payload_key} = LoginToken.new_login_token_for_email(email)
 
+      encrypted_payload = %{"email" => email} |> Poison.encode!() |> Crypto.encrypt(payload_key) |> :base64.encode()
+
+      signin_args = %{auth_topic: socket.topic, auth_token: token, auth_origin: origin, auth_payload: encrypted_payload}
       Statix.increment("ret.emails.auth.attempted", 1)
 
       RetWeb.Email.auth_email(email, signin_args) |> Ret.Mailer.deliver_now()
@@ -38,15 +40,16 @@ defmodule RetWeb.AuthChannel do
     end
   end
 
-  def handle_in("auth_verified", %{"token" => token}, socket) do
+  def handle_in("auth_verified", %{"token" => token, "payload" => auth_payload}, socket) do
     Process.send_after(self(), :close_channel, 1000 * 5)
 
     # Slow down token guessing
     :timer.sleep(500)
 
-    token
-    |> LoginToken.identifier_hash_for_token()
-    |> broadcast_credentials_for_identifier_hash(socket)
+    %LoginToken{identifier_hash: identifier_hash, payload_key: payload_key} = LoginToken.lookup_by_token(token)
+    decrypted_payload = auth_payload |> :base64.decode() |> Ret.Crypto.decrypt(payload_key) |> Poison.decode!()
+
+    broadcast_credentials_and_payload(identifier_hash, decrypted_payload, socket)
 
     LoginToken.expire(token)
 
@@ -65,19 +68,13 @@ defmodule RetWeb.AuthChannel do
   def handle_out("auth_credentials" = event, payload, socket) do
     Process.send_after(self(), :close_channel, 1000 * 5)
     push(socket, event, payload)
-
-    # Send the email address over for all connected processes to use as well
-    if socket.assigns |> Map.has_key?(:email) do
-      broadcast!(socket, "auth_email", %{email: socket.assigns.email})
-    end
-
     {:noreply, socket}
   end
 
-  defp broadcast_credentials_for_identifier_hash(nil, _socket), do: nil
+  defp broadcast_credentials_and_payload(nil, _payload, _socket), do: nil
 
-  defp broadcast_credentials_for_identifier_hash(hash, socket) do
-    credentials = hash |> Account.credentials_for_identifier_hash()
-    broadcast!(socket, "auth_credentials", %{credentials: credentials})
+  defp broadcast_credentials_and_payload(identifier_hash, payload, socket) do
+    credentials = identifier_hash |> Account.credentials_for_identifier_hash()
+    broadcast!(socket, "auth_credentials", %{credentials: credentials, payload: payload})
   end
 end

--- a/priv/repo/migrations/20190703224946_add_login_token_payload_keys.exs
+++ b/priv/repo/migrations/20190703224946_add_login_token_payload_keys.exs
@@ -1,0 +1,9 @@
+defmodule Ret.Repo.Migrations.AddEmbedTokenToHubs do
+  use Ecto.Migration
+
+  def change do
+    alter table("login_tokens") do
+      add(:payload_key, :string)
+    end
+  end
+end

--- a/test/ret/login_token_test.exs
+++ b/test/ret/login_token_test.exs
@@ -9,13 +9,13 @@ defmodule Ret.LoginTokenTest do
   end
 
   test "should generate a valid token" do
-    token = LoginToken.new_token_for_email("test@mozilla.com")
-    assert LoginToken.identifier_hash_for_token(token) == Ret.Crypto.hash("test@mozilla.com")
+    %LoginToken{token: token} = LoginToken.new_login_token_for_email("test@mozilla.com")
+    assert LoginToken.lookup_by_token(token).identifier_hash == Ret.Crypto.hash("test@mozilla.com")
   end
 
   test "should allow expiring a token" do
-    token = LoginToken.new_token_for_email("test@mozilla.com")
+    %LoginToken{token: token} = LoginToken.new_login_token_for_email("test@mozilla.com")
     LoginToken.expire(token)
-    assert LoginToken.identifier_hash_for_token(token) == nil
+    assert LoginToken.lookup_by_token(token) == nil
   end
 end


### PR DESCRIPTION
Goes with https://github.com/mozilla/hubs/pull/1496

This rolls back the change in https://github.com/mozilla/reticulum/pull/194 because it failed to address signing in from PWAs. The reason is because when using a PWA, the opposite auth channel connection is closed before it could respond with the email address.

This new approach stores a secret symmetric key with the login token, and encrypts the email with the key and puts it into one of the query string variables of the sign in link. This encrypted payload is then handed to the auth channel on the verification side and the secret symmetric key is used to decrypt and broadcast the email address to all on the channel.

This seemed like a better approach than putting the email address in the query string directly (obviously) or putting a secret, encrypted version in our database since theoretically then we'd be storing PII since it'd be easily reversible if you cracked the db and also managed to get our secret key. In this scenario, an attacker would need both the original email sent, as well as the secret key stored in our db.
