### PR TITLE
Remove scm step from jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,6 @@ pipeline {
   stages {
     stage('pre-build') {
       steps {
-        checkout scm: [$class: 'GitSCM', clean: false, clearWorkspace: false]
-
         sh 'rm -rf ./results ./tmp'
       }
     }


### PR DESCRIPTION
As far as I can tell, this line in the Jenkinsfile is what's causing the build to happen on non-master branches.
I'm not sure it's necessary, since the configuration on the Jenkins job already takes care of SCM tasks