### PR TITLE
Remove farspark, update CSP

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -133,7 +133,7 @@ config :ret, Ret.Storage,
 asset_hosts =
   "https://localhost:4000 https://localhost:8080 " <>
     "https://#{host}:4000 https://#{host}:8080 https://#{host}:3000 https://#{host}:9090 " <>
-    "https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
+    "https://assets-prod.reticulum.io https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
     "https://farspark-prod.reticulum.io https://farspark-dev.reticulum.io " <> "https://hubs-proxy.com"
 
 websocket_hosts =

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -142,17 +142,21 @@ websocket_hosts =
     "wss://#{dev_janus_host} wss://prod-janus.reticulum.io wss://#{host}:4000 wss://#{host}:8080 https://#{host}:8080 https://hubs.local:8080 wss://hubs.local:8080"
 
 script_shas =
-  "'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' 'sha256-s+5D1eE8ArfQ+/5P96XNP7FkXqei4/oQ5TlHdlpuFdw='"
+  "'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' 'sha256-aF47D2e8rRobVmW15rgetYffvYocKsA9QbosafkX2/E='"
+
+worker_script_shas = "'sha256-aF47D2e8rRobVmW15rgetYffvYocKsA9QbosafkX2/E='"
 
 config :ret, RetWeb.AddCSPPlug,
   content_security_policy:
-    "default-src 'none'; script-src 'self' #{script_shas} #{asset_hosts} https://cdn.rawgit.com https://aframe.io https://www.google-analytics.com 'unsafe-eval'; worker-src 'self' blob:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.aframe.io #{
+    "default-src 'none'; script-src 'self' #{script_shas} #{asset_hosts} https://cdn.rawgit.com https://aframe.io https://www.google-analytics.com 'unsafe-eval'; worker-src 'self' #{
+      worker_script_shas
+    } blob:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.aframe.io #{asset_hosts}; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net #{
       asset_hosts
-    }; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net #{asset_hosts} 'unsafe-inline'; connect-src 'self' https://#{
-      host
-    }:8080 https://sentry.prod.mozaws.net https://dpdb.webvr.rocks #{asset_hosts} #{websocket_hosts} https://cdn.aframe.io https://www.mozilla.org data: blob:; img-src 'self' #{
+    } 'unsafe-inline'; connect-src 'self' https://#{host}:8080 https://sentry.prod.mozaws.net https://dpdb.webvr.rocks #{
       asset_hosts
-    } https://cdn.aframe.io https://cdn.jsdelivr.net data: blob:; media-src 'self' #{asset_hosts} data: blob:; frame-src 'self'; base-uri 'none'; form-action 'self';"
+    } #{websocket_hosts} https://cdn.aframe.io https://www.mozilla.org data: blob:; img-src 'self' #{asset_hosts} https://cdn.aframe.io https://cdn.jsdelivr.net data: blob:; media-src 'self' #{
+      asset_hosts
+    } data: blob:; frame-src 'self'; base-uri 'none'; form-action 'self';"
 
 config :ret, Ret.Mailer, adapter: Bamboo.LocalAdapter
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -133,7 +133,7 @@ config :ret, Ret.Storage,
 asset_hosts =
   "https://localhost:4000 https://localhost:8080 " <>
     "https://#{host}:4000 https://#{host}:8080 https://#{host}:3000 https://#{host}:9090 " <>
-    "https://assets-prod.reticulum.io https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
+    "https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
     "https://farspark-prod.reticulum.io https://farspark-dev.reticulum.io " <> "https://hubs-proxy.com"
 
 websocket_hosts =

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -142,7 +142,7 @@ websocket_hosts =
     "wss://#{dev_janus_host} wss://prod-janus.reticulum.io wss://#{host}:4000 wss://#{host}:8080 https://#{host}:8080 https://hubs.local:8080 wss://hubs.local:8080"
 
 script_shas =
-  "'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8='"
+  "'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' 'sha256-s+5D1eE8ArfQ+/5P96XNP7FkXqei4/oQ5TlHdlpuFdw='"
 
 config :ret, RetWeb.AddCSPPlug,
   content_security_policy:

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -92,12 +92,6 @@ config :ret, Ret.DiscordClient,
   client_secret: "",
   bot_token: ""
 
