### PR TITLE
Avatar Remixing

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -11,7 +11,7 @@ defmodule Ret.Avatar do
   import Ecto.Changeset
   import Ecto.Query
 
-  alias Ret.{Avatar, AvatarListing, Repo, OwnedFile, Account, Sids}
+  alias Ret.{Avatar, AvatarListing, Repo, OwnedFile, Account, Sids, Storage}
   alias Ret.Avatar.{AvatarSlug}
 
   @schema_prefix "ret0"
@@ -132,7 +132,7 @@ defmodule Ret.Avatar do
          thumbnail when not is_nil(thumbnail) <- parent.thumbnail_owned_file,
          {:ok, new_thumbnail} <- Storage.duplicate(thumbnail, account) do
       %Avatar{
-        thumbnail_owned_file_id: new_thumbnail.owned_file_id
+        thumbnail_owned_file: new_thumbnail
       }
     else
       _ -> %Avatar{}

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -38,6 +38,7 @@ defmodule Ret.Avatar do
     belongs_to(:account, Account, references: :account_id)
     belongs_to(:parent_avatar, Avatar, references: :avatar_id)
     belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id)
+    has_many(:avatar_listings, AvatarListing, foreign_key: :avatar_id, references: :avatar_id, on_replace: :nilify)
 
     field(:allow_remixing, :boolean)
     field(:allow_promotion, :boolean)

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -36,8 +36,9 @@ defmodule Ret.Avatar do
     field(:attributions, :map)
 
     belongs_to(:account, Account, references: :account_id)
-    belongs_to(:parent_avatar, Avatar, references: :avatar_id)
-    belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id)
+    belongs_to(:parent_avatar, Avatar, references: :avatar_id, on_replace: :nilify)
+    belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id, on_replace: :nilify)
+
     has_many(:avatar_listings, AvatarListing, foreign_key: :avatar_id, references: :avatar_id, on_replace: :nilify)
 
     field(:allow_remixing, :boolean)
@@ -145,10 +146,10 @@ defmodule Ret.Avatar do
   defp put_owned_files(in_changeset, owned_files_map) do
     Enum.reduce(owned_files_map, in_changeset, fn
       {key, :remove}, changes ->
-        changes |> put_assoc(:"#{key}_owned_file", nil)
+        changes |> put_assoc(key, nil)
 
       {key, file}, changes ->
-        changes |> put_assoc(:"#{key}_owned_file", file)
+        changes |> put_assoc(key, file)
     end)
   end
 

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -9,6 +9,7 @@ end
 defmodule Ret.Avatar do
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
 
   alias Ret.{Avatar, AvatarListing, Repo, OwnedFile, Account, Sids}
   alias Ret.Avatar.{AvatarSlug}
@@ -102,7 +103,9 @@ defmodule Ret.Avatar do
   def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/avatars/#{avatar.avatar_listing_sid}"
 
   defp api_base_url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
-  defp api_base_url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
+
+  defp api_base_url(%AvatarListing{} = avatar),
+    do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
 
   def gltf_url(%t{} = a) when t in [Avatar, AvatarListing], do: "#{api_base_url(a)}/avatar.gltf?v=#{Avatar.version(a)}"
 
@@ -121,6 +124,40 @@ defmodule Ret.Avatar do
       AvatarListing |> Repo.get_by(avatar_listing_sid: sid) |> Repo.preload(:avatar)
   end
 
+  def new_avatar_from_parent_sid(parent_sid, account) when not is_nil(parent_sid) and parent_sid != "" do
+    with parent <-
+           parent_sid
+           |> avatar_or_avatar_listing_by_sid()
+           |> Repo.preload([:thumbnail_owned_file]),
+         thumbnail when not is_nil(thumbnail) <- parent.thumbnail_owned_file,
+         {:ok, new_thumbnail} <- Storage.duplicate(thumbnail, account) do
+      %Avatar{
+        thumbnail_owned_file_id: new_thumbnail.owned_file_id
+      }
+    else
+      _ -> %Avatar{}
+    end
+  end
+
+  def new_avatar_from_parent_sid(_parent_avatar_sid, _account) do
+    %Avatar{}
+  end
+
+  def delete_avatar_and_delist_listings(avatar) do
+    Ecto.Multi.new()
+    |> Ecto.Multi.update_all(
+      :update_all,
+      from(l in AvatarListing,
+        join: a in Avatar,
+        on: l.avatar_id == a.avatar_id,
+        where: l.avatar_id == ^avatar.avatar_id and l.account_id == ^avatar.account_id
+      ),
+      set: [state: :delisted, avatar_id: nil]
+    )
+    |> Ecto.Multi.delete(:delete, avatar)
+    |> Repo.transaction()
+  end
+
   @doc false
   def changeset(
         %Avatar{} = avatar,
@@ -135,7 +172,7 @@ defmodule Ret.Avatar do
     |> validate_required([])
     |> maybe_add_avatar_sid_to_changeset
     |> unique_constraint(:avatar_sid)
-    |> put_assoc(:account, account)
+    |> put_change(:account_id, account.account_id)
     |> put_assoc(:parent_avatar, parent_avatar)
     |> put_assoc(:parent_avatar_listing, parent_avatar_listing)
     |> put_owned_files(owned_files_map)

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -33,6 +33,8 @@ defmodule Ret.AvatarListing do
     belongs_to(:account, Account, references: :account_id)
     belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id)
 
