### PR TITLE
Scene Remixing and Project publish endpoint

### DIFF
--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -263,7 +263,7 @@ defmodule Ret.Avatar do
       |> Avatar.changeset(account, owned_files_map, nil, nil, %{
         name: remote_avatar["name"],
         description: remote_avatar["description"],
-        attributions: remote_avatar["attribution"],
+        attributions: remote_avatar["attributions"],
         allow_remixing: remote_avatar["allow_remixing"],
         imported_from_host: imported_from_host,
         imported_from_port: imported_from_port,

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -33,6 +33,10 @@ defmodule Ret.MediaSearch do
     scene_listing_search(cursor, query, "featured", asc: :order)
   end
 
+  def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: "remixable", q: query}) do
+    scene_listing_remixable_search(cursor, query)
+  end
+
   def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: filter, q: query}) do
     scene_listing_search(cursor, query, filter)
   end
@@ -540,6 +544,22 @@ defmodule Ret.MediaSearch do
       |> order_by(^order)
       |> Repo.paginate(%{page: page_number, page_size: @page_size})
       |> result_for_page(page_number, :avatar_listings, &avatar_listing_to_entry/1)
+
+    {:commit, results}
+  end
+
+  defp scene_listing_remixable_search(cursor, query, order \\ [desc: :updated_at]) do
+    page_number = (cursor || "1") |> Integer.parse() |> elem(0)
+
+    results =
+      SceneListing
+      |> join(:inner, [l], s in assoc(l, :scene))
+      |> where([l, s], l.state == ^"active" and s.state == ^"active" and s.allow_promotion == ^true and s.allow_remixing == ^true)
+      |> add_query_to_listing_search_query(query)
+      |> preload([:screenshot_owned_file, :model_owned_file, :scene_owned_file])
+      |> order_by(^order)
+      |> Repo.paginate(%{page: page_number, page_size: @scene_page_size})
+      |> result_for_page(page_number, :scene_listings, &scene_or_scene_listing_to_entry/1)
 
     {:commit, results}
   end

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -635,10 +635,14 @@ defmodule Ret.MediaSearch do
     }
   end
 
-  defp scene_or_scene_listing_to_entry(%Scene{} = scene), do: scene_or_scene_listing_to_entry(scene, "scene")
+  defp scene_or_scene_listing_to_entry(%Scene{} = s) do
+    scene_or_scene_listing_to_entry(s, "scene") |> Map.put(:allow_remixing, s.allow_remixing)
+  end
 
-  defp scene_or_scene_listing_to_entry(%SceneListing{} = scene),
-    do: scene_or_scene_listing_to_entry(scene, "scene_listing")
+  defp scene_or_scene_listing_to_entry(%SceneListing{} = s) do
+    scene_or_scene_listing_to_entry(s, "scene_listings")
+    |> Map.put(:allow_remixing, s.scene !== nil and s.scene.allow_remixing)
+  end
 
   defp scene_or_scene_listing_to_entry(s, type) do
     %{

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -49,6 +49,12 @@ defmodule Ret.Project do
     |> Repo.insert
   end
 
+  def add_scene_to_project(%Project{} = project, scene) do
+    project
+    |> put_assoc(:scene, scene)
+    |> Repo.update
+  end
+
   # Create a Project
   def changeset(%Project{} = project, account, params \\ %{}) do
     project

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -3,7 +3,7 @@ defmodule Ret.Project do
   import Ecto.Changeset
   import Ecto.Query
 
-  alias Ret.{Repo, Project, ProjectAsset, OwnedFile}
+  alias Ret.{Repo, Project, ProjectAsset, Scene, OwnedFile}
 
   @schema_prefix "ret0"
   @primary_key {:project_id, :id, autogenerate: true}
@@ -15,29 +15,32 @@ defmodule Ret.Project do
     belongs_to(:project_owned_file, Ret.OwnedFile, references: :owned_file_id)
     belongs_to(:thumbnail_owned_file, Ret.OwnedFile, references: :owned_file_id)
     many_to_many(:assets, Ret.Asset, join_through: Ret.ProjectAsset, join_keys: [project_id: :project_id, asset_id: :asset_id], on_replace: :delete)
+    belongs_to(:scene, Scene, references: :scene_id, on_replace: :nilify)
 
     timestamps()
   end
 
+  def to_sid(nil), do: nil
+  def to_sid(%Project{} = project), do: project.project_sid
   def to_url(%Project{} = project), do: "#{RetWeb.Endpoint.url()}/projects/#{project.project_sid}"
 
   def project_by_sid(project_sid) do
     Project
     |> Repo.get_by(project_sid: project_sid)
-    |> Repo.preload([:created_by_account, :project_owned_file, :thumbnail_owned_file])
+    |> Repo.preload([:created_by_account, :project_owned_file, :thumbnail_owned_file, :scene])
   end
 
   def project_by_sid_for_account(project_sid, account) do
     from(p in Project,
       where: p.project_sid == ^project_sid and p.created_by_account_id == ^account.account_id,
-      preload: [:created_by_account, :project_owned_file, :thumbnail_owned_file, assets: [:asset_owned_file, :thumbnail_owned_file]])
+      preload: [:created_by_account, :project_owned_file, :thumbnail_owned_file, :scene, assets: [:asset_owned_file, :thumbnail_owned_file]])
     |> Repo.one
   end
 
   def projects_for_account(account) do
     Repo.all from p in Project,
       where: p.created_by_account_id == ^account.account_id,
-      preload: [:project_owned_file, :thumbnail_owned_file]
+      preload: [:project_owned_file, :thumbnail_owned_file, :scene]
   end
 
   def add_asset_to_project(project, asset) do
@@ -65,6 +68,12 @@ defmodule Ret.Project do
     |> changeset(account, params)
     |> put_change(:project_owned_file_id, project_owned_file.owned_file_id)
     |> put_change(:thumbnail_owned_file_id, thumbnail_owned_file.owned_file_id)