-config :ret, Ret.TwitterClient,
-  consumer_key: "yuFg5hG2SSSwKjiK7HWXQ",
-  consumer_secret: "WWM3FOqdViz29ajRfjuSBqYQTQku6gVW7xIY9fug",
-  access_token: "21245713-qNN1bbRQ25HtGNWw1TCahWmC1ZMKet0aA0b25P0W7",
-  access_token_secret: "0t8GWF35LhfVucXLlzhSwry4k2my5udmqUbGvWm6JFz3B"
-
 # Allow any origin for API access in dev
 config :cors_plug, origin: ["*"]
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -133,7 +133,7 @@ config :ret, Ret.Storage,
 asset_hosts =
   "https://localhost:4000 https://localhost:8080 " <>
     "https://#{host}:4000 https://#{host}:8080 https://#{host}:3000 https://#{host}:9090 " <>
-    "https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
+    "https://assets-prod.reticulum.io https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io " <>
     "https://farspark-prod.reticulum.io https://farspark-dev.reticulum.io " <> "https://hubs-proxy.com"
 
 websocket_hosts =
@@ -142,21 +142,19 @@ websocket_hosts =
     "wss://#{dev_janus_host} wss://prod-janus.reticulum.io wss://#{host}:4000 wss://#{host}:8080 https://#{host}:8080 https://hubs.local:8080 wss://hubs.local:8080"
 
 script_shas =
-  "'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' 'sha256-aF47D2e8rRobVmW15rgetYffvYocKsA9QbosafkX2/E='"
-
-worker_script_shas = "'sha256-aF47D2e8rRobVmW15rgetYffvYocKsA9QbosafkX2/E='"
+  "'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8='"
 
 config :ret, RetWeb.AddCSPPlug,
   content_security_policy:
-    "default-src 'none'; script-src 'self' #{script_shas} #{asset_hosts} https://cdn.rawgit.com https://aframe.io https://www.google-analytics.com 'unsafe-eval'; worker-src 'self' #{
-      worker_script_shas
-    } blob:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.aframe.io #{asset_hosts}; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net #{
+    "default-src 'none'; script-src 'self' #{script_shas} #{asset_hosts} https://cdn.rawgit.com https://aframe.io https://www.google-analytics.com 'unsafe-eval'; worker-src 'self' blob:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.aframe.io #{
       asset_hosts
-    } 'unsafe-inline'; connect-src 'self' https://#{host}:8080 https://sentry.prod.mozaws.net https://dpdb.webvr.rocks #{
+    }; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net #{asset_hosts} 'unsafe-inline'; connect-src 'self' https://#{
+      host
+    }:8080 https://sentry.prod.mozaws.net https://dpdb.webvr.rocks #{asset_hosts} #{websocket_hosts} https://cdn.aframe.io https://www.mozilla.org data: blob:; img-src 'self' #{
       asset_hosts
-    } #{websocket_hosts} https://cdn.aframe.io https://www.mozilla.org data: blob:; img-src 'self' #{asset_hosts} https://cdn.aframe.io https://cdn.jsdelivr.net data: blob:; media-src 'self' #{
+    } https://cdn.aframe.io https://cdn.jsdelivr.net data: blob:; media-src 'self' #{asset_hosts} data: blob:; frame-src 'self'; base-uri 'none'; form-action 'self'; manifest-src 'self' #{
       asset_hosts
-    } data: blob:; frame-src 'self'; base-uri 'none'; form-action 'self';"
+    };"
 
 config :ret, Ret.Mailer, adapter: Bamboo.LocalAdapter
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -92,16 +92,17 @@ config :ret, Ret.DiscordClient,
   client_secret: "",
   bot_token: ""
 
+config :ret, Ret.TwitterClient,
+  consumer_key: "yuFg5hG2SSSwKjiK7HWXQ",
+  consumer_secret: "WWM3FOqdViz29ajRfjuSBqYQTQku6gVW7xIY9fug",
+  access_token: "21245713-qNN1bbRQ25HtGNWw1TCahWmC1ZMKet0aA0b25P0W7",
+  access_token_secret: "0t8GWF35LhfVucXLlzhSwry4k2my5udmqUbGvWm6JFz3B"
+
 # Allow any origin for API access in dev
 config :cors_plug, origin: ["*"]
 
 config :ret,
   upload_encryption_key: "a8dedeb57adafa7821027d546f016efef5a501bd",
