### PR TITLE
Feature/import origins

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -179,13 +179,11 @@ defmodule Ret.Avatar do
     body |> Poison.decode!() |> get_in(["avatars", Access.at(0)])
   end
 
-  defp collapse_remote_avatar!(%{"parent_avatar_listing_id" => nil} = avatar, base_uri),
-    do: avatar
-
   defp collapse_remote_avatar!(
          %{"parent_avatar_listing_id" => parent_id} = avatar,
          base_uri
-       ) do
+       )
+       when parent_id != nil do
     parent_avatar = URI.merge(base_uri, parent_id) |> fetch_remote_avatar!()
 
     collapse_remote_avatar!(
@@ -203,13 +201,11 @@ defmodule Ret.Avatar do
     )
   end
 
-  defp collapse_remote_avatar!(%{"parent_avatar_id" => nil} = avatar, base_uri),
-    do: avatar
-
   defp collapse_remote_avatar!(
          %{"parent_avatar_id" => parent_id} = avatar,
          base_uri
-       ) do
+       )
+       when parent_id != nil do
     parent_avatar = URI.merge(base_uri, parent_id) |> fetch_remote_avatar!()
 
     collapse_remote_avatar!(
@@ -226,6 +222,8 @@ defmodule Ret.Avatar do
       base_uri
     )
   end
+
+  defp collapse_remote_avatar!(avatar, _base_uri), do: avatar
 
   def import_from_url!(uri, account) do
     remote_avatar = uri |> fetch_remote_avatar!() |> collapse_remote_avatar!(uri)

--- a/lib/ret/meta.ex
+++ b/lib/ret/meta.ex
@@ -28,7 +28,9 @@ defmodule Ret.Meta do
           featured: Ret.AvatarListing.has_any_in_filter?("featured")
         },
         scene_listings: %{
-          any: Ret.SceneListing.has_any_in_filter?(nil)
+          any: Ret.SceneListing.has_any_in_filter?(nil),
+          default: Ret.SceneListing.has_any_in_filter?("default"),
+          featured: Ret.SceneListing.has_any_in_filter?("featured")
         }
       }
     }

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -60,6 +60,13 @@ defmodule Ret.Scene do
     [model_owned_file, screenshot_owned_file] =
       [remote_scene["model_url"], remote_scene["screenshot_url"]] |> Storage.owned_files_from_urls!(account)
 
