### PR TITLE
Remove idle database accesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Run the following commands at the root of the reticulum directory:
 4. from the `assets` directory, `npm install`
 
 ### Start Reticulum
-Run `mix phx.server`
+Run `scripts/run.sh` if you have the hubs secret repo cloned. Otherwise `iex -S mix phx.server`
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -194,6 +194,14 @@ config :ret, Ret.HttpUtils, insecure_ssl: true
 
 config :ret, Ret.Meta, phx_host: host
 
-config :ret, Ret.Locking, lock_timeout_ms: 1000 * 60 * 15
+config :ret, Ret.Locking,
+  lock_timeout_ms: 1000 * 60 * 15,
+  session_lock_db: [
+    username: "postgres",
+    password: "postgres",
+    database: "ret_dev",
+    hostname: if(env_db_host == "", do: "localhost", else: env_db_host)
+  ]
+
 config :ret, Ret.Repo.Migrations.AdminSchemaInit, postgrest_password: "password"
 config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -196,3 +196,4 @@ config :ret, Ret.Meta, phx_host: host
 
 config :ret, Ret.Locking, lock_timeout_ms: 1000 * 60 * 15
 config :ret, Ret.Repo.Migrations.AdminSchemaInit, postgrest_password: "password"
+config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -132,4 +132,11 @@ config :ret, Ret.JanusLoadStatus, janus_port: 443
 config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false
 
 # Default repo check and page check to off so for polycosm hosts database + s3 hits can go idle
-config :ret, RetWeb.HealthController, check_repo: false
+config :ret, RetWeb.HealthController,
+  check_repo: false,
+  session_lock_db: [
+    username: "postgres",
+    password: "postgres",
+    database: "ret_production",
+    hostname: "localhost"
+  ]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -98,9 +98,9 @@ config :ret, Ret.Scheduler,
     {{:cron, "0 10 * * *"}, {Ret.Storage, :vacuum, []}},
     {{:cron, "5 10 * * *"}, {Ret.Storage, :demote_inactive_owned_files, []}},
     {{:cron, "10 10 * * *"}, {Ret.LoginToken, :expire_stale, []}},
-    {{:cron, "15 10 * * *"}, {Ret.Hub, :vacuum_entry_codes, []}},
-    {{:cron, "20 10 * * *"}, {Ret.Hub, :vacuum_hosts, []}},
-    {{:cron, "25 10 * * *"}, {Ret.CachedFile, :vacuum, []}}
+    {{:cron, "11 10 * * *"}, {Ret.Hub, :vacuum_entry_codes, []}},
+    {{:cron, "12 10 * * *"}, {Ret.Hub, :vacuum_hosts, []}},
+    {{:cron, "13 10 * * *"}, {Ret.CachedFile, :vacuum, []}}
   ]
 
 config :ret, RetWeb.Plugs.HeaderAuthorization, header_name: "x-ret-admin-access-key"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -34,6 +34,8 @@ config :ret, Ret.Repo,
   database: "ret_production",
   hostname: "localhost",
   template: "template0",
+  # Disable prepared queries bc of pgbouncer
+  prepare: :unnamed,
   pool_size: 10
 
 # ## SSL Support

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -125,18 +125,20 @@ config :sentry,
   }
 
 config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
-config :ret, Ret.Locking, lock_timeout_ms: 1000 * 60 * 15
-config :ret, Ret.JanusLoadStatus, janus_port: 443
 
-# Default stats job to off so for polycosm hosts the database can go idle
-config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false
-
-# Default repo check and page check to off so for polycosm hosts database + s3 hits can go idle
-config :ret, RetWeb.HealthController,
-  check_repo: false,
+config :ret, Ret.Locking,
+  lock_timeout_ms: 1000 * 60 * 15,
   session_lock_db: [
     username: "postgres",
     password: "postgres",
     database: "ret_production",
     hostname: "localhost"
   ]