-  farspark_signature_key:
-    "248cf801c4f5d6fd70c1b0dfea8dedeb57adafa7821027d546f016efef5a501bd8168c8479d33b466199d0ac68c71bb71b68c27537102a63cd70776aa83bca76",
-  farspark_signature_salt:
-    "da914bb89e332b2a815a667875584d067b698fe1f6f5c61d98384dc74d2ed85b67eea0a51325afb9d9c7d798f4bbbd630102a261e152aceb13d9469b02da6b31",
-  farspark_host: "https://farspark-dev.reticulum.io",
   bot_access_key: ""
 
 config :ret, Ret.PageOriginWarmer,

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -65,9 +65,6 @@ perms_key = "{{ cfg.guardian.perms_key }}"
 oauth_token_key = "{{ cfg.guardian.oauth_token_key }}"
 
 [ret]
-farspark_signature_key = "{{ cfg.farspark.signature_key }}"
-farspark_signature_salt = "{{ cfg.farspark.signature_salt }}"
-farspark_host = "{{ cfg.farspark.host }}"
 bot_access_key = "{{ cfg.ret.bot_access_key }}"
 
 [ret."Elixir.Ret.MediaResolver"]

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -98,25 +98,6 @@ defmodule RetWeb.Api.V1.MediaController do
   end
 
   defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}, index) do
-    raw = gen_farspark_url(uri, index)
-
-    conn
-    |> render("show.json", origin: uri |> URI.to_string(), raw: raw, meta: meta)
-  end
-
-  defp gen_farspark_url(uri, index) do
-    path = "/raw/0/0/0/#{index}/#{uri |> URI.to_string() |> Base.url_encode64(padding: false)}"
-
-    host = Application.get_env(:ret, :farspark_host)
-    "#{host}/#{gen_signature(path)}#{path}"
-  end
-
-  defp gen_signature(path) do
-    key = Application.get_env(:ret, :farspark_signature_key) |> Base.decode16!(case: :lower)
-    salt = Application.get_env(:ret, :farspark_signature_salt) |> Base.decode16!(case: :lower)
-
-    :sha256
-    |> :crypto.hmac(key, salt <> path)
-    |> Base.url_encode64(padding: false)
+    conn |> render("show.json", origin: uri |> URI.to_string(), meta: meta)
   end
 end

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -2,12 +2,8 @@ defmodule RetWeb.Api.V1.MediaController do
   use RetWeb, :controller
   use Retry
 
-  def create(conn, %{"media" => %{"url" => url, "index" => index}}) do
-    resolve_and_render(conn, url, index)
-  end
-
   def create(conn, %{"media" => %{"url" => url}}) do
-    resolve_and_render(conn, url, 0)
+    resolve_and_render(conn, url)
   end
 
   def create(
@@ -71,7 +67,7 @@ defmodule RetWeb.Api.V1.MediaController do
     end
   end
 
-  defp resolve_and_render(conn, url, index) do
+  defp resolve_and_render(conn, url) do
     ua =
       conn
       |> Plug.Conn.get_req_header("user-agent")
@@ -90,14 +86,14 @@ defmodule RetWeb.Api.V1.MediaController do
         conn |> send_resp(404, "")
 
       {_status, %Ret.ResolvedMedia{} = resolved_media} ->
-        render_resolved_media(conn, resolved_media, index)
+        render_resolved_media(conn, resolved_media)
 
       _ ->
         conn |> send_resp(404, "")
     end
   end
 
-  defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}, index) do
+  defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}) do
     conn |> render("show.json", origin: uri |> URI.to_string(), meta: meta)
   end
 end

--- a/lib/ret_web/views/api/v1/media_view.ex
+++ b/lib/ret_web/views/api/v1/media_view.ex
@@ -4,13 +4,12 @@ defmodule RetWeb.Api.V1.MediaView do
   def render("show.json", %{
         file_id: file_id,
         origin: origin,
-        raw: raw,
         meta: meta
       }) do
-    %{file_id: file_id, origin: origin, raw: raw, meta: meta}
+    %{file_id: file_id, origin: origin, meta: meta}
   end
 
-  def render("show.json", %{origin: origin, raw: raw, meta: meta}) do
-    %{origin: origin, raw: raw, meta: meta}
+  def render("show.json", %{origin: origin, meta: meta}) do
+    %{origin: origin, meta: meta}
   end
 end


### PR DESCRIPTION
Removes the `raw` field from media resolver results (dependent upon https://github.com/mozilla/hubs/pull/1595) -- and hence drops references to `farspark` from reticulum.

Also, adds a necessary CSP rule for PDF conversion.