+    has_many(:child_avatars, Avatar, references: :avatar_listing_id, foreign_key: :parent_avatar_listing_id, on_replace: :nilify)
+
     belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:bin_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:thumbnail_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -10,7 +10,7 @@ defmodule Ret.AvatarListing do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Ret.{AvatarListing, OwnedFile}
+  alias Ret.{AvatarListing, OwnedFile, Avatar}
   alias AvatarListing.{AvatarListingSlug}
 
   @schema_prefix "ret0"
@@ -22,7 +22,7 @@ defmodule Ret.AvatarListing do
     field(:order, :integer)
     field(:state, AvatarListing.State)
     field(:tags, :map)
-    belongs_to(:avatar, Ret.Avatar, references: :avatar_id)
+    belongs_to(:avatar, Avatar, references: :avatar_id)
     timestamps()
 
     # Properties cloned from avatars
@@ -55,6 +55,7 @@ defmodule Ret.AvatarListing do
     |> maybe_add_avatar_listing_sid_to_changeset
     |> unique_constraint(:avatar_listing_sid)
     |> put_assoc(:avatar, avatar)
+    |> put_change(:account_id, avatar.account_id)
     |> put_change(:name, params[:name] || avatar.name)
     |> put_change(:description, params[:description] || avatar.description)
     |> put_change(:attributions, avatar.attributions)

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -30,7 +30,7 @@ defmodule Ret.AvatarListing do
     field(:description, :string)
     field(:attributions, :map)
 
-    has_one(:account, through: [:avatar, :account])
+    belongs_to(:account, Account, references: :account_id)
     belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id)
 
     belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)

--- a/lib/ret/crypto.ex
+++ b/lib/ret/crypto.ex
@@ -4,29 +4,20 @@ defmodule Ret.Crypto do
   @chunk_size 1024 * 1024
   @min_aes_size 12
 
-  # Takes the file at source path and stream encrypts it using AES-CTR
-  # to a file at dest path. The file has a header that has a magic number
+  # Takes a stream and encrypts it using AES-CTR to a file at dest path.
+  # The file has a header that has a magic number
   # (to easily check if the decryption key is correct) as well as the
   # original file length.
-  def encrypt_file(source_path, destination_path, key) do
-    case File.stat(source_path) do
-      {:ok, %{size: source_size}} ->
-        outfile = File.stream!(destination_path, [], @chunk_size)
-        infile = source_path |> File.stream!([], @chunk_size)
+  def encrypt_stream_to_file(source_stream, source_size, destination_path, key) do
+    outfile = File.stream!(destination_path, [], @chunk_size)
+    state = :crypto.stream_init(:aes_ctr, :crypto.hash(:sha256, key), <<0::size(128)>>)
 
-        state = :crypto.stream_init(:aes_ctr, :crypto.hash(:sha256, key), <<0::size(128)>>)
-
-        Stream.concat([@header_bytes <> <<source_size::size(32)>>], infile)
-        |> Stream.map(&pad_chunk/1)
-        |> Stream.scan({state, nil}, &encrypt_chunk/2)
-        |> Stream.map(fn x -> elem(x, 1) end)
-        |> Enum.into(outfile)
-
-        :ok
-
-      {:error, _reason} = err ->
-        err
-    end
+    [@header_bytes <> <<source_size::size(32)>>]
+    |> Stream.concat(source_stream)
+    |> Stream.map(&pad_chunk/1)
+    |> Stream.scan({state, nil}, &encrypt_chunk/2)
+    |> Stream.map(fn x -> elem(x, 1) end)
+    |> Enum.into(outfile)
   end
 
   def encrypt(plaintext, key \\ default_secret_key()) do

--- a/lib/ret/crypto.ex
+++ b/lib/ret/crypto.ex
@@ -45,7 +45,7 @@ defmodule Ret.Crypto do
   # Given the source path and the user-specified decryption key, return
   # { :error, reason } if decryption fails, or return { :ok, stream }
   # where stream is a Stream of the decrypted file contents.
-  def stream_decrypt_file(source_path, key) do
+  def decrypt_file_to_stream(source_path, key) do
     case stream_decode_encrypted_header(source_path, key) do
       {:ok, file_size, aes_key, stream} ->
         state = :crypto.stream_init(:aes_ctr, aes_key, <<0::size(128)>>)