+  end
+
+  def changeset(%Project{} = project, account, %OwnedFile{} = project_owned_file, %OwnedFile{} = thumbnail_owned_file, scene, params) do
+    project
+    |> changeset(account, params)
+    |> put_assoc(:scene, scene)
   end
 
   defp maybe_add_project_sid_to_changeset(changeset) do

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -43,7 +43,7 @@ defmodule Ret.Project do
         :created_by_account,
         :project_owned_file,
         :thumbnail_owned_file,
-        :scene,
+        scene: [:account, :model_owned_file, :screenshot_owned_file, :scene_owned_file],
         assets: [:asset_owned_file, :thumbnail_owned_file]
       ]
     )
@@ -54,7 +54,11 @@ defmodule Ret.Project do
     Repo.all(
       from(p in Project,
         where: p.created_by_account_id == ^account.account_id,
-        preload: [:project_owned_file, :thumbnail_owned_file, :scene]
+        preload: [
+          :project_owned_file,
+          :thumbnail_owned_file,
+          scene: [:account, :model_owned_file, :screenshot_owned_file, :scene_owned_file]
+        ]
       )
     )
   end

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -78,7 +78,7 @@ defmodule Ret.Project do
 
   def changeset(%Project{} = project, account, %OwnedFile{} = project_owned_file, %OwnedFile{} = thumbnail_owned_file, scene, params) do
     project
-    |> changeset(account, params)
+    |> changeset(account, project_owned_file, thumbnail_owned_file, params)
     |> put_assoc(:scene, scene)
   end
 

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -64,7 +64,7 @@ defmodule Ret.Project do
   end
 
   def add_scene_to_project(%Project{} = project, scene) do
-    project |> put_assoc(:scene, scene) |> Repo.update()
+    project |> change() |> put_assoc(:scene, scene) |> Repo.update()
   end
 
   # Create a Project

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -83,7 +83,8 @@ defmodule Ret.Scene do
           |> Repo.insert!()
 
         %Project{}
-        |> Project.changeset(account, scene_owned_file, screenshot_owned_file, new_scene, %{name: new_scene.name})
+        |> Project.changeset(account, scene_owned_file, screenshot_owned_file, %{name: new_scene.name})
+        |> put_assoc(:scene, new_scene)
         |> Repo.insert!()
 
         new_scene
@@ -179,6 +180,18 @@ defmodule Ret.Scene do
     |> put_assoc(:screenshot_owned_file, screenshot_owned_file)
     |> put_assoc(:scene_owned_file, scene_owned_file)
     |> SceneSlug.maybe_generate_slug()
+  end
+
+  def changeset(
+        %Scene{} = scene,
+        account,
+        model_owned_file,
+        screenshot_owned_file,
+        scene_owned_file,
+        nil = _parent_scene,
+        params
+      ) do
+    changeset(scene, account, model_owned_file, screenshot_owned_file, scene_owned_file, params)
   end
 
   def changeset(

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -10,7 +10,7 @@ defmodule Ret.Scene do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Ret.{Repo, Scene, SceneListing, Storage}
+  alias Ret.{Repo, Scene, SceneListing, Project, Storage}
   alias Ret.Scene.{SceneSlug}
 
   @schema_prefix "ret0"
@@ -30,6 +30,10 @@ defmodule Ret.Scene do
     field(:imported_from_port, :integer)
     field(:imported_from_sid, :string)
 
+    belongs_to(:parent_scene, Scene, references: :scene_id, on_replace: :nilify)
+    belongs_to(:parent_scene_listing, SceneListing, references: :scene_listing_id, on_replace: :nilify)
+    has_one(:project, Project, foreign_key: :scene_id)
+
     belongs_to(:account, Ret.Account, references: :account_id)
     belongs_to(:model_owned_file, Ret.OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:screenshot_owned_file, Ret.OwnedFile, references: :owned_file_id, on_replace: :nilify)
@@ -43,6 +47,7 @@ defmodule Ret.Scene do
     Scene |> Repo.get_by(scene_sid: sid) || SceneListing |> Repo.get_by(scene_listing_sid: sid) |> Repo.preload(:scene)
   end
 
+  def to_sid(nil), do: nil
   def to_sid(%Scene{} = scene), do: scene.scene_sid
   def to_sid(%SceneListing{} = scene_listing), do: scene_listing.scene_listing_sid
   def to_url(%t{} = s) when t in [Scene, SceneListing], do: "#{RetWeb.Endpoint.url()}/scenes/#{s |> to_sid}/#{s.slug}"
@@ -50,6 +55,42 @@ defmodule Ret.Scene do
   defp fetch_remote_scene!(uri) do
     %{body: body} = HTTPoison.get!(uri)
     body |> Poison.decode!() |> get_in(["scenes", Access.at(0)])
+  end
+
+  def new_scene_from_parent_scene(parent_scene, account) do
+    {:ok, model_owned_file} = Storage.duplicate(parent_scene.model_owned_file, account)
+    {:ok, screenshot_owned_file} = Storage.duplicate(parent_scene.screenshot_owned_file, account)
+    {:ok, scene_owned_file} = Storage.duplicate(parent_scene.scene_owned_file, account)
+
+    {:ok, new_scene} =
+      Repo.transaction(fn ->
+        new_scene =
+          %Scene{}
+          |> Scene.changeset(
+            account,
+            model_owned_file,
+            screenshot_owned_file,
+            scene_owned_file,
+            parent_scene,
+            %{
+              name: parent_scene.name,
+              description: parent_scene.description,
+              attributions: parent_scene.attributions,
+              allow_remixing: parent_scene.allow_remixing,
+              allow_promotion: parent_scene.allow_promotion
+            }
+          )
+          |> Repo.insert!()
+
+        new_project =
+          %Project{}
+          |> Project.changeset(account, scene_owned_file, screenshot_owned_file, new_scene, %{name: new_scene.name})
+          |> Repo.insert!()
+
+        new_scene
+      end)
+
+    new_scene
   end
 
   def import_from_url!(uri, account) do
@@ -74,7 +115,14 @@ defmodule Ret.Scene do
         imported_from_port: imported_from_port,
         imported_from_sid: imported_from_sid
       )
