### PR TITLE
Disable PWA on iOS, fix icons

### DIFF
--- a/lib/ret/page_origin_warmer.ex
+++ b/lib/ret/page_origin_warmer.ex
@@ -19,7 +19,7 @@ defmodule Ret.PageOriginWarmer do
       cache_values =
         @pages
         |> Enum.map(fn {source, page} -> Task.async(fn -> page_to_cache_entry(source, page) end) end)
-        |> Enum.map(&Task.await(&1, 15000))
+        |> Enum.map(&Task.await(&1, 15_000))
         |> Enum.reject(&is_nil/1)
 
       {:ok, cache_values}
@@ -29,7 +29,7 @@ defmodule Ret.PageOriginWarmer do
   end
 
   def chunks_for_page(source, page) do
-    {:ok, page_to_cache_entry(source, page) |> elem(1)}
+    {:ok, source |> page_to_cache_entry(page) |> elem(1)}
   end
 
   defp page_to_cache_entry(source, page) do

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -1,8 +1,12 @@
+<link rel="icon" sizes="16x16 24x24 32x32 48x48 64x64" href="/favicon.ico">
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= @hub |> Ret.Hub.url_for %>" />
 <meta property="og:title" content="<%= @hub.name %> | Hubs by Mozilla" />
 <meta property="og:description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
 <meta property="og:image" content="<%= @hub |> Ret.Hub.image_url_for %>"/>
+<meta name="description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
+<meta itemprop="name" content="<%= @hub.name %> | Hubs by Mozilla" />
+<meta itemprop="description" content="Join others in VR at <%= @hub.name %>, right in your browser." />
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
 <meta name="twitter:title" value="<%= @hub.name %> | Hubs by Mozilla" />
@@ -13,4 +17,5 @@
 <meta name="ret:phx_host" value="<%= @ret_meta[:phx_host] %>" />
 <meta name="ret:phx_port" value="<%= @ret_meta[:phx_port] %>" />
 <meta name="ret:pool" value="<%= @ret_meta[:pool] %>" />
+<link rel="apple-touch-icon" sizes="180x180" href="https://assets-prod.reticulum.io/assets/images/pwaicon-180-hubs.png">
 <title><%= @hub.name %> | Hubs by Mozilla</title>

--- a/lib/ret_web/templates/page/index-meta.html.eex
+++ b/lib/ret_web/templates/page/index-meta.html.eex
@@ -1,4 +1,3 @@
-<title>Hubs - Private social VR in your web browser</title>
 <!-- iOS (for "Add to Homescreen") -->
 <meta name="mobile-web-app-capable" content="yes">
 <!-- Description for search engines -->

--- a/lib/ret_web/templates/page/index-meta.html.eex
+++ b/lib/ret_web/templates/page/index-meta.html.eex
@@ -1,0 +1,26 @@
+<title>Hubs - Private social VR in your web browser</title>
+<!-- iOS (for "Add to Homescreen") -->
+<meta name="mobile-web-app-capable" content="yes">
+<!-- Description for search engines -->
+<meta name="description" content="Share a private virtual room with friends. Watch videos, play with 3D objects, or just hang out.">
+<!-- Schema.org for Google -->
+<meta itemprop="name" content="Hubs by Mozilla">
+<meta itemprop="description" content="Share a private virtual room with friends. Watch videos, play with 3D objects, or just hang out.">
+<!-- OpenGraph for Facebook -->
+<meta property="og:type" content="website">
+<meta property="og:title" content="Hubs by Mozilla">
+<meta property="og:description" content="Private social VR in your web browser.">
+<meta property="og:url" content="/">
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@byhubs">
+<meta name="twitter:title" content="Hubs by Mozilla">
+<meta name="twitter:image" content="https://hubs.mozilla.com/hub-preview.png">
+<meta name="twitter:description" content="Private social VR in your web browser.">
+<!-- Microsoft Edge -->
+<meta name="application-name" content="Hubs by Mozilla">
+<meta name="msapplication-tooltip" content="Share a virtual room with friends.">
+<meta name="msapplication-starturl" content="/">
+<meta name="application-name" content="Hubs">
+<link rel="apple-touch-icon" sizes="180x180" href="https://assets-prod.reticulum.io/assets/images/pwaicon-180-hubs.png">
+<link rel="icon" sizes="16x16 24x24 32x32 48x48 64x64" href="/favicon.ico">

--- a/lib/ret_web/templates/page/scene-meta.html.eex
+++ b/lib/ret_web/templates/page/scene-meta.html.eex
@@ -4,6 +4,9 @@
 <meta property="og:title" content="<%= @scene.name %> | Hubs by Mozilla" />
 <meta property="og:description" content="Join others in <%= @scene.name %>, right in your browser." />
 <meta property="og:image" content="<%= @scene.screenshot_owned_file |> Ret.OwnedFile.uri_for |> URI.to_string %>"/>
+<meta name="description" content="Join others in <%= @scene.name %>, right in your browser." />
+<meta itemprop="name" content="<%= @scene.name %> | Hubs by Mozilla" />
+<meta itemprop="description" content="Join others in <%= @scene.name %>, right in your browser." />
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" value="<%= RetWeb.Endpoint.host %>" />
 <meta name="twitter:title" value="<%= @scene.name %> | Hubs by Mozilla" />


### PR DESCRIPTION
Fixes the iOS add to home icons and disables serving the manifest on iOS since webrtc won't work.