### PR TITLE
Drop uniqueness on slugs and always update them

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -1,5 +1,5 @@
 defmodule Ret.Avatar.AvatarSlug do
-  use EctoAutoslugField.Slug, from: :name, to: :slug
+  use EctoAutoslugField.Slug, from: :name, to: :slug, always_change: true
 
   def get_sources(_changeset, _opts) do
     [:avatar_sid, :name]
@@ -138,7 +138,6 @@ defmodule Ret.Avatar do
     |> put_assoc(:parent_avatar_listing, parent_avatar_listing)
     |> put_owned_files(owned_files_map)
     |> AvatarSlug.maybe_generate_slug()
-    |> AvatarSlug.unique_constraint()
   end
 
   defp put_owned_files(in_changeset, owned_files_map) do

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -1,5 +1,5 @@
 defmodule Ret.AvatarListing.AvatarListingSlug do
-  use EctoAutoslugField.Slug, from: :name, to: :slug
+  use EctoAutoslugField.Slug, from: :name, to: :slug, always_change: true
 
   def get_sources(_changeset, _opts) do
     [:avatar_listing_sid, :name]
@@ -65,7 +65,6 @@ defmodule Ret.AvatarListing do
     |> put_change(:normal_map_owned_file_id, avatar.normal_map_owned_file_id)
     |> put_change(:orm_map_owned_file_id, avatar.orm_map_owned_file_id)
     |> AvatarListingSlug.maybe_generate_slug()
-    |> AvatarListingSlug.unique_constraint()
   end
 
   defp maybe_add_avatar_listing_sid_to_changeset(changeset) do

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -1,5 +1,5 @@
 defmodule Ret.Scene.SceneSlug do
-  use EctoAutoslugField.Slug, from: :name, to: :slug
+  use EctoAutoslugField.Slug, from: :name, to: :slug, always_change: true
 
   def get_sources(_changeset, _opts) do
     [:scene_sid, :name]
@@ -73,7 +73,6 @@ defmodule Ret.Scene do
     |> put_change(:screenshot_owned_file_id, screenshot_owned_file.owned_file_id)
     |> put_change(:scene_owned_file_id, scene_owned_file.owned_file_id)
     |> SceneSlug.maybe_generate_slug()
-    |> SceneSlug.unique_constraint()
   end
 
   def changeset_to_mark_as_reviewed(%Scene{} = scene) do

--- a/lib/ret/scene_listing.ex
+++ b/lib/ret/scene_listing.ex
@@ -1,5 +1,5 @@
 defmodule Ret.SceneListing.SceneListingSlug do
-  use EctoAutoslugField.Slug, from: :name, to: :slug
+  use EctoAutoslugField.Slug, from: :name, to: :slug, always_change: true
 
   def get_sources(_changeset, _opts) do
     [:scene_listing_sid, :name]
@@ -51,7 +51,6 @@ defmodule Ret.SceneListing do
     |> put_change(:screenshot_owned_file_id, scene.screenshot_owned_file.owned_file_id)
     |> put_change(:scene_owned_file_id, scene.scene_owned_file.owned_file_id)
     |> SceneListingSlug.maybe_generate_slug()
-    |> SceneListingSlug.unique_constraint()
   end
 
   defp maybe_add_scene_listing_sid_to_changeset(changeset) do

--- a/test/ret_web/controllers/api/scene_controller_test.exs
+++ b/test/ret_web/controllers/api/scene_controller_test.exs
@@ -51,6 +51,7 @@ defmodule RetWeb.SceneControllerTest do
     updated_scene = Scene |> Repo.get_by(scene_sid: scene.scene_sid)
 
     assert updated_scene.name == "New Name"
+    assert updated_scene.slug == "new-name"
     assert updated_scene.description == "New Description"
   end
 


### PR DESCRIPTION
Our slug code in `Hub` properly ignored uniqueness of slugs and also updates the slug when the room changes. We weren't doing this for the other entities which have slugs: avatars, avatar listings, scenes, and scene listings. This PR rectifies that.

(Slugs do not need to be unique nor should they be immutable, since they are not the unique identifiers in our system, the SID is, and they are used just to adorn the URL with information.)