-      |> Repo.preload([:account, :model_owned_file, :screenshot_owned_file, :scene_owned_file])
+      |> Repo.preload([
+        :account,
+        :model_owned_file,
+        :screenshot_owned_file,
+        :scene_owned_file,
+        :parent_scene,
+        :parent_scene_listing
+      ])
 
     # Disallow non-admins from importing if account varies
     if scene && scene.account_id != account.account_id && !account.is_admin do
@@ -86,7 +134,7 @@ defmodule Ret.Scene do
       |> Scene.changeset(account, model_owned_file, screenshot_owned_file, scene_owned_file, %{
         name: remote_scene["name"],
         description: remote_scene["description"],
-        attributions: remote_scene["attribution"],
+        attributions: remote_scene["attributions"],
         allow_remixing: remote_scene["allow_remixing"],
         imported_from_host: imported_from_host,
         imported_from_port: imported_from_port,
@@ -132,6 +180,32 @@ defmodule Ret.Scene do
     |> put_assoc(:screenshot_owned_file, screenshot_owned_file)
     |> put_assoc(:scene_owned_file, scene_owned_file)
     |> SceneSlug.maybe_generate_slug()
+  end
+
+  def changeset(
+        %Scene{} = scene,
+        account,
+        model_owned_file,
+        screenshot_owned_file,
+        scene_owned_file,
+        %Scene{} = parent_scene,
+        params
+      ) do
+    changeset(scene, account, model_owned_file, screenshot_owned_file, scene_owned_file, params)
+    |> put_assoc(:parent_scene, parent_scene)
+  end
+
+  def changeset(
+        %Scene{} = scene,
+        account,
+        model_owned_file,
+        screenshot_owned_file,
+        scene_owned_file,
+        %SceneListing{} = parent_scene_listing,
+        params
+      ) do
+    changeset(scene, account, model_owned_file, screenshot_owned_file, scene_owned_file, params)
+    |> put_assoc(:parent_scene_listing, parent_scene_listing)
   end
 
   def changeset_to_mark_as_reviewed(%Scene{} = scene) do

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -82,10 +82,9 @@ defmodule Ret.Scene do
           )
           |> Repo.insert!()
 
-        new_project =
-          %Project{}
-          |> Project.changeset(account, scene_owned_file, screenshot_owned_file, new_scene, %{name: new_scene.name})
-          |> Repo.insert!()
+        %Project{}
+        |> Project.changeset(account, scene_owned_file, screenshot_owned_file, new_scene, %{name: new_scene.name})
+        |> Repo.insert!()
 
         new_scene
       end)

--- a/lib/ret/scene_listing.ex
+++ b/lib/ret/scene_listing.ex
@@ -28,6 +28,7 @@ defmodule Ret.SceneListing do
     belongs_to(:screenshot_owned_file, Ret.OwnedFile, references: :owned_file_id)
     belongs_to(:scene_owned_file, Ret.OwnedFile, references: :owned_file_id)
     has_one(:account, through: [:scene, :account])
+    has_one(:project, through: [:scene, :project])
     field(:order, :integer)
     field(:state, SceneListing.State)
 

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -7,24 +7,15 @@ defmodule RetWeb.Api.V1.MediaSearchController do
     conn |> render("index.json", results: results)
   end
 
-  def index(conn, %{"source" => "scene_listings", "filter" => "featured"} = params) do
-    {:commit, results} =
-      %Ret.MediaSearchQuery{source: "scene_listings", cursor: params["cursor"] || "1", filter: "featured"}
-      |> Ret.MediaSearch.search()
-
-    conn |> render("index.json", results: results)
-  end
-
-  def index(conn, %{"source" => "scene_listings", "q" => q} = params) do
-    {:commit, results} =
-      %Ret.MediaSearchQuery{source: "scene_listings", cursor: params["cursor"] || "1", q: q} |> Ret.MediaSearch.search()
-
-    conn |> render("index.json", results: results)
-  end
-
   def index(conn, %{"source" => "scene_listings"} = params) do
     {:commit, results} =
-      %Ret.MediaSearchQuery{source: "scene_listings", cursor: params["cursor"] || "1"} |> Ret.MediaSearch.search()
+      %Ret.MediaSearchQuery{
+        source: "scene_listings",
+        q: params["q"],
+        filter: params["filter"],
+        cursor: params["cursor"] || "1"
+      }
+      |> Ret.MediaSearch.search()
 
     conn |> render("index.json", results: results)
   end

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -46,7 +46,7 @@ defmodule RetWeb.Api.V1.ProjectController do
            Storage.promote(promotion_params, account),
          {:ok, project} <-
            project |> Project.changeset(account, project_file, thumbnail_file, params) |> Repo.insert_or_update() do
-      project = Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])
+      project = Repo.preload(project, [:project_owned_file, :thumbnail_owned_file, :scene])
       render(conn, "show.json", project: project)
     else
       {:error, error} -> render_error_json(conn, error)

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -71,7 +71,7 @@ defmodule RetWeb.Api.V1.ProjectController do
     conn |> publish_project(scene_params, project_sid |> Project.project_by_sid_for_account(account), account)
   end
 
-  def publish(conn, %{"project_id" => project_sid}) do
+  def publish(conn, %{"project_id" => _project_sid}) do
     conn |> render_error_json(400, "You must provide a valid scene to publish")
   end
 

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -1,7 +1,7 @@
 defmodule RetWeb.Api.V1.ProjectController do
   use RetWeb, :controller
 