--- a/lib/ret/enums.ex
+++ b/lib/ret/enums.ex
@@ -7,5 +7,5 @@ defenum(Ret.OwnedFile.State, :owned_file_state, [:active, :inactive, :removed], 
 defenum(Ret.Scene.State, :scene_state, [:active, :removed], schema: "ret0")
 defenum(Ret.SceneListing.State, :scene_listing_state, [:active, :delisted], schema: "ret0")
 defenum(Ret.Avatar.State, :avatar_state, [:active, :removed], schema: "ret0")
-defenum(Ret.AvatarListing.State, :avatar_listing_state, [:active, :delisted], schema: "ret0")
+defenum(Ret.AvatarListing.State, :avatar_listing_state, [:active, :delisted, :removed], schema: "ret0")
 defenum(Ret.Asset.Type, :asset_type, [:image, :video, :model], schema: "ret0")

--- a/lib/ret/gltf_utils.ex
+++ b/lib/ret/gltf_utils.ex
@@ -30,17 +30,16 @@ defmodule Ret.GLTFUtils do
     ])
   end
 
-  @primary_material_name "Bot_PBS"
   def with_default_material_override(gltf, image_files) do
-    material_idx = gltf["materials"] |> Enum.find_index(&(&1["name"] == @primary_material_name))
-    gltf |> with_material_override(material_idx, image_files)
+    gltf |> with_material_override("Bot_PBS", image_files)
   end
 
   def with_material_override(gltf, nil, _image_files) do
     gltf
   end
 
-  def with_material_override(gltf, mat_index, image_files) do
+  def with_material_override(gltf, mat_name, image_files) do
+    mat_index = gltf["materials"] |> Enum.find_index(&(&1["name"] == mat_name))
     material = gltf |> get_in(["materials", Access.at(mat_index)])
 
     image_files

--- a/lib/ret/gltf_utils.ex
+++ b/lib/ret/gltf_utils.ex
@@ -30,40 +30,10 @@ defmodule Ret.GLTFUtils do
     ])
   end
 
-  def reduce(%{"children" => children} = node, {nodes, acc}, fun) do
-    acc = fun.(node, acc)
-    children |> Enum.map(&Enum.at(nodes, &1)) |> Enum.reduce({nodes, acc}, &reduce(&1, &2, fun))
-  end
-
-  def reduce(node, {nodes, acc}, fun) do
-    {nodes, fun.(node, acc)}
-  end
-
-  def reduce(%{"scenes" => scenes, "scene" => scene, "nodes" => nodes} = gltf, acc, fun) do
-    {nodes, acc} =
-      List.first(scenes)["nodes"]
-      |> Enum.map(&Enum.at(nodes, &1))
-      |> Enum.reduce({nodes, acc}, &reduce(&1, &2, fun))
-
-    acc
-  end
-
   @primary_material_name "Bot_PBS"
   def with_default_material_override(gltf, image_files) do
-    material_to_replace =
-      case gltf["materials"] |> Enum.find_index(&(&1["name"] == @primary_material_name)) do
-        nil ->
-          # TODO this currently traverses the whole GLTF, and should early out instead
-          first_material =
-            gltf
-            |> reduce([], &(&2 ++ materials_for_node(gltf, &1)))
-            |> List.first()
-        idx ->
-          idx
-
-      end
-
-    gltf |> with_material_override(material_to_replace, image_files)
+    material_idx = gltf["materials"] |> Enum.find_index(&(&1["name"] == @primary_material_name))
+    gltf |> with_material_override(material_idx, image_files)
   end
 
   def with_material_override(gltf, nil, _image_files) do

--- a/lib/ret/gltf_utils.ex
+++ b/lib/ret/gltf_utils.ex
@@ -24,7 +24,8 @@ defmodule Ret.GLTFUtils do
     gltf
     |> Map.put("buffers", [
       %{
-        "uri" => bin_file |> OwnedFile.uri_for() |> URI.to_string()
+        "uri" => bin_file |> OwnedFile.uri_for() |> URI.to_string(),
+        "byteLength" => bin_file.content_length
       }
     ])
   end

--- a/lib/ret/gltf_utils.ex
+++ b/lib/ret/gltf_utils.ex
@@ -11,7 +11,16 @@ defmodule Ret.GLTFUtils do
     ]
   }
 
