### PR TITLE
Add entering presence

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -104,6 +104,20 @@ defmodule RetWeb.HubChannel do
     hub |> join_with_hub(account, socket, context, params)
   end
 
+  def handle_in("events:entering", _payload, socket) do
+    context = socket.assigns.context || %{}
+    socket = socket |> assign(:context, context |> Map.put("entering", true)) |> broadcast_presence_update
+
+    {:noreply, socket}
+  end
+
+  def handle_in("events:entering_cancelled", _payload, socket) do
+    context = socket.assigns.context || %{}
+    socket = socket |> assign(:context, context |> Map.delete("entering")) |> broadcast_presence_update
+
+    {:noreply, socket}
+  end
+
   def handle_in("events:entered", %{"initialOccupantCount" => occupant_count} = payload, socket) do
     socket =
       socket

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,5 +13,5 @@ if [ -z "$PERMS_KEY" ]; then
   >&2 echo "$(tput setaf 1)Perms key not found. Exiting.$(tput sgr0)"
   exit 1
 else
-  PERMS_KEY="$PERMS_KEY" mix phx.server
+  PERMS_KEY="$PERMS_KEY" iex -S mix phx.server
 fi


### PR DESCRIPTION
Adds support for two new reticulum events which update presence state so that the client can know which users are currently going through the entry flow. This is used to enforce a soft cap on room capacity.