### PR TITLE
Respect desired_conent_type for non video uploads

### DIFF
--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -42,7 +42,7 @@ defmodule RetWeb.Api.V1.MediaController do
         store_and_render_upload(conn, converted_upload, desired_content_type, promotion_token)
 
       _ ->
-        store_and_render_upload(conn, upload, content_type, promotion_token)
+        store_and_render_upload(conn, upload, desired_content_type || content_type, promotion_token)
     end
   end
 


### PR DESCRIPTION
`desired_content_type` was being thrown on the ground for non video uploads, this allows it to be passed through, falling back to the content type from Plug.Upload if it is not specified.