+
+config :ret, Ret.JanusLoadStatus, janus_port: 443
+
+# Default stats job to off so for polycosm hosts the database can go idle
+config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false
+
+# Default repo check and page check to off so for polycosm hosts database + s3 hits can go idle
+config :ret, RetWeb.HealthController, check_repo: false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -127,3 +127,9 @@ config :sentry,
 config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
 config :ret, Ret.Locking, lock_timeout_ms: 1000 * 60 * 15
 config :ret, Ret.JanusLoadStatus, janus_port: 443
+
+# Default stats job to off so for polycosm hosts the database can go idle
+config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false
+
+# Default repo check and page check to off so for polycosm hosts database + s3 hits can go idle
+config :ret, RetWeb.HealthController, check_repo: false, check_pages: false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -34,8 +34,6 @@ config :ret, Ret.Repo,
   database: "ret_production",
   hostname: "localhost",
   template: "template0",
-  # Disable prepared queries bc of pgbouncer
-  prepare: :unnamed,
   pool_size: 10
 
 # ## SSL Support
@@ -82,7 +80,9 @@ import_config "prod.secret.exs"
 
 # Filter out media search API params
 config :phoenix, :filter_parameters, ["q", "filter", "cursor"]
-config :ret, Ret.Repo, adapter: Ecto.Adapters.Postgres
+
+# Disable prepared queries bc of pgbouncer
+config :ret, Ret.Repo, adapter: Ecto.Adapters.Postgres, prepare: :unnamed
 
 config :peerage, via: Ret.PeerageProvider
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -132,4 +132,4 @@ config :ret, Ret.JanusLoadStatus, janus_port: 443
 config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false
 
 # Default repo check and page check to off so for polycosm hosts database + s3 hits can go idle
-config :ret, RetWeb.HealthController, check_repo: false, check_pages: false
+config :ret, RetWeb.HealthController, check_repo: false

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -59,6 +59,12 @@ hostname = "{{ cfg.db.hostname }}"
 template = "{{ cfg.db.template }}"
 pool_size = {{ cfg.db.pool_size }}
 
+[ret."Elixir.Ret.Locking".session_lock_db]
+username = "{{ cfg.session_lock_db.username }}"
+password = "{{ cfg.session_lock_db.password }}"
+database = "{{ cfg.session_lock_db.database }}"
+hostname = "{{ cfg.session_lock_db.hostname }}"
+
 [ret."Elixir.Ret.Habitat"]
 ip = "{{ cfg.habitat.ip }}"
 http_port = {{ cfg.habitat.http_port }}

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -130,6 +130,14 @@ content_security_policy = "{{ cfg.security.content_security_policy }}"
 [ret."Ret.Repo.Migrations.AdminSchemaInit"]
 postgrest_password = "{{ cfg.db.postgrest_password }}"
 