-  alias Ret.{Project, Repo, Storage}
+  alias Ret.{Project, Repo, Storage, Scene}
 
   # Limit to 1 TPS
   plug(RetWeb.Plugs.RateLimit when action in [:create])
@@ -39,11 +39,13 @@ defmodule RetWeb.Api.V1.ProjectController do
   defp create_or_update_project(conn, account, params, project) do
     promotion_params = %{
       project: {params["project_file_id"], params["project_file_token"]},
-      thumbnail: {params["thumbnail_file_id"], params["thumbnail_file_token"]},
+      thumbnail: {params["thumbnail_file_id"], params["thumbnail_file_token"]}
     }
 
-    with %{project: {:ok, project_file}, thumbnail: {:ok, thumbnail_file}} <- Storage.promote(promotion_params, account),
-         {:ok, project} <- project |> Project.changeset(account, project_file, thumbnail_file, params) |> Repo.insert_or_update() do
+    with %{project: {:ok, project_file}, thumbnail: {:ok, thumbnail_file}} <-
+           Storage.promote(promotion_params, account),
+         {:ok, project} <-
+           project |> Project.changeset(account, project_file, thumbnail_file, params) |> Repo.insert_or_update() do
       project = Repo.preload(project, [:project_owned_file, :thumbnail_owned_file])
       render(conn, "show.json", project: project)
     else
@@ -52,7 +54,7 @@ defmodule RetWeb.Api.V1.ProjectController do
     end
   end
 
-  def delete(conn, %{"id" => project_sid }) do
+  def delete(conn, %{"id" => project_sid}) do
     account = Guardian.Plug.current_resource(conn)
 
     with %Project{} = project <- Project.project_by_sid_for_account(project_sid, account),
@@ -62,5 +64,47 @@ defmodule RetWeb.Api.V1.ProjectController do
       {:error, error} -> render_error_json(conn, error)
       nil -> render_error_json(conn, :not_found)
     end
+  end
+
+  def publish(conn, %{"project_id" => project_sid, "scene" => scene_params}) do
+    account = Guardian.Plug.current_resource(conn)
+    conn |> publish_project(scene_params, project_sid |> Project.project_by_sid_for_account(account), account)
+  end
+
+  def publish(conn, %{"project_id" => project_sid}) do
+    conn |> render_error_json(400, "You must provide a valid scene to publish")
+  end
+
+  defp publish_project(conn, _scen_params, _project = nil, _account) do
+    conn |> render_error_json(:not_found)
+  end
+
+  defp publish_project(conn, scene_params, project = %Project{scene: nil}, account) do
+    conn |> publish_project(scene_params, project, %Scene{}, account)
+  end
+
+  defp publish_project(conn, scene_params, project = %Project{scene: scene}, account) do
+    conn |> publish_project(scene_params, project, scene, account)
+  end
+
+  defp publish_project(conn, scene_params, project = %Project{}, scene = %Scene{}, account) do
+    Repo.transaction(fn ->
+      with {:ok, model_owned_file} <-
+             Storage.promote(scene_params["model_file_id"], scene_params["model_file_token"], nil, account),
+           {:ok, screenshot_owned_file} <-
+             Storage.promote(scene_params["screenshot_file_id"], scene_params["screenshot_file_token"], nil, account),
+           {:ok, scene_owned_file} <-
+             Storage.promote(scene_params["scene_file_id"], scene_params["scene_file_token"], nil, account),
+           {:ok, scene} <-
+             scene
+             |> Scene.changeset(account, model_owned_file, screenshot_owned_file, scene_owned_file, scene_params)
+             |> Repo.insert_or_update(),
+           {:ok, project} <- project |> Project.add_scene_to_project(scene) do
+        conn |> render("show.json", project: project)
+      else
+        {:error, :not_found} -> conn |> render_error_json(400, "You must provide a valid model, screenshot, and scene file")
+        {:error, error} -> conn |> render_error_json(error)
+      end
+    end)
   end
 end

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -75,7 +75,7 @@ defmodule RetWeb.Api.V1.ProjectController do
     conn |> render_error_json(400, "You must provide a valid scene to publish")
   end
 
-  defp publish_project(conn, _scen_params, _project = nil, _account) do
+  defp publish_project(conn, _scene_params, _project = nil, _account) do
     conn |> render_error_json(:not_found)
   end
 

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -102,8 +102,11 @@ defmodule RetWeb.Api.V1.ProjectController do
            {:ok, project} <- project |> Project.add_scene_to_project(scene) do
         conn |> render("show.json", project: project)
       else
-        {:error, :not_found} -> conn |> render_error_json(400, "You must provide a valid model, screenshot, and scene file")
-        {:error, error} -> conn |> render_error_json(error)
+        {:error, :not_found} ->
+          conn |> render_error_json(400, "You must provide a valid model, screenshot, and scene file")
+
+        {:error, error} ->
+          conn |> render_error_json(error)
       end
     end)
   end

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -1,10 +1,21 @@
 defmodule RetWeb.Api.V1.ProjectController do
   use RetWeb, :controller
 
-  alias Ret.{Project, Repo, Storage, Scene}
+  alias Ret.{Project, Repo, Storage, Scene, SceneListing}
 
   # Limit to 1 TPS
   plug(RetWeb.Plugs.RateLimit when action in [:create])
+
+  defp preload(project) do
+    project
+    |> Repo.preload([
+      :project_owned_file,
+      :thumbnail_owned_file,
+      scene: [:parent_scene, :parent_scene_listing, :project],
+      parent_scene: [:parent_scene, :parent_scene_listing, :project],
+      parent_scene_listing: [:parent_scene, :parent_scene_listing, :project]
+    ])
+  end
 
   def index(conn, %{} = _params) do
     account = Guardian.Plug.current_resource(conn)
@@ -18,6 +29,18 @@ defmodule RetWeb.Api.V1.ProjectController do
     case Project.project_by_sid_for_account(project_sid, account) do
       %Project{} = project -> render(conn, "show.json", project: project)
       nil -> render_error_json(conn, :not_found)