+    scene_owned_file =
+      if remote_scene["scene_project_url"] do
+        [remote_scene["scene_project_url"]] |> Storage.owned_files_from_urls!(account) |> Enum.at(0)
+      else
+        nil
+      end
+
     scene =
       Scene
       |> Repo.get_by(
@@ -76,7 +83,7 @@ defmodule Ret.Scene do
 
     {:ok, new_scene} =
       (scene || %Scene{})
-      |> Scene.changeset(account, model_owned_file, screenshot_owned_file, nil, %{
+      |> Scene.changeset(account, model_owned_file, screenshot_owned_file, scene_owned_file, %{
         name: remote_scene["name"],
         description: remote_scene["description"],
         attributions: remote_scene["attribution"],

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -195,7 +195,7 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   def delete(conn, %Avatar{account_id: avatar_account_id} = avatar, %Account{account_id: account_id})
-       when not is_nil(avatar_account_id) and avatar_account_id == account_id do
+      when not is_nil(avatar_account_id) and avatar_account_id == account_id do
     avatar
     |> Avatar.delete_avatar_and_delist_listings()
     |> case do

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -65,7 +65,7 @@ defmodule RetWeb.Router do
   end
 
   scope "/api/postgrest" do
-    pipe_through([:secure_headers, :postgrest_api, :admin_required])
+    pipe_through([:secure_headers, :auth_optional, :postgrest_api, :admin_required])
     forward("/", ReverseProxyPlug, upstream: "http://localhost:3000")
   end
 

--- a/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
+++ b/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
@@ -1,0 +1,21 @@
+defmodule Ret.Repo.Migrations.AddImportedFromColumns do
+  use Ecto.Migration
+
+  def change do
+    alter table("avatars") do
+      add(:imported_from_host, :string)
+      add(:imported_from_port, :integer)
+      add(:imported_from_sid, :string)
+    end
+
+    create(index(:avatars, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true))
+
+    alter table("scenes") do
+      add(:imported_from_host, :string)
+      add(:imported_from_port, :integer)
+      add(:imported_from_sid, :string)
+    end
+
+    create(index(:scenes, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true))
+  end
+end

--- a/priv/repo/migrations/20191015184128_add_fk_lookup_on_listings.exs
+++ b/priv/repo/migrations/20191015184128_add_fk_lookup_on_listings.exs
@@ -1,0 +1,62 @@
+defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
+  use Ecto.Migration
+
+  def up do
+    # Move extra-columns to the end since otherwise we can't add new ones
+    execute("""
+      create or replace function ret0_admin.create_or_replace_admin_view(
+      name text,
+      extra_columns text default '',
+      extra_clauses text default ''
+    )
+    returns void as
+    $$
+    declare
+    pk character varying(255);
+    begin
+
+    -- Get the primary key
+    SELECT
+      pg_attribute.attname into pk
+    FROM pg_index, pg_class, pg_attribute, pg_namespace
+    WHERE
+      pg_class.oid = ('ret0.' || name)::regclass AND
+      indrelid = pg_class.oid AND
+      nspname = 'ret0' AND
+      pg_class.relnamespace = pg_namespace.oid AND
+      pg_attribute.attrelid = pg_class.oid AND
+      pg_attribute.attnum = any(pg_index.indkey)
+     AND indisprimary;
+
+    -- Create a view with the primary key renamed to id 
+    execute 'create or replace view ret0_admin.' || name
+    || ' as (select ' || pk || ' as id, '
+    || ' cast(' || pk || ' as varchar) as _text_id, '
+    || array_to_string(ARRAY(SELECT 'o' || '.' || c.column_name
+            FROM information_schema.columns As c
+                WHERE table_name = name AND table_schema = 'ret0'
+                AND  c.column_name NOT IN(pk)
+        ), ',') || extra_columns ||
+    				' from ret0.' || name || ' as o ' || extra_clauses || ')';
+
+    end
+
+    $$ language plpgsql;
+    """)
+
+    execute(
+      "select ret0_admin.create_or_replace_admin_view('avatar_listings', ',cast(avatar_id as varchar) as _avatar_id')"
+    )
+
+    execute("grant select, insert, update on ret0_admin.avatar_listings to ret_admin;")
+
+    execute(
+      "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
+    )
+
+    execute("grant select, insert, update on ret0_admin.scene_listings to ret_admin;")
+  end
+
+  def down do
+  end
+end

--- a/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
+++ b/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
@@ -2,7 +2,7 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
   use Ecto.Migration
 
   def up do
-    # Drops scene listings view and featured scenes view
+    # Drops scene listings view and featured, pending scenes view
     execute("drop view ret0_admin.scene_listings cascade")
 
     # Hosted spoke won't necessarily fill this file in
@@ -30,6 +30,18 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
     """)
 
     execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+
+    execute("""
+    create or replace view ret0_admin.pending_scenes as (
+    		select scenes.id, scene_sid, scenes.slug, scenes.name, scenes.description, scenes.screenshot_owned_file_id, scenes.model_owned_file_id, scenes.scene_owned_file_id, 
+    		scenes.attributions, scene_listings.id as scene_listing_id, scenes.updated_at, scenes.allow_remixing as _allow_remixing, scenes.allow_promotion as _allow_promotion
+    		from ret0_admin.scenes
+    		left outer join ret0_admin.scene_listings on scene_listings.scene_id = scenes.id
+    		where ((scenes.reviewed_at is null or scenes.reviewed_at < scenes.updated_at) and scenes.allow_promotion and scenes.state = 'active')
+    );
+    """)
+
+    execute("grant select on ret0_admin.pending_scenes to ret_admin;")
   end
 
   def down do
@@ -57,5 +69,17 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
     """)
 
     execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+
+    execute("""
+    create or replace view ret0_admin.pending_scenes as (
+    		select scenes.id, scene_sid, scenes.slug, scenes.name, scenes.description, scenes.screenshot_owned_file_id, scenes.model_owned_file_id, scenes.scene_owned_file_id, 
+    		scenes.attributions, scene_listings.id as scene_listing_id, scenes.updated_at, scenes.allow_remixing as _allow_remixing, scenes.allow_promotion as _allow_promotion
+    		from ret0_admin.scenes
+    		left outer join ret0_admin.scene_listings on scene_listings.scene_id = scenes.id
+    		where ((scenes.reviewed_at is null or scenes.reviewed_at < scenes.updated_at) and scenes.allow_promotion and scenes.state = 'active')
+    );
+    """)
+
+    execute("grant select on ret0_admin.pending_scenes to ret_admin;")
   end
 end

--- a/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
+++ b/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
@@ -1,0 +1,61 @@
+defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
+  use Ecto.Migration
+
+  def up do
+    # Drops scene listings view and featured scenes view
+    execute("drop view ret0_admin.scene_listings cascade")
+
+    # Hosted spoke won't necessarily fill this file in
+
+    alter table("scene_listings") do
+      modify(:scene_owned_file_id, :bigint, null: true)
+    end
+
+    # Re-create views
+    execute(
+      "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
+    )
+
+    execute("grant select, insert, update on ret0_admin.scene_listings to ret_admin;")
+
+    execute("""
+    create or replace view ret0_admin.featured_scene_listings as (
+    select id, scene_listing_sid, slug, name, description, screenshot_owned_file_id, model_owned_file_id, scene_owned_file_id, attributions, scene_listings.order, tags
+    from ret0_admin.scene_listings
+    where 
+    state = 'active' and
+    tags->'tags' ? 'featured' and
+    exists (select id from ret0_admin.scenes s where s.id = scene_listings.scene_id and s.state = 'active' and s.allow_promotion)
+    );
+    """)
+
+    execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+  end
+
+  def down do
+    execute("drop view ret0_admin.scene_listings cascade")
+
+    alter table("scene_listings") do
+      modify(:scene_owned_file_id, :bigint, null: false)
+    end
+
+    execute(
+      "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
+    )
+
+    execute("grant select, insert, update on ret0_admin.scene_listings to ret_admin;")
+
+    execute("""
+    create or replace view ret0_admin.featured_scene_listings as (
+    select id, scene_listing_sid, slug, name, description, screenshot_owned_file_id, model_owned_file_id, scene_owned_file_id, attributions, scene_listings.order, tags
+    from ret0_admin.scene_listings
+    where 
+    state = 'active' and
+    tags->'tags' ? 'featured' and
+    exists (select id from ret0_admin.scenes s where s.id = scene_listings.scene_id and s.state = 'active' and s.allow_promotion)
+    );
+    """)
+
+    execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+  end
+end


### PR DESCRIPTION
This PR:
- Adds import data tracking, so that if you import the same URL twice, we update the existing avatar/scene, don't create a new one
- Fixes up the view on avatar and scene listings to enable admin console features
- Fixes some bugs stemming from the ordering of functions and matching in avatar.ex preventing some avatars from being imported
- Makes scene project files on scenes nullable, and updates the importer to import them if they are there (@netpro2k not sure if you skipped these for a reason?)