-  def with_buffer(gltf, bin_file) do
+  def materials_for_node(gltf, node) do
+    with mesh_idx when not is_nil(mesh_idx) <- node["mesh"],
+         primitives <- get_in(gltf, ["meshes", Access.at(node["mesh"]), "primitives"]) do
+      for prim <- primitives, not is_nil(prim["material"]), do: prim["material"]
+    else
+      _ -> []
+    end
+  end
+
+  def with_buffer_override(gltf, bin_file) do
     gltf
     |> Map.put("buffers", [
       %{
@@ -20,28 +29,64 @@ defmodule Ret.GLTFUtils do
     ])
   end
 
-  def with_material(gltf, name, image_files) do
-    case gltf["materials"] |> Enum.find(&(&1["name"] == name)) do
-      nil ->
-        gltf
+  def reduce(%{"children" => children} = node, {nodes, acc}, fun) do
+    acc = fun.(node, acc)
+    children |> Enum.map(&Enum.at(nodes, &1)) |> Enum.reduce({nodes, acc}, &reduce(&1, &2, fun))
+  end
 
-      material ->
-        image_files
-        |> Enum.filter(fn {_, v} -> v end)
-        |> Enum.flat_map(fn {col, file} ->
-          Enum.map(@texture_paths[col], fn path ->
-            texture_index = material |> get_in(path ++ ["index"])
-            image_index = gltf |> get_in(["textures", Access.at(texture_index), "source"])
-            {image_index, file}
-          end)
-        end)
-        |> Enum.reduce(gltf, fn {index, file}, gltf ->
-          gltf
-          |> put_in(["images", Access.at(index)], %{
-            "uri" => file |> OwnedFile.uri_for() |> URI.to_string(),
-            "mimeType" => file.content_type
-          })
-        end)
-    end
+  def reduce(node, {nodes, acc}, fun) do
+    {nodes, fun.(node, acc)}
+  end
+
+  def reduce(%{"scenes" => scenes, "scene" => scene, "nodes" => nodes} = gltf, acc, fun) do
+    {nodes, acc} =
+      List.first(scenes)["nodes"]
+      |> Enum.map(&Enum.at(nodes, &1))
+      |> Enum.reduce({nodes, acc}, &reduce(&1, &2, fun))
+
+    acc
+  end
+
+  @primary_material_name "Bot_PBS"
+  def with_default_material_override(gltf, image_files) do
+    material_to_replace =
+      case gltf["materials"] |> Enum.find_index(&(&1["name"] == @primary_material_name)) do
+        nil ->
+          # TODO this currently traverses the whole GLTF, and should early out instead
+          first_material =
+            gltf
+            |> reduce([], &(&2 ++ materials_for_node(gltf, &1)))
+            |> List.first()
+        idx ->
+          idx
+
+      end
+
+    gltf |> with_material_override(material_to_replace, image_files)
+  end
+
+  def with_material_override(gltf, nil, _image_files) do
+    gltf
+  end
+
+  def with_material_override(gltf, mat_index, image_files) do
+    material = gltf |> get_in(["materials", Access.at(mat_index)])
+
+    image_files
+    |> Enum.filter(fn {_, v} -> v end)
+    |> Enum.flat_map(fn {col, file} ->
+      Enum.map(@texture_paths[col], fn path ->
+        texture_index = material |> get_in(path ++ ["index"])
+        image_index = gltf |> get_in(["textures", Access.at(texture_index), "source"])
+        {image_index, file}
+      end)
+    end)
+    |> Enum.reduce(gltf, fn {index, file}, gltf ->
+      gltf
+      |> put_in(["images", Access.at(index)], %{
+        "uri" => file |> OwnedFile.uri_for() |> URI.to_string(),
+        "mimeType" => file.content_type
+      })
+    end)
   end
 end

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -595,7 +595,7 @@ defmodule Ret.MediaSearch do
       name: avatar_listing.name,
       description: avatar_listing.description,
       attributions: avatar_listing.attributions,
-      allow_remixing: not is_nil(avatar_listing.avatar) and avatar_listing.avatar.allow_remixing,
+      allow_remixing: avatar_listing.avatar !== nil and avatar_listing.avatar.allow_remixing,
       images: %{
         preview: %{
           url: thumbnail || "https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png",

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -38,12 +38,8 @@ defmodule Ret.MediaSearch do
     scene_search(cursor, query, filter, account_id)
   end
 
-  def search(%Ret.MediaSearchQuery{source: "avatar_listings", cursor: cursor, filter: "featured", q: query}) do
-    avatar_listing_search(cursor, query, "featured", asc: :order)
-  end
-
   def search(%Ret.MediaSearchQuery{source: "avatar_listings", cursor: cursor, filter: filter, q: query}) do
-    avatar_listing_search(cursor, query, filter)
+    avatar_listing_search(cursor, query, filter, asc: :order)
   end
 
   def search(%Ret.MediaSearchQuery{source: "avatars", cursor: cursor, filter: filter, user: account_id, q: query}) do

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -460,7 +460,7 @@ defmodule Ret.MediaSearch do
       |> where([l, a], l.state == ^"active" and a.state == ^"active" and a.allow_promotion == ^true)
       |> add_query_to_listing_search_query(query)
       |> add_tag_to_listing_search_query(filter)
-      |> preload([:thumbnail_owned_file])
+      |> preload([:thumbnail_owned_file, :avatar])
       |> order_by(^order)
       |> Repo.paginate(%{page: page_number, page_size: @page_size})
       |> result_for_page(page_number, :avatar_listings, &avatar_listing_to_entry/1)
@@ -595,6 +595,7 @@ defmodule Ret.MediaSearch do
       name: avatar_listing.name,
       description: avatar_listing.description,
       attributions: avatar_listing.attributions,
+      allow_remixing: not is_nil(avatar_listing.avatar) and avatar_listing.avatar.allow_remixing,
       images: %{
         preview: %{
           url: thumbnail || "https://asset-bundles-prod.reticulum.io/bots/avatar_unavailable.png",

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -16,7 +16,7 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   defp preload(%Avatar{} = a, preloads) do
-    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing]])
+    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :avatar_listings]])
   end
 
   defp preload(%AvatarListing{} = a, preloads) do
