### PR TITLE
Feature/cors proxying

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 [
-  line_length: 120
+  line_length: 120,
   import_deps: [:phoenix],
   inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/mix.exs
+++ b/mix.exs
@@ -74,9 +74,10 @@ defmodule Ret.Mixfile do
       {:scrivener_ecto, "~> 2.0"},
       {:ua_parser, "~> 1.5"},
       {:download, git: "https://github.com/gfodor/download.git", branch: "reticulum/master"},
+      {:reverse_proxy_plug,
+       git: "https://github.com/mozillareality/reverse_proxy_plug.git", branch: "reticulum/master"},
       {:oauther, "~> 1.1"},
-      {:jason, "~> 1.1"},
-      {:reverse_proxy_plug, "~> 1.2"}
+      {:jason, "~> 1.1"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -67,14 +67,16 @@ defmodule Ret.Mixfile do
       {:canary, "~> 1.1.1"},
       {:temp, "~> 0.4"},
       {:timex, "~> 3.6"},
-      {:web_push_encryption, "0.2.1"}, # 0.2.2 breaks FCM without an auth token, not sure what's up with that.
+      # 0.2.2 breaks FCM without an auth token, not sure what's up with that.
+      {:web_push_encryption, "0.2.1"},
       {:sentry, "~> 6.0"},
       {:toml, "~> 0.5"},
       {:scrivener_ecto, "~> 2.0"},
       {:ua_parser, "~> 1.5"},
       {:download, git: "https://github.com/gfodor/download.git", branch: "reticulum/master"},
       {:oauther, "~> 1.1"},
-      {:jason, "~> 1.1"}
+      {:jason, "~> 1.1"},
+      {:reverse_proxy_plug, "~> 1.2"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -86,6 +86,7 @@
   "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "9c1965273032ffb79ec0ff80b250e5d0b4608aa7", [ref: ""]},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "retry": {:hex, :retry, "0.13.0", "bb9b2713f70f39337837852337ad280c77662574f4fb852a8386c269f3d734c4", [:mix], [], "hexpm"},
+  "reverse_proxy_plug": {:hex, :reverse_proxy_plug, "1.2.1", "f950a7ba212182b36fb44d06b8c6a347951863fd22d2201452c5233ce23701b1", [:mix], [{:cowboy, "~> 2.4", [hex: :cowboy, repo: "hexpm", optional: false]}, {:httpoison, "~> 1.2", [hex: :httpoison, repo: "hexpm", optional: false]}, {:plug, "~> 1.6", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "scrivener": {:hex, :scrivener, "2.7.0", "fa94cdea21fad0649921d8066b1833d18d296217bfdf4a5389a2f45ee857b773", [:mix], [], "hexpm"},
   "scrivener_ecto": {:hex, :scrivener_ecto, "2.2.0", "53d5f1ba28f35f17891cf526ee102f8f225b7024d1cdaf8984875467158c9c5e", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm"},
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -86,7 +86,7 @@
   "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "9c1965273032ffb79ec0ff80b250e5d0b4608aa7", [ref: ""]},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "retry": {:hex, :retry, "0.13.0", "bb9b2713f70f39337837852337ad280c77662574f4fb852a8386c269f3d734c4", [:mix], [], "hexpm"},
-  "reverse_proxy_plug": {:hex, :reverse_proxy_plug, "1.2.1", "f950a7ba212182b36fb44d06b8c6a347951863fd22d2201452c5233ce23701b1", [:mix], [{:cowboy, "~> 2.4", [hex: :cowboy, repo: "hexpm", optional: false]}, {:httpoison, "~> 1.2", [hex: :httpoison, repo: "hexpm", optional: false]}, {:plug, "~> 1.6", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "reverse_proxy_plug": {:git, "https://github.com/mozillareality/reverse_proxy_plug.git", "49fb43eea8c8bcbc8fd6f08b9d043dbaf89ea779", [branch: "reticulum/master"]},
   "scrivener": {:hex, :scrivener, "2.7.0", "fa94cdea21fad0649921d8066b1833d18d296217bfdf4a5389a2f45ee857b773", [:mix], [], "hexpm"},
   "scrivener_ecto": {:hex, :scrivener_ecto, "2.2.0", "53d5f1ba28f35f17891cf526ee102f8f225b7024d1cdaf8984875467158c9c5e", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm"},
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm"},


### PR DESCRIPTION
Adds CORS proxying to reticulum, with the same API as cors-anywhere and our cloudflare worker.

This takes advantage of a fork of `ReverseProxyPlug` I created which introduces the ability to add CORS headers and CORS proxy redirecting.

Also fixes the formatter 🤕 