### PR TITLE
Add Vary: Origin header to fix issues with chrome mis-caching

### DIFF
--- a/lib/ret_web/endpoint.ex
+++ b/lib/ret_web/endpoint.ex
@@ -40,6 +40,7 @@ defmodule RetWeb.Endpoint do
   plug(RetWeb.Plugs.Head)
 
   plug(CORSPlug, origin: &RetWeb.Endpoint.get_cors_origins/0)
+  plug(RetWeb.Plugs.AddVary)
   plug(RetWeb.Router)
 
   @doc """

--- a/lib/ret_web/plugs/add_vary.ex
+++ b/lib/ret_web/plugs/add_vary.ex
@@ -1,0 +1,7 @@
+defmodule RetWeb.Plugs.AddVary do
+  def init(default), do: default
+
+  def call(conn, _options) do
+    conn |> Plug.Conn.put_resp_header("vary", "Origin")
+  end
+end


### PR DESCRIPTION
Hubs started loading photos before fetching them via XHR without an Origin header for some reason, and this results in Chrome mis-reading the non CORS'd responses from cache when we do make the XHR request to fetch the data. We should be returning "Vary: Origin" in the response from reticulum to ensure that browsers do not cache CORS and non-CORS responses.  See also: https://serverfault.com/questions/856904/chrome-s3-cloudfront-no-access-control-allow-origin-header-on-initial-xhr-req