@@ -88,7 +88,7 @@ defmodule RetWeb.Api.V1.AvatarController do
           |> Avatar.changeset(account, owned_files, parent_avatar, parent_avatar_listing, params)
           |> Repo.insert_or_update()
 
-        avatar = avatar |> Repo.preload(Avatar.file_columns())
+        avatar = avatar |> preload()
 
         case result do
           :ok ->

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -115,7 +115,7 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   def show(conn, %Avatar{state: :removed}), do: conn |> send_resp(404, "Avatar not found")
-  def show(conn, %AvatarListing{state: :delisted}), do: conn |> send_resp(404, "Avatar not found")
+  def show(conn, %AvatarListing{state: :removed}), do: conn |> send_resp(404, "Avatar not found")
 
   def show(conn, %t{} = avatar) when t in [Avatar, AvatarListing] do
     account = conn |> Guardian.Plug.current_resource()
@@ -146,7 +146,7 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   def show_gltf(conn, %Avatar{state: :removed}, _overrides), do: conn |> send_resp(404, "Avatar not found")
-  def show_gltf(conn, %AvatarListing{state: :delisted}, _overrides), do: conn |> send_resp(404, "Avatar not found")
+  def show_gltf(conn, %AvatarListing{state: :removed}, _overrides), do: conn |> send_resp(404, "Avatar not found")
 
   def show_gltf(conn, %t{} = a, apply_overrides) when t in [Avatar, AvatarListing],
     do: conn |> show_gltf(a |> Avatar.collapsed_files(), apply_overrides)

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -16,11 +16,11 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   defp preload(%Avatar{} = a, preloads) do
-    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :avatar_listings]])
+    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :avatar_listings] ++ preloads])
   end
 
   defp preload(%AvatarListing{} = a, preloads) do
-    a |> Repo.preload([Avatar.file_columns() ++ [:avatar, :parent_avatar_listing]])
+    a |> Repo.preload([Avatar.file_columns() ++ [:avatar, :parent_avatar_listing] ++ preloads])
   end
 
   defp preload(_avatar, _preloads), do: nil

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -5,7 +5,6 @@ defmodule RetWeb.Api.V1.AvatarController do
 
   plug(RetWeb.Plugs.RateLimit when action in [:create, :update])
 
-  @primary_material_name "Bot_PBS"
 
   defp get_avatar(avatar_sid) do
     avatar_sid
@@ -151,11 +150,8 @@ defmodule RetWeb.Api.V1.AvatarController do
           stream
           |> Enum.join("")
           |> Poison.decode!()
-          |> GLTFUtils.with_material(
-            @primary_material_name,
-            (apply_overrides && avatar_files |> Map.take(Avatar.image_columns())) || []
-          )
-          |> GLTFUtils.with_buffer(avatar_files.bin_owned_file)
+          |> GLTFUtils.with_default_material_override((apply_overrides && avatar_files |> Map.take(Avatar.image_columns())) || [])
+          |> GLTFUtils.with_buffer_override(avatar_files.bin_owned_file)
 
         conn
         # |> put_resp_content_type("model/gltf", nil)

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -12,6 +12,10 @@ defmodule RetWeb.Api.V1.AvatarController do
     |> preload()
   end
 
+  defp preload(nil = _avatar) do
+    nil
+  end
+
   defp preload(%Avatar{} = a) do
     a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :account]])
   end
@@ -83,7 +87,8 @@ defmodule RetWeb.Api.V1.AvatarController do
 
     case promotion_error do
       nil ->
-        owned_files = owned_file_results |> Enum.map(fn {k, {:ok, file}} -> {k, file} end) |> Enum.into(%{})
+        owned_files =
+          owned_file_results |> Enum.map(fn {k, {:ok, file}} -> {:"#{k}_owned_file", file} end) |> Enum.into(%{})
 
         parent_avatar = params["parent_avatar_id"] && Repo.get_by(Avatar, avatar_sid: params["parent_avatar_id"])
 

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -21,6 +21,17 @@ defmodule RetWeb.Api.V1.AvatarController do
     a |> Repo.preload([Avatar.file_columns() ++ [:avatar, :parent_avatar_listing, :account]])
   end
 
+  # TODO this should clone the thumbnail owned file
+  def create(conn, %{"avatar" => %{"parent_avatar_listing_id" => parent_avatar_listing_id} = params})
+      when not is_nil(parent_avatar_listing_id) and parent_avatar_listing_id != "" do
+    account = conn |> Guardian.Plug.current_resource()
+    parent_avatar_listing = Repo.get_by(AvatarListing, avatar_listing_sid: parent_avatar_listing_id)
+
+    create_or_update(conn, params, %Avatar{
+      thumbnail_owned_file_id: parent_avatar_listing.thumbnail_owned_file_id
+    })
+  end
+
   def create(conn, %{"avatar" => params}) do
     create_or_update(conn, params, %Avatar{})
   end

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -17,11 +17,11 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   defp preload(%Avatar{} = a) do
-    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :account]])
+    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing]])
   end
 
   defp preload(%AvatarListing{} = a) do