+    end
+  end
+
+  def create(conn, %{"project" => %{"parent_scene_id" => parent_scene_sid} = params}) do
+    account = Guardian.Plug.current_resource(conn)
+
+    case parent_scene_sid |> Scene.scene_or_scene_listing_by_sid() do
+      %t{} = s when t in [Scene, SceneListing] ->
+        conn |> create_or_update_project(account, params, %Project{}, s)
+
+      _ ->
+        conn |> send_resp(404, "not found")
     end
   end
 
@@ -36,7 +59,7 @@ defmodule RetWeb.Api.V1.ProjectController do
     end
   end
 
-  defp create_or_update_project(conn, account, params, project) do
+  defp create_or_update_project(conn, account, params, project, parent_scene \\ nil) do
     promotion_params = %{
       project: {params["project_file_id"], params["project_file_token"]},
       thumbnail: {params["thumbnail_file_id"], params["thumbnail_file_token"]}
@@ -45,8 +68,11 @@ defmodule RetWeb.Api.V1.ProjectController do
     with %{project: {:ok, project_file}, thumbnail: {:ok, thumbnail_file}} <-
            Storage.promote(promotion_params, account),
          {:ok, project} <-
-           project |> Project.changeset(account, project_file, thumbnail_file, params) |> Repo.insert_or_update() do
-      project = Repo.preload(project, [:project_owned_file, :thumbnail_owned_file, :scene])
+           project
+           |> Project.changeset(account, project_file, thumbnail_file, parent_scene, params)
+           |> Repo.insert_or_update() do
+      project = project |> preload()
+
       render(conn, "show.json", project: project)
     else
       {:error, error} -> render_error_json(conn, error)
@@ -88,26 +114,35 @@ defmodule RetWeb.Api.V1.ProjectController do
   end
 
   defp publish_project(conn, scene_params, project = %Project{}, scene = %Scene{}, account) do
-    Repo.transaction(fn ->
-      with {:ok, model_owned_file} <-
-             Storage.promote(scene_params["model_file_id"], scene_params["model_file_token"], nil, account),
-           {:ok, screenshot_owned_file} <-
-             Storage.promote(scene_params["screenshot_file_id"], scene_params["screenshot_file_token"], nil, account),
-           {:ok, scene_owned_file} <-
-             Storage.promote(scene_params["scene_file_id"], scene_params["scene_file_token"], nil, account),
-           {:ok, scene} <-
-             scene
-             |> Scene.changeset(account, model_owned_file, screenshot_owned_file, scene_owned_file, scene_params)
-             |> Repo.insert_or_update(),
-           {:ok, project} <- project |> Project.add_scene_to_project(scene) do
-        conn |> render("show.json", project: project)
-      else
-        {:error, :not_found} ->
-          conn |> render_error_json(400, "You must provide a valid model, screenshot, and scene file")
+    {:ok, conn} =
+      Repo.transaction(fn ->
+        with {:ok, model_owned_file} <-
+               Storage.promote(scene_params["model_file_id"], scene_params["model_file_token"], nil, account),
+             {:ok, screenshot_owned_file} <-
+               Storage.promote(scene_params["screenshot_file_id"], scene_params["screenshot_file_token"], nil, account),
+             {:ok, scene_owned_file} <-
+               Storage.promote(scene_params["scene_file_id"], scene_params["scene_file_token"], nil, account),
+             scene_changes <-
+               scene
+               |> Scene.changeset(
+                 account,
+                 model_owned_file,
+                 screenshot_owned_file,
+                 scene_owned_file,
+                 project.parent_scene_listing || project.parent_scene,
+                 scene_params
+               ),
+             {:ok, updated_project} <- project |> Project.add_scene_to_project(scene_changes) do
+          conn |> render("show.json", project: updated_project |> preload())
+        else
+          {:error, :not_found} ->
+            conn |> render_error_json(400, "You must provide a valid model, screenshot, and scene file")
 
-        {:error, error} ->
-          conn |> render_error_json(error)
-      end
-    end)
+          {:error, error} ->
+            conn |> render_error_json(error)
+        end
+      end)
+
+    conn
   end
 end

--- a/lib/ret_web/controllers/api/v1/scene_controller.ex
+++ b/lib/ret_web/controllers/api/v1/scene_controller.ex
@@ -107,7 +107,7 @@ defmodule RetWeb.Api.V1.SceneController do
 
         scene =
           scene
-          |> Repo.preload([:model_owned_file, :screenshot_owned_file, :scene_owned_file])
+          |> preload()
 
         if scene.allow_promotion do
           Task.async(fn -> scene |> Ret.Support.send_notification_of_new_scene() end)

--- a/lib/ret_web/controllers/api/v1/scene_controller.ex
+++ b/lib/ret_web/controllers/api/v1/scene_controller.ex
@@ -10,7 +10,10 @@ defmodule RetWeb.Api.V1.SceneController do
   end
 
   defp preload(%Scene{} = a, preloads) do
-    a |> Repo.preload([:model_owned_file, :screenshot_owned_file, :scene_owned_file] ++ preloads)
+    a
+    |> Repo.preload(
+      [:model_owned_file, :screenshot_owned_file, :scene_owned_file, :parent_scene, :parent_scene_listing, :project] ++ preloads
+    )
   end
 
   def show(conn, %{"id" => scene_sid}) do
@@ -24,6 +27,18 @@ defmodule RetWeb.Api.V1.SceneController do
     case scene_sid |> get_scene() do
       %Scene{} = scene -> create_or_update(conn, params, scene)
       _ -> conn |> send_resp(404, "not found")
+    end
+  end
+
+  def create(conn, %{"parent_scene_id" => scene_sid}) do
+    account = Guardian.Plug.current_resource(conn)
+
+    case scene_sid |> get_scene() do
+      %t{} = s when t in [Scene, SceneListing] ->
+        conn |> render("show.json", scene: s |> Scene.new_scene_from_parent_scene(account))
+
+      _ ->
+        conn |> send_resp(404, "not found")
     end
   end
 
@@ -42,9 +57,10 @@ defmodule RetWeb.Api.V1.SceneController do
   end
 
   defp get_scene(scene_sid) do
-    scene_sid
-    |> Scene.scene_or_scene_listing_by_sid()
-    |> Repo.preload([:account, :model_owned_file, :screenshot_owned_file, :scene_owned_file])
+    case scene_sid |> Scene.scene_or_scene_listing_by_sid() do
+      nil -> nil
+      scene -> scene |> preload([:account])
+    end
   end
 
   defp create_or_update(conn, params, scene \\ %Scene{}) do

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -81,7 +81,6 @@ defmodule RetWeb.Router do
     scope "/v1", as: :api_v1 do
       get("/meta", Api.V1.MetaController, :show)
       resources("/media", Api.V1.MediaController, only: [:create])
-      resources("/scenes", Api.V1.SceneController, only: [:show])
       get("/avatars/:id/base.gltf", Api.V1.AvatarController, :show_base_gltf)
       get("/avatars/:id/avatar.gltf", Api.V1.AvatarController, :show_avatar_gltf)
       get("/oauth/:type", Api.V1.OAuthController, :show)
@@ -104,6 +103,7 @@ defmodule RetWeb.Router do
       resources("/hubs", Api.V1.HubController, only: [:create, :delete])
       resources("/media/search", Api.V1.MediaSearchController, only: [:index])
       resources("/avatars", Api.V1.AvatarController, only: [:show])
+      resources("/scenes", Api.V1.SceneController, only: [:show])
     end
 
     scope "/v1", as: :api_v1 do

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -115,6 +115,7 @@ defmodule RetWeb.Router do
       post("/twitter/tweets", Api.V1.TwitterController, :tweets)
 
       resources("/projects", Api.V1.ProjectController, only: [:index, :show, :create, :update, :delete]) do
+        post("/publish", Api.V1.ProjectController, :publish)
         resources("/assets", Api.V1.ProjectAssetsController, only: [:index, :create, :delete])
       end
     end

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -35,7 +35,7 @@ defmodule RetWeb.Api.V1.HubView do
           entry_mode: hub.entry_mode,
           host: hub.host,
           port: janus_port(),
-          scene: RetWeb.Api.V1.SceneView.render_scene(hub.scene || hub.scene_listing),
+          scene: RetWeb.Api.V1.SceneView.render_scene(hub.scene || hub.scene_listing, nil),
           embed_token:
             if embeddable do
               hub.embed_token

--- a/lib/ret_web/views/api/v1/project_view.ex
+++ b/lib/ret_web/views/api/v1/project_view.ex
@@ -11,7 +11,7 @@ defmodule RetWeb.Api.V1.ProjectView do
       name: project.name,
       project_url: url_for_file(project.project_owned_file),
       thumbnail_url: url_for_file(project.thumbnail_owned_file),
-      scene_id: project.scene |> Scene.to_sid()
+      scene: RetWeb.Api.V1.SceneView.render_scene(project.scene, nil)
     }
   end
 