+[ret."Elixir.Ret.StatsJob"]
+{{#if cfg.stats.node_stats_enabled }}
+node_stats_enabled = {{ cfg.stats.node_stats_enabled }}
+{{/if}}
+{{#if cfg.stats.node_gauges_enabled }}
+node_gauges_enabled = {{ cfg.stats.node_gauges_enabled }}
+{{/if}}
+
 [web_push_encryption.vapid_details]
 subject = "{{ cfg.web_push.subject }}"
 public_key = "{{ cfg.web_push.public_key }}"

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -58,6 +58,9 @@ database = "{{ cfg.db.database }}"
 hostname = "{{ cfg.db.hostname }}"
 template = "{{ cfg.db.template }}"
 pool_size = {{ cfg.db.pool_size }}
+{{#if cfg.db.idle_interval }}
+idle_interval = {{ cfg.db.idle_interval }}
+{{/if}}
 
 [ret."Elixir.Ret.Locking".session_lock_db]
 username = "{{ cfg.session_lock_db.username }}"

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -144,6 +144,11 @@ node_stats_enabled = {{ cfg.stats.node_stats_enabled }}
 node_gauges_enabled = {{ cfg.stats.node_gauges_enabled }}
 {{/if}}
 
+[ret."Elixir.RetWeb.HealthController"]
+{{#if cfg.health.check_repo }}
+check_repo = {{ cfg.health.check_repo }}
+{{/if}}
+
 [web_push_encryption.vapid_details]
 subject = "{{ cfg.web_push.subject }}"
 public_key = "{{ cfg.web_push.public_key }}"

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -3,6 +3,12 @@
 set -e
 exec 2>&1
 
+# If ita is running, wait for services to be configured before starting.
+if [[ -d "/hab/svc/ita" && ! -f "/hab/svc/ita/var/ready" ]] ; then
+    echo "ita found but not ready. exiting."
+    exit 1
+fi
+
 export HOME={{ pkg.svc_var_path }}
 export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 export REPLACE_OS_VARS=true # Inlines OS vars into vm args

--- a/lib/ret/app_config.ex
+++ b/lib/ret/app_config.ex
@@ -33,8 +33,8 @@ defmodule Ret.AppConfig do
     |> unique_constraint(:key)
   end
 
-  def get_config() do
-    {:commit, config} = Cachex.fetch(:app_config, "")
+  def get_config(skip_cache \\ false) do
+    {:commit, config} = if skip_cache do fetch_config("") else Cachex.fetch(:app_config, "") end 
     config
   end
 

--- a/lib/ret/app_config.ex
+++ b/lib/ret/app_config.ex
@@ -1,5 +1,4 @@
 defmodule Ret.AppConfig do
-  use Cachex.Warmer
   use Ecto.Schema
   import Ecto.Changeset
 
@@ -16,10 +15,6 @@ defmodule Ret.AppConfig do
   end
 
   def interval, do: :timer.seconds(15)
-
-  def execute(_state) do
-    {:ok, [{:app_config, get_config()}]}
-  end
 
   def changeset(%AppConfig{} = app_config, key, %OwnedFile{} = owned_file) do
     app_config
@@ -39,18 +34,19 @@ defmodule Ret.AppConfig do
   end
 
   def get_config() do
-    try do
+    {:commit, config} = Cachex.fetch(:app_config, "")
+    config
+  end
+
+  def fetch_config(_arg) do
+    config =
       AppConfig
       |> Repo.all()
       |> Repo.preload(:owned_file)
       |> Enum.map(fn app_config -> expand_key(app_config.key, app_config) end)
       |> Enum.reduce(%{}, fn config, acc -> deep_merge(acc, config) end)
-    rescue
-      # The page warmer fetches configs on startup, so we don't want to block startup if this fails.
-      # e.g. It will definitely fail the very first time since DB migrations need to run before configs
-      # are available.
-      _ -> %{}
-    end
+
+    {:commit, config}
   end
 
   defp expand_key(key, app_config) do

--- a/lib/ret/application.ex
+++ b/lib/ret/application.ex
@@ -80,7 +80,8 @@ defmodule Ret.Application do
         [
           :app_config,
           [
-            warmers: [warmer(module: Ret.AppConfig)]
+            expiration: expiration(default: :timer.seconds(10)),
+            fallback: fallback(default: &Ret.AppConfig.fetch_config/1)
           ]
         ],
         id: :app_config_cache

--- a/lib/ret/jobs/stats_job.ex
+++ b/lib/ret/jobs/stats_job.ex
@@ -2,23 +2,31 @@ defmodule Ret.StatsJob do
   alias Ret.{Repo, NodeStat}
 
   def send_statsd_gauges do
-    Ret.Statix.send_gauges()
+    if module_config(:node_gauges_enabled) do
+      Ret.Statix.send_gauges()
+    end
   end
 
   def save_node_stats do
-    {:ok, _} =
-      with node_id <- Node.self() |> to_string,
-           measured_at <- NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-           present_sessions <- RetWeb.Presence.present_session_count(),
-           present_rooms <- RetWeb.Presence.present_room_count() do
-        %NodeStat{}
-        |> NodeStat.changeset(%{
-          node_id: node_id,
-          measured_at: measured_at,
-          present_sessions: present_sessions,
-          present_rooms: present_rooms
-        })
-        |> Repo.insert()
-      end
+    if module_config(:node_stats_enabled) do
+      {:ok, _} =
+        with node_id <- Node.self() |> to_string,
+             measured_at <- NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
+             present_sessions <- RetWeb.Presence.present_session_count(),
+             present_rooms <- RetWeb.Presence.present_room_count() do
+          %NodeStat{}
+          |> NodeStat.changeset(%{
+            node_id: node_id,
+            measured_at: measured_at,
+            present_sessions: present_sessions,
+            present_rooms: present_rooms
+          })
+          |> Repo.insert()
+        end
+    end
+  end
+
+  defp module_config(key) do
+    Application.get_env(:ret, __MODULE__)[key]
   end
 end

--- a/lib/ret/load_balancing/janus_load_status.ex
+++ b/lib/ret/load_balancing/janus_load_status.ex
@@ -14,7 +14,7 @@ defmodule Ret.JanusLoadStatus do
           module_config(:janus_service_name)
           |> Ret.Habitat.get_service_members()
           |> Enum.map(fn {host, ip} -> Task.async(fn -> {host, janus_ip_to_ccu(ip)} end) end)
-          |> Enum.map(&Task.await(&1, 30_000))
+          |> Enum.map(&Task.await(&1, 10_000))
 
         {:ok, [{:host_to_ccu, entries}]}
     end

--- a/lib/ret/locking.ex
+++ b/lib/ret/locking.ex
@@ -1,20 +1,27 @@
 defmodule Ret.Locking do
   alias Ret.Repo
 
-  def exec_after_session_lock(lock_name, exec) do
-    Repo.checkout(
-      fn ->
-        <<lock_key::little-signed-integer-size(64), _::binary>> = :crypto.hash(:sha256, lock_name |> to_string)
-        %Postgrex.Result{rows: [[:void]]} = Ecto.Adapters.SQL.query!(Repo, "select pg_advisory_lock($1);", [lock_key])
+  def exec_if_session_lockable(lock_name, exec) do
+    [username: username, password: password, database: database, hostname: hostname] = module_config(:session_lock_db)
+    {:ok, pid} = Postgrex.start_link(hostname: hostname, username: username, password: password, database: database)
 
-        try do
-          exec.()
-        after
-          Ecto.Adapters.SQL.query!(Repo, "select pg_advisory_unlock($1);", [lock_key])
-        end
-      end,
-      []
-    )
+    try do
+      <<lock_key::little-signed-integer-size(64), _::binary>> = :crypto.hash(:sha256, lock_name |> to_string)
+
+      case Postgrex.query!(pid, "select pg_try_advisory_lock($1)", [lock_key]) do
+        %Postgrex.Result{rows: [[true]]} ->
+          try do
+            exec.()
+          after
+            Postgrex.query!(pid, "select pg_advisory_unlock($1)", [lock_key])
+          end
+
+        _ ->
+          nil
+      end
+    after
+      GenServer.stop(pid)
+    end
   end
 
   def exec_if_lockable(lock_name, exec) do

--- a/lib/ret/locking.ex
+++ b/lib/ret/locking.ex
@@ -2,7 +2,12 @@ defmodule Ret.Locking do
   alias Ret.Repo
 
   def exec_if_session_lockable(lock_name, exec) do
-    [username: username, password: password, database: database, hostname: hostname] = module_config(:session_lock_db)
+    session_lock_db_config = module_config(:session_lock_db)
+    hostname = session_lock_db_config |> Keyword.get(:hostname)
+    username = session_lock_db_config |> Keyword.get(:username)
+    password = session_lock_db_config |> Keyword.get(:password)
+    database = session_lock_db_config |> Keyword.get(:database)
+
     {:ok, pid} = Postgrex.start_link(hostname: hostname, username: username, password: password, database: database)
 
     try do

--- a/lib/ret/page_origin_warmer.ex
+++ b/lib/ret/page_origin_warmer.ex
@@ -83,7 +83,6 @@ defmodule Ret.PageOriginWarmer do
   end
 
   defp page_to_etag(source, page) do
-    # Split the HTML file into two parts, on the line that contains HUB_META_TAGS, so we can add meta tags
     case "#{module_config(config_key_for_source(source))}/#{page}"
          |> retry_head_until_success do
       :error ->

--- a/lib/ret/release_tasks.ex
+++ b/lib/ret/release_tasks.ex
@@ -2,7 +2,7 @@ defmodule Ret.ReleaseTasks do
   def migrate do
     {:ok, _} = Application.ensure_all_started(:ret)
 
-    Ret.Locking.exec_after_session_lock("ret_migration", fn ->
+    Ret.Locking.exec_if_session_lockable("ret_migration", fn ->
       Ecto.Migrator.run(Ret.Repo, migrations_path(:ret), :up, all: true)
     end)
   end

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -8,6 +8,7 @@ defmodule RetWeb.HealthController do
       from(h in Ret.Hub, limit: 0) |> Ret.Repo.all()
     end
 
+    # Check page cache
     true = Cachex.get(:page_chunks, {:hubs, "index.html"}) |> elem(1) |> Enum.count() > 0
     true = Cachex.get(:page_chunks, {:hubs, "hub.html"}) |> elem(1) |> Enum.count() > 0
     true = Cachex.get(:page_chunks, {:spoke, "index.html"}) |> elem(1) |> Enum.count() > 0

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -8,12 +8,9 @@ defmodule RetWeb.HealthController do
       from(h in Ret.Hub, limit: 0) |> Ret.Repo.all()
     end
 
-    # Check page cache
-    if module_config(:check_pages) do
-      true = Cachex.get(:page_chunks, {:hubs, "index.html"}) |> elem(1) |> Enum.count() > 0
-      true = Cachex.get(:page_chunks, {:hubs, "hub.html"}) |> elem(1) |> Enum.count() > 0
-      true = Cachex.get(:page_chunks, {:spoke, "index.html"}) |> elem(1) |> Enum.count() > 0
-    end
+    true = Cachex.get(:page_chunks, {:hubs, "index.html"}) |> elem(1) |> Enum.count() > 0
+    true = Cachex.get(:page_chunks, {:hubs, "hub.html"}) |> elem(1) |> Enum.count() > 0
+    true = Cachex.get(:page_chunks, {:spoke, "index.html"}) |> elem(1) |> Enum.count() > 0
 
     # Check room routing
     true = Ret.RoomAssigner.get_available_host("") != nil

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -4,16 +4,24 @@ defmodule RetWeb.HealthController do
 
   def index(conn, _params) do
     # Check database
-    from(h in Ret.Hub, limit: 0) |> Ret.Repo.all()
+    if module_config(:check_repo) do
+      from(h in Ret.Hub, limit: 0) |> Ret.Repo.all()
+    end
 
     # Check page cache
-    true = Cachex.get(:page_chunks, {:hubs, "index.html"}) |> elem(1) |> Enum.count() > 0
-    true = Cachex.get(:page_chunks, {:hubs, "hub.html"}) |> elem(1) |> Enum.count() > 0
-    true = Cachex.get(:page_chunks, {:spoke, "index.html"}) |> elem(1) |> Enum.count() > 0
+    if module_config(:check_pages) do
+      true = Cachex.get(:page_chunks, {:hubs, "index.html"}) |> elem(1) |> Enum.count() > 0
+      true = Cachex.get(:page_chunks, {:hubs, "hub.html"}) |> elem(1) |> Enum.count() > 0
+      true = Cachex.get(:page_chunks, {:spoke, "index.html"}) |> elem(1) |> Enum.count() > 0
+    end
 
     # Check room routing
     true = Ret.RoomAssigner.get_available_host("") != nil
 
     send_resp(conn, 200, "ok")
+  end
+
+  defp module_config(key) do
+    Application.get_env(:ret, __MODULE__)[key]
   end
 end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -221,13 +221,7 @@ defmodule RetWeb.PageController do
   end
 
   defp generate_app_config() do
-    app_config =
-      if module_config(:skip_cache) do
-        Ret.AppConfig.get_config()
-      else
-        {:ok, app_config} = Cachex.get(:app_config, :app_config)
-        app_config
-      end
+    app_config = Ret.AppConfig.get_config(!!module_config(:skip_cache))
 
     app_config_json = app_config |> Poison.encode!()
     app_config_script = "window.APP_CONFIG = JSON.parse('#{app_config_json |> String.replace("'", "\\'")}')"

--- a/lib/ret_web/plugs/redirect_to_main_domain.ex
+++ b/lib/ret_web/plugs/redirect_to_main_domain.ex
@@ -28,7 +28,7 @@ defmodule RetWeb.Plugs.RedirectToMainDomain do
     end
   end
 
-  defp matches_host(conn, nil), do: false
-  defp matches_host(conn, ""), do: false
+  defp matches_host(_conn, nil), do: false
+  defp matches_host(_conn, ""), do: false
   defp matches_host(conn, host), do: Regex.match?(~r/\A#{conn.host}\z/i, host)
 end

--- a/priv/repo/migrations/20180408231444_create_session_stats_table.exs
+++ b/priv/repo/migrations/20180408231444_create_session_stats_table.exs
@@ -1,7 +1,7 @@
 defmodule Ret.Repo.Migrations.CreateSessionStatsTable do
   use Ecto.Migration
 
-  @max_year 2022
+  @max_year 2030
 
   def up do
     create table(
@@ -21,10 +21,8 @@ defmodule Ret.Repo.Migrations.CreateSessionStatsTable do
         month <- 0..11 do
       with end_month <- rem(month + 1, 12),
            end_year <- if(month == 11, do: year + 1, else: year) do
-        execute(
-          "create table ret0.session_stats_y#{year}_m#{month + 1} partition of session_stats
-                 for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')"
-        )
+        execute("create table ret0.session_stats_y#{year}_m#{month + 1} partition of session_stats
+                 for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')")
       end
     end
   end


### PR DESCRIPTION
In order to minimize AWS costs we need to ensure the database is completely disconnected from when the service is not in-use. To do so, we now run pgbouncer on each reticulum node for polycosm hosts, which serves as a connection pooler, and connect reticulum to pgbouncer over localhost. The reason being that pgbouncer will gracefully disconnect from the database if no transactions are being run if you use `transaction` scoped pooling. This is not possible to do natively in ecto -- ecto will just hold the connections open permanently while phoenix is running.

So the net goal of this PR is to a) deal with any issues stemming from the use of pgbouncer and b) remove all background jobs that would normally otherwise hit the database.

- First, pgbouncer's `transaction` scoped connection pooling is fundamentally incompatible with session-wide advisory locks and prepared statements. Prepared statements are flipped off. For session advisory locks, we currently use them in order to have a lock on which node is performing the database migration. As such, we expose a *second* logical database from pgbouncer which uses `sesssion` scoped connection pooling, for the explicit purpose of using it to get sane session-wide advisory locks. It's critical that these connections be active only while the lock is in use, and disconnected once the lock is freed. The code is updated to use this alternative database for session locking. (the transaction-level advisory locks we use everywhere else remain safe to use in pgbouncer.) In our prod infra, we can just use the same connection settings for both, since we don't have any issues with session advisory locks outside of pgbouncer.

- the app config proactive warmer is removed and now is reactively warmed, so if no traffic is hitting the server we do not keep materializing the config out of the db.

- the stats job now is disabled by default, which otherwise would normally be writing node stats to the database every 5 minutes.

- the cron jobs are tightened up in time to minimize the duration the database is hot

- the health check no longer hits the db by default

- the page origin warmer doesn't hit the db, but ends up doing a non-trivial amount of requests and data transfer to s3. moving this to a reactive warmer seemed like a bad idea because of the cold case, but i ended up updating it so that now HEAD requests + etags are used to detect if anything has changed at the origin before doing the crawl, which should cut out most of the data transfer cost.

- noticed the janus status warmer was awaiting longer than its interval, which could lead to a pile-up, so shortened it.

- pushed out the # of stat table migrations to 2030, just in case we want to allow people to turn them back on at some point.
