### PR TITLE
Fix query parameter encoding for youtube-dl-server

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -460,10 +460,10 @@ defmodule Ret.MediaResolver do
     ext = query |> ytdl_ext
 
     [
-      "best#{ext}[protocol*=http][height<=?#{resolution}]",
-      "best#{ext}[protocol*=m3u8][height<=?#{resolution}]",
-      "best#{ext}[protocol*=http]",
-      "best#{ext}[protocol*=m3u8]"
+      "best#{ext}[protocol*=http][height<=?#{resolution}][format_id!=0]",
+      "best#{ext}[protocol*=m3u8][height<=?#{resolution}][format_id!=0]",
+      "best#{ext}[protocol*=http][format_id!=0]",
+      "best#{ext}[protocol*=m3u8][format_id!=0]"
     ]
     |> Enum.join("/")
   end

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -51,10 +51,15 @@ defmodule Ret.MediaResolver do
 
   def resolve_with_ytdl(%URI{} = uri, root_host, ytdl_format) do
     with ytdl_host when is_binary(ytdl_host) <- module_config(:ytdl_host) do
-      encoded_url = uri |> URI.to_string() |> URI.encode()
+
+      query = URI.encode_query(%{
+        format: ytdl_format,
+        url: URI.to_string(uri),
+        playlist_items: 1
+      })
 
       ytdl_resp =
-        "#{ytdl_host}/api/play?format=#{URI.encode(ytdl_format)}&url=#{encoded_url}&playlist_items=1"
+        "#{ytdl_host}/api/play?#{query}"
         |> retry_get_until_valid_ytdl_response
 
       case ytdl_resp do


### PR DESCRIPTION
This fixes query parameter encoding when making the API request to youtube-dl-server. It also ignores unknown video formats (which also includes redirects for some reason).

Fixes https://github.com/mozilla/Spoke/issues/689