### PR TITLE
Add proper origin check to websocket

### DIFF
--- a/lib/ret_web/endpoint.ex
+++ b/lib/ret_web/endpoint.ex
@@ -7,13 +7,11 @@ defmodule RetWeb.Endpoint do
   def get_cors_origins, do: Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")
   def get_cors_origin_urls, do: get_cors_origins() |> Enum.filter(&(&1 != "*")) |> Enum.map(&URI.parse/1)
 
-  def allowed_origin?(url) do
+  def allowed_origin?(%URI{ host: host, port: port, scheme: scheme }) do
     if get_cors_origins() === ["*"] do
       true
     else
-      get_cors_origin_urls() |> Enum.any?(fn o ->
-        o.host == url.host && o.port == url.port && o.scheme == url.scheme
-      end)
+      get_cors_origin_urls() |> Enum.any?(&(&1.host == host && &1.port == port && &1.scheme == scheme))
     end
   end
 


### PR DESCRIPTION
Updates the origin check on the websocket to now properly use the `allowed_origins` config variable, which is now possible in Phoenix 1.4 since `origin_check` can point to a function evaluated at check time.