-    a |> Repo.preload([Avatar.file_columns() ++ [:avatar, :parent_avatar_listing, :account]])
+    a |> Repo.preload([Avatar.file_columns() ++ [:avatar, :parent_avatar_listing]])
   end
 
   def create(conn, %{"avatar" => params}) do

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -29,9 +29,9 @@ defmodule RetWeb.Api.V1.MediaSearchController do
     conn |> render("index.json", results: results)
   end
 
-  def index(conn, %{"source" => "avatar_listings", "filter" => "featured"} = params) do
+  def index(conn, %{"source" => "avatar_listings", "filter" => filter} = params) do
     {:commit, results} =
-      %Ret.MediaSearchQuery{source: "avatar_listings", cursor: params["cursor"] || "1", filter: "featured"}
+      %Ret.MediaSearchQuery{source: "avatar_listings", cursor: params["cursor"] || "1", filter: filter}
       |> Ret.MediaSearch.search()
 
     conn |> render("index.json", results: results)

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -10,6 +10,10 @@ defmodule RetWeb.Api.V1.AvatarView do
     %{avatars: [render_avatar(avatar, account)]}
   end
 
+  def render("show.json", %{avatars: avatars, account: account}) do
+    %{avatars: avatars |> Enum.map(&render_avatar(&1, account))}
+  end
+
   defp render_avatar(%Avatar{} = avatar, account) do
     avatar
     |> common_fields()

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -24,7 +24,7 @@ defmodule RetWeb.Api.V1.AvatarView do
       account_id: account && avatar.account_id == account.account_id && avatar.account_id |> Integer.to_string(),
       allow_remixing: avatar.allow_remixing,
       allow_promotion: avatar.allow_promotion,
-      has_listings: length(avatar.avatar_listings) > 0
+      has_listings: length(avatar.avatar_listings |> Enum.filter(fn l -> l.state == :active end)) > 0
     })
   end
 

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -23,7 +23,8 @@ defmodule RetWeb.Api.V1.AvatarView do
       # Only include account id on your own avatars
       account_id: account && avatar.account_id == account.account_id && avatar.account_id |> Integer.to_string(),
       allow_remixing: avatar.allow_remixing,
-      allow_promotion: avatar.allow_promotion
+      allow_promotion: avatar.allow_promotion,
+      has_listings: length(avatar.avatar_listings) > 0
     })
   end
 

--- a/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
+++ b/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
@@ -1,0 +1,31 @@
+defmodule Ret.Repo.Migrations.AddAvatarListingsAccount do
+  use Ecto.Migration
+  import Ecto.Query
+
+  alias Ret.{Repo, Avatar}
+
+  def up do
+    alter table(:avatar_listings, prefix: "ret0") do
+      add(:account_id, references(:accounts, column: :account_id, null: false))
+    end
+    execute "ALTER TABLE ret0.avatar_listings ALTER COLUMN avatar_id DROP NOT NULL"
+    create constraint(:avatar_listings, :avatar_required_for_listed, check: "avatar_id is not null or (avatar_id is null and state = 'delisted')")
+
+    flush()
+
+    from(l in "avatar_listings",
+      join: a in Avatar,
+      on: a.avatar_id == l.avatar_id,
+      update: [set: [account_id: a.account_id]]
+    )
+    |> Repo.update_all([])
+  end
+
+  def down do
+    alter table(:avatar_listings, prefix: "ret0") do
+      remove :account_id
+    end
+    drop constraint(:avatar_listings, :avatar_required_for_listed)
+    execute "ALTER TABLE ret0.avatar_listings ALTER COLUMN avatar_id SET NOT NULL"
+  end
+end

--- a/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
+++ b/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
@@ -1,0 +1,8 @@
+defmodule Ret.Repo.Migrations.AddAvatarListingsRemovedState do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+  def change do
+    Ecto.Migration.execute("ALTER TYPE avatar_listing_state ADD VALUE IF NOT EXISTS 'removed'")
+  end
+end

--- a/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
+++ b/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
@@ -1,8 +1,22 @@
 defmodule Ret.Repo.Migrations.AddAvatarListingsRemovedState do
   use Ecto.Migration
+  import Ecto.Query
+  alias Ret.{Repo, AvatarListing}
+
   @disable_ddl_transaction true
 
-  def change do
-    Ecto.Migration.execute("ALTER TYPE avatar_listing_state ADD VALUE IF NOT EXISTS 'removed'")
+  def up do
+    Ecto.Migration.execute("ALTER TYPE ret0.avatar_listing_state ADD VALUE IF NOT EXISTS 'removed'")
+
+    flush()
+
+    Repo.update_all(
+      from(l in AvatarListing, where: l.state == ^:delisted and not is_nil(l.avatar_id)),
+      set: [state: :removed]
+    )
+  end
+
+  def down do
+    # There is no great way to reverse this migration, so we would probably need to manually decide what to do
   end
 end