@@ -23,7 +23,7 @@ defmodule RetWeb.Api.V1.ProjectView do
 
   def render("show.json", %{project: project}) do
     Map.merge(
-      %{ status: :ok },
+      %{status: :ok},
       render_project(project)
     )
   end

--- a/lib/ret_web/views/api/v1/project_view.ex
+++ b/lib/ret_web/views/api/v1/project_view.ex
@@ -1,6 +1,6 @@
 defmodule RetWeb.Api.V1.ProjectView do
   use RetWeb, :view
-  alias Ret.{OwnedFile}
+  alias Ret.{OwnedFile, Scene}
 
   defp url_for_file(%Ret.OwnedFile{} = f), do: f |> OwnedFile.uri_for() |> URI.to_string()
   defp url_for_file(_), do: nil
@@ -10,7 +10,8 @@ defmodule RetWeb.Api.V1.ProjectView do
       project_id: project.project_sid,
       name: project.name,
       project_url: url_for_file(project.project_owned_file),
-      thumbnail_url: url_for_file(project.thumbnail_owned_file)
+      thumbnail_url: url_for_file(project.thumbnail_owned_file),
+      scene_id: project.scene |> Scene.to_sid()
     }
   end
 

--- a/lib/ret_web/views/api/v1/project_view.ex
+++ b/lib/ret_web/views/api/v1/project_view.ex
@@ -11,7 +11,8 @@ defmodule RetWeb.Api.V1.ProjectView do
       name: project.name,
       project_url: url_for_file(project.project_owned_file),
       thumbnail_url: url_for_file(project.thumbnail_owned_file),
-      scene: RetWeb.Api.V1.SceneView.render_scene(project.scene, nil)
+      scene: RetWeb.Api.V1.SceneView.render_scene(project.scene, nil),
+      parent_scene: RetWeb.Api.V1.SceneView.render_scene(project.parent_scene_listing || project.parent_scene, nil)
     }
   end
 

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -18,8 +18,7 @@ defmodule RetWeb.Api.V1.SceneView do
   def render_scene(scene, account) do
     map = %{
       scene_id: scene |> Scene.to_sid(),
-      parent_scene_id: scene.parent_scene |> Scene.to_sid(),
-      parent_scene_listing_id: scene.parent_scene_listing |> Scene.to_sid(),
+      parent_scene_id: (scene.parent_scene_listing || scene.parent_scene) |> Scene.to_sid(),
       project_id: scene.project |> Project.to_sid(),
       name: scene.name,
       description: scene.description,

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -2,19 +2,19 @@ defmodule RetWeb.Api.V1.SceneView do
   use RetWeb, :view
   alias Ret.{OwnedFile, Scene, SceneListing, Project}
 
-  def render("create.json", %{scene: scene}) do
-    %{scenes: [render_scene(scene)]}
+  def render("create.json", %{scene: scene, account: account}) do
+    %{scenes: [render_scene(scene, account)]}
   end
 
-  def render("show.json", %{scene: scene}) do
-    %{scenes: [render_scene(scene)]}
+  def render("show.json", %{scene: scene, account: account}) do
+    %{scenes: [render_scene(scene, account)]}
   end
 
-  def render_scene(%Scene{state: :removed}), do: nil
-  def render_scene(%SceneListing{state: :delisted}), do: nil
+  def render_scene(%Scene{state: :removed}, account), do: nil
+  def render_scene(%SceneListing{state: :delisted}, account), do: nil
 
   # scene var passed in can be either a Ret.Scene or Ret.SceneListing
-  def render_scene(scene) do
+  def render_scene(scene, account) do
     map = %{
       scene_id: scene |> Scene.to_sid(),
       parent_scene_id: scene.parent_scene |> Scene.to_sid(),
@@ -35,20 +35,21 @@ defmodule RetWeb.Api.V1.SceneView do
         %{}
       end
 
-    map |> add_scene_or_listing_fields(scene) |> Map.merge(remix_fields)
+    map |> add_scene_or_listing_fields(scene, account) |> Map.merge(remix_fields)
   end
 
-  defp add_scene_or_listing_fields(map, %SceneListing{} = scene_listing) do
+  defp add_scene_or_listing_fields(map, %SceneListing{} = scene_listing, account) do
     map
-    |> add_scene_or_listing_fields(scene_listing.scene)
+    |> add_scene_or_listing_fields(scene_listing.scene, account)
     |> Meap.merge(%{
       type: "scene_listing"
     })
   end
 
-  defp add_scene_or_listing_fields(map, %Scene{} = scene) do
+  defp add_scene_or_listing_fields(map, %Scene{} = scene, account) do
     map
     |> Map.merge(%{
+      account_id: account && scene.account_id == account.account_id && scene.account_id |> Integer.to_string(),
       attribution: scene.attribution,
       allow_remixing: scene.allow_remixing,
       allow_promotion: scene.allow_promotion,

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -1,6 +1,6 @@
 defmodule RetWeb.Api.V1.SceneView do
   use RetWeb, :view
-  alias Ret.{OwnedFile, Scene, SceneListing}
+  alias Ret.{OwnedFile, Scene, SceneListing, Project}
 
   def render("create.json", %{scene: scene}) do
     %{scenes: [render_scene(scene)]}
@@ -17,6 +17,9 @@ defmodule RetWeb.Api.V1.SceneView do
   def render_scene(scene) do
     map = %{
       scene_id: scene |> Scene.to_sid(),
+      parent_scene_id: scene.parent_scene |> Scene.to_sid(),
+      parent_scene_listing_id: scene.parent_scene_listing |> Scene.to_sid(),
+      project_id: scene.project |> Project.to_sid(),
       name: scene.name,
       description: scene.description,
       attributions: scene.attributions,

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -10,6 +10,7 @@ defmodule RetWeb.Api.V1.SceneView do
     %{scenes: [render_scene(scene, account)]}
   end
 
+  def render_scene(nil, _account), do: nil
   def render_scene(%Scene{state: :removed}, _account), do: nil
   def render_scene(%SceneListing{state: :delisted}, _account), do: nil
 

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -10,8 +10,8 @@ defmodule RetWeb.Api.V1.SceneView do
     %{scenes: [render_scene(scene, account)]}
   end
 
-  def render_scene(%Scene{state: :removed}, account), do: nil
-  def render_scene(%SceneListing{state: :delisted}, account), do: nil
+  def render_scene(%Scene{state: :removed}, _account), do: nil
+  def render_scene(%SceneListing{state: :delisted}, _account), do: nil
 
   # scene var passed in can be either a Ret.Scene or Ret.SceneListing
   def render_scene(scene, account) do
@@ -41,7 +41,7 @@ defmodule RetWeb.Api.V1.SceneView do
   defp add_scene_or_listing_fields(map, %SceneListing{} = scene_listing, account) do
     map
     |> add_scene_or_listing_fields(scene_listing.scene, account)
-    |> Meap.merge(%{
+    |> Map.merge(%{
       type: "scene_listing"
     })
   end

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -39,17 +39,21 @@ defmodule RetWeb.Api.V1.SceneView do
   end
 
   defp add_scene_or_listing_fields(map, %SceneListing{} = scene_listing) do
-    map |> add_scene_or_listing_fields(scene_listing.scene)
+    map
+    |> add_scene_or_listing_fields(scene_listing.scene)
+    |> Meap.merge(%{
+      type: "scene_listing"
+    })
   end
 
   defp add_scene_or_listing_fields(map, %Scene{} = scene) do
-    fields = %{
+    map
+    |> Map.merge(%{
       attribution: scene.attribution,
       allow_remixing: scene.allow_remixing,
-      allow_promotion: scene.allow_promotion
-    }
-
-    map |> Map.merge(fields)
+      allow_promotion: scene.allow_promotion,
+      type: "scene"
+    })
   end
 
   defp allow_remixing?(%SceneListing{} = scene_listing), do: scene_listing.scene.allow_remixing

--- a/priv/repo/migrations/20191111234010_add_parenting_to_scenes.exs
+++ b/priv/repo/migrations/20191111234010_add_parenting_to_scenes.exs
@@ -1,0 +1,15 @@
+defmodule Ret.Repo.Migrations.AddParentingToScenes do
+  use Ecto.Migration
+
+  def change do
+    alter table("scenes") do
+      add(:parent_scene_id, references(:scenes, column: :scene_id))
+      add(:parent_scene_listing_id, references(:scene_listings, column: :scene_listing_id))
+    end
+
+    alter table("projects") do
+      add(:scene_id, references(:scenes, column: :scene_id))
+    end
+
+  end
+end

--- a/priv/repo/migrations/20191121222742_add_parent_to_projects.exs
+++ b/priv/repo/migrations/20191121222742_add_parent_to_projects.exs
@@ -1,0 +1,10 @@
+defmodule Ret.Repo.Migrations.AddParentToProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table("projects") do
+      add(:parent_scene_id, references(:scenes, column: :scene_id))
+      add(:parent_scene_listing_id, references(:scene_listings, column: :scene_listing_id))
+    end
+  end
+end

--- a/test/ret_web/controllers/api/projects_controller_test.exs
+++ b/test/ret_web/controllers/api/projects_controller_test.exs
@@ -4,7 +4,13 @@ defmodule RetWeb.ProjectsControllerTest do
 
   alias Ret.{Project, Repo, Account}
 
-  setup [:create_account, :create_project_owned_file, :create_thumbnail_owned_file, :create_project]
+  setup [
+    :create_account,
+    :create_project_owned_file,
+    :create_thumbnail_owned_file,
+    :create_project,
+    :create_model_owned_file
+  ]
 
   setup do
     on_exit(fn ->
@@ -31,7 +37,7 @@ defmodule RetWeb.ProjectsControllerTest do
       ]
     } = response
 
-    assert name == "Test Scene"
+    assert name == "Test Project"
     assert thumbnail_url != nil
     assert project_url != nil
     assert project_id != nil
@@ -52,7 +58,7 @@ defmodule RetWeb.ProjectsControllerTest do
       "name" => name
     } = response
 
-    assert name == "Test Scene"
+    assert name == "Test Project"
     assert thumbnail_url != nil
     assert project_url != nil
     assert project_id != nil
@@ -63,7 +69,11 @@ defmodule RetWeb.ProjectsControllerTest do
   end
 
   @tag :authenticated
-  test "projects create works when logged in", %{conn: conn, project_owned_file: project_owned_file, thumbnail_owned_file: thumbnail_owned_file} do
+  test "projects create works when logged in", %{
+    conn: conn,
+    project_owned_file: project_owned_file,
+    thumbnail_owned_file: thumbnail_owned_file
+  } do
     params = %{
       project: %{
         name: "Test Project",
@@ -140,6 +150,51 @@ defmodule RetWeb.ProjectsControllerTest do
     assert project_id != nil
   end
 
+  @tag :authenticated
+  test "projects with no scene creates a new scene on publish", %{
+    conn: conn,
+    project: project,
+    project_owned_file: scene_owned_file,
+    thumbnail_owned_file: screenshot_owned_file,
+    model_owned_file: model_owned_file
+  } do
+    params = %{
+      scene: %{
+        name: "Test Publish",
+        model_file_id: model_owned_file.owned_file_uuid,
+        model_file_token: model_owned_file.key,
+        screenshot_file_id: screenshot_owned_file.owned_file_uuid,
+        screenshot_file_token: screenshot_owned_file.key,
+        scene_file_id: scene_owned_file.owned_file_uuid,
+        scene_file_token: scene_owned_file.key
+      }
+    }
+
+    # Publishing the first time should create a new scene
+    project = project |> Repo.preload([:scene])
+    assert project.scene == nil
+
+    response_project =
+      conn |> post(api_v1_project_project_path(conn, :publish, project.project_sid, params)) |> json_response(200)
+
+    new_scene_sid = response_project["scene"]["scene_id"]
+
+    updated_project = Project |> Repo.get_by(project_sid: project.project_sid) |> Repo.preload([:scene])
+    assert updated_project.scene.scene_sid == new_scene_sid
+    assert response_project["name"] == "Test Project"
+    assert response_project["scene"]["name"] == "Test Publish"
+
+
+    # Republishing should not create a new scene
+    params = params |> put_in([:scene, :name], "Test Republish")
+
+    response_project =
+      conn |> post(api_v1_project_project_path(conn, :publish, project.project_sid, params)) |> json_response(200)
+
+    assert response_project["scene"]["name"] == "Test Republish"
+    assert response_project["scene"]["scene_id"] == new_scene_sid
+  end
+
   test "projects delete 401's when not logged in", %{conn: conn, project: project} do
     conn |> delete(api_v1_project_path(conn, :delete, project.project_sid)) |> response(401)
   end
@@ -164,7 +219,7 @@ defmodule RetWeb.ProjectsControllerTest do
     {:ok, project} =
       %Project{}
       |> Project.changeset(other_account, project_owned_file, thumbnail_owned_file, %{
-        name: "Test Scene"
+        name: "Test Project"
       })
       |> Repo.insert_or_update()
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -124,6 +124,10 @@ defmodule Ret.TestHelpers do
     {:ok, thumbnail_owned_file: generate_fixture_owned_file(account, thumbnail_file, "image/png")}
   end
 
+  def create_model_owned_file(%{account: account}) do
+    {:ok, model_owned_file: generate_temp_owned_file(account)}
+  end
+
   def create_project(%{
         account: account,
         project_owned_file: project_owned_file,
@@ -132,7 +136,7 @@ defmodule Ret.TestHelpers do
     {:ok, project} =
       %Project{}
       |> Project.changeset(account, project_owned_file, thumbnail_owned_file, %{
-        name: "Test Scene"
+        name: "Test Project"
       })
       |> Repo.insert_or_update()
 


### PR DESCRIPTION
This adds the ability to clone a scene or scene listing into "my scenes". A project is also created for the scene, though we may want to split that off into its own step.

To make creating publishing projects simpler, a new `/projects/:id/publish` endpoint has been added that will automatically create a scene if one does not exist and associate it with the project, then update its files, all in a single transaction.

Changes were also made to the responses for Scenes, SceneListings, and Projects ass well as the associated media search responses to facilitate the new client features this was built for.

Also small side fix for importing attributions from remote scenes/avatars.