--- a/test/ret/avatar_listing_test.exs
+++ b/test/ret/avatar_listing_test.exs
@@ -1,0 +1,85 @@
+defmodule Ret.AvatarListingTest do
+  use Ret.DataCase
+  import Ret.TestHelpers
+
+  alias Ret.{Repo, Account, Avatar, AvatarListing}
+
+  setup do
+    on_exit(fn ->
+      clear_all_stored_files()
+    end)
+  end
+
+  setup _context do
+    account_1 = Account.account_for_email("test@mozilla.com")
+    account_2 = Account.account_for_email("test2@mozilla.com")
+
+    account_1_avatar_1 = create_avatar(account_1)
+    account_1_avatar_2 = create_avatar(account_1)
+    account_2_avatar_1 = create_avatar(account_2)
+
+    %{
+      account_1: account_1,
+      account_2: account_2,
+      account_1_avatar_1: account_1_avatar_1,
+      account_1_avatar_2: account_1_avatar_2,
+      account_2_avatar_1: account_2_avatar_1,
+      account_1_avatar_1_listing_1: create_avatar_listing(account_1_avatar_1),
+      account_1_avatar_1_listing_2: create_avatar_listing(account_1_avatar_1),
+      account_1_avatar_2_listing_1: create_avatar_listing(account_1_avatar_2),
+      account_2_avatar_1_listing_1: create_avatar_listing(account_2_avatar_1)
+    }
+  end
+
+  test "can create an avatar listing", %{account_1_avatar_1: avatar, account_1_avatar_1_listing_1: listing} do
+    assert listing.name == avatar.name
+    assert listing.description == avatar.description
+    assert listing.avatar_id == avatar.avatar_id
+    assert listing.account_id == avatar.account_id
+    assert listing.parent_avatar_listing_id == avatar.parent_avatar_listing_id
+    assert listing.gltf_owned_file_id == avatar.gltf_owned_file_id
+    assert listing.bin_owned_file_id == avatar.bin_owned_file_id
+    assert listing.thumbnail_owned_file_id == avatar.thumbnail_owned_file_id
+    assert listing.base_map_owned_file_id == avatar.base_map_owned_file_id
+    assert listing.emissive_map_owned_file_id == avatar.emissive_map_owned_file_id
+    assert listing.normal_map_owned_file_id == avatar.normal_map_owned_file_id
+    assert listing.orm_map_owned_file_id == avatar.orm_map_owned_file_id
+  end
+
+  test "listings for an avatar become unlisted when deleting it", %{
+    account_1: account_1,
+    account_2: account_2,
+    account_1_avatar_1: avatar,
+    account_1_avatar_2: avatar2,
+    account_2_avatar_1: account_2_avatar,
+    account_1_avatar_1_listing_1: listing,
+    account_1_avatar_1_listing_2: listing2,
+    account_1_avatar_2_listing_1: other_avatars_listing,
+    account_2_avatar_1_listing_1: other_accounts_listing
+  } do
+    avatar |> Avatar.delete_avatar_and_delist_listings()
+
+    assert avatar.avatar_sid |> Avatar.avatar_or_avatar_listing_by_sid() == nil
+
+    listing = AvatarListing |> Repo.get(listing.avatar_listing_id)
+    listing2 = AvatarListing |> Repo.get(listing2.avatar_listing_id)
+    other_avatars_listing = AvatarListing |> Repo.get(other_avatars_listing.avatar_listing_id)
+    other_accounts_listing = AvatarListing |> Repo.get(other_accounts_listing.avatar_listing_id)
+
+    assert listing.state == :delisted
+    assert listing.avatar_id == nil
+    assert listing.account_id == account_1.account_id
+
+    assert listing2.state == :delisted
+    assert listing2.avatar_id == nil
+    assert listing2.account_id == account_1.account_id
+
+    assert other_avatars_listing.state == :active
+    assert other_avatars_listing.avatar_id == avatar2.avatar_id
+    assert other_avatars_listing.account_id == account_1.account_id
+
+    assert other_accounts_listing.state == :active
+    assert other_accounts_listing.avatar_id == account_2_avatar.avatar_id
+    assert other_accounts_listing.account_id == account_2.account_id
+  end
+end

--- a/test/ret/gltf_utils_test.exs
+++ b/test/ret/gltf_utils_test.exs
@@ -146,20 +146,23 @@ defmodule Ret.GLTFUtilsTest do
 
   test "replaces buffers with bin owned file", %{temp_owned_file: temp_owned_file} do
     input_gltf = @sample_gltf
-    output_gltf = input_gltf |> GLTFUtils.with_buffer(temp_owned_file)
+    output_gltf = input_gltf |> GLTFUtils.with_buffer_override(temp_owned_file)
 
     bin_url = temp_owned_file |> OwnedFile.uri_for() |> URI.to_string()
-    buffers = output_gltf |> get_in(["buffers", Access.at(0)])
+    buffers = output_gltf["buffers"]
+    buffer = output_gltf |> get_in(["buffers", Access.at(0)])
     assert Enum.count(buffers) == 1
-    assert bin_url == buffers["uri"]
+    assert buffer["uri"] == bin_url
+    assert buffer["byteLength"] == temp_owned_file.content_length
   end
 
   test "replace only base texture", %{temp_owned_file: temp_owned_file} do
     input_gltf = @sample_gltf
-    output_gltf = input_gltf |> GLTFUtils.with_material("Bot_PBS", %{base_map_owned_file: temp_owned_file})
+    output_gltf = input_gltf |> GLTFUtils.with_default_material_override(%{base_map_owned_file: temp_owned_file})
 
     img_url = temp_owned_file |> OwnedFile.uri_for() |> URI.to_string()
     assert img_url == output_gltf |> get_in(["images", Access.at(2), "uri"])
+
     for i <- [0, 1, 3], path = ["images", Access.at(i)] do
       assert input_gltf |> get_in(path) == output_gltf |> get_in(path)
     end
@@ -167,10 +170,11 @@ defmodule Ret.GLTFUtilsTest do
 
   test "replace ORM texture", %{temp_owned_file: temp_owned_file} do
     input_gltf = @sample_gltf
-    output_gltf = input_gltf |> GLTFUtils.with_material("Bot_PBS", %{orm_map_owned_file: temp_owned_file})
+    output_gltf = input_gltf |> GLTFUtils.with_default_material_override(%{orm_map_owned_file: temp_owned_file})
 
     img_url = temp_owned_file |> OwnedFile.uri_for() |> URI.to_string()
     assert img_url == output_gltf |> get_in(["images", Access.at(1), "uri"])
+
     for i <- [0, 2, 3], path = ["images", Access.at(i)] do
       assert input_gltf |> get_in(path) == output_gltf |> get_in(path)
     end
@@ -178,11 +182,12 @@ defmodule Ret.GLTFUtilsTest do
 
   test "replace multiple ORM texture", %{temp_owned_file: temp_owned_file} do
     input_gltf = @multi_orm_gltf
-    output_gltf = input_gltf |> GLTFUtils.with_material("Bot_PBS", %{orm_map_owned_file: temp_owned_file})
+    output_gltf = input_gltf |> GLTFUtils.with_default_material_override(%{orm_map_owned_file: temp_owned_file})
 
     img_url = temp_owned_file |> OwnedFile.uri_for() |> URI.to_string()
     assert img_url == output_gltf |> get_in(["images", Access.at(1), "uri"])
     assert img_url == output_gltf |> get_in(["images", Access.at(4), "uri"])
+
     for i <- [0, 2, 3], path = ["images", Access.at(i)] do
       assert input_gltf |> get_in(path) == output_gltf |> get_in(path)
     end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,5 +1,5 @@
 defmodule Ret.TestHelpers do
-  alias Ret.{Storage, Project, Account, Asset, ProjectAsset, Scene, SceneListing, Repo, Hub, Avatar}
+  alias Ret.{Storage, Project, Account, Asset, ProjectAsset, Scene, SceneListing, Repo, Hub, Avatar, AvatarListing}
 
   def generate_temp_owned_file(account) do
     temp_file = generate_temp_file("test")
@@ -69,8 +69,8 @@ defmodule Ret.TestHelpers do
       |> Avatar.changeset(
         account,
         %{
-          gltf: generate_temp_owned_file(account),
-          bin: generate_temp_owned_file(account)
+          gltf_owned_file: generate_temp_owned_file(account),
+          bin_owned_file: generate_temp_owned_file(account)
         },
         nil,
         nil,
@@ -81,6 +81,19 @@ defmodule Ret.TestHelpers do
       |> Repo.insert_or_update()
 
     avatar
+  end
+
+  def create_avatar_listing(%{avatar: avatar}) do
+    {:ok, avatar_listing: create_avatar_listing(avatar)}
+  end
+
+  def create_avatar_listing(avatar) do
+    {:ok, listing} =
+      %AvatarListing{}
+      |> AvatarListing.changeset_for_listing_for_avatar(avatar, %{})
+      |> Repo.insert()
+
+    listing
   end
 
   def create_scene_listing(%{scene: scene}) do


### PR DESCRIPTION
This contains the necessary backend bits to turn on avatar remixing, namely:

- Allowing duplication of thumbnails when creating an avatar with a `parent_avatar_listing_id`
- Allow searching `avatar_listings` by tag, primarily for base, to be used in
  the updated avatar picker and default to be used to remove client baked-in
  avatars
- Bake account `into avatar_listings` instead of associating through avatars. When
  deleting avatars also delist their associated listings, keeping the account
  association for use down the road.
- Rework GLTF material resolving to have a traversal based fallback for finding
  skinnable material.

TODO:

- [x] fix `with_buffer_override` to include buffer size (unrelated but touching related code)
- [x] ~~decide if we want to keep traversal based material resolving or bake something into the GLTF on upload. If we keep traversal it should probably be cleaned up a bit.~~
   Decided to have the client handle renaming materials if a valid one is not found. The plan is to transition this to some meta information in the gltf eventually, but for now this lets us isolate the special cases to one spot.
- [x] write unit test for avatar deletion and delisting
- [x] base.gltf doesnt work correctly when the parent_avatar_listing has maps
- [x] You can currently not get a gltf for a delisted listing