### PR TITLE
Increase maximum sketchfab collection file size / polycount

### DIFF
--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -27,9 +27,9 @@ defmodule Ret.MediaSearch do
   # HACK for now to reduce page size for scene listings -- real fix will be to expose page_size to API
   @scene_page_size 23
   @max_face_count 60000
-  @max_collection_face_count 200000
-  @max_file_size_bytes 20 * 1_048_576
-  @max_collection_file_size_bytes 100 * 1_048_576
+  @max_collection_face_count 200_000
+  @max_file_size_bytes 20 * 1024 * 1024
+  @max_collection_file_size_bytes 100 * 1024 * 1024
 
   def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: "featured", q: query}) do
     scene_listing_search(cursor, query, "featured", asc: :order)

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -27,7 +27,9 @@ defmodule Ret.MediaSearch do
   # HACK for now to reduce page size for scene listings -- real fix will be to expose page_size to API
   @scene_page_size 23
   @max_face_count 60000
+  @max_collection_face_count 200000
   @max_file_size_bytes 20 * 1_048_576
+  @max_collection_file_size_bytes 100 * 1_048_576
 
   def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: "featured", q: query}) do
     scene_listing_search(cursor, query, "featured", asc: :order)
@@ -113,8 +115,8 @@ defmodule Ret.MediaSearch do
         type: :models,
         downloadable: true,
         count: @page_size,
-        max_face_count: @max_face_count,
-        max_filesizes: "gltf:#{@max_file_size_bytes}",
+        max_face_count: @max_collection_face_count,
+        max_filesizes: "gltf:#{@max_collection_file_size_bytes}",
         processing_status: :succeeded,
         sort_by:
           if q == nil || q == "" do


### PR DESCRIPTION
There are a few models in the Sketchfab collections I'd like to feature that are over the filesize / polycount limit. Because we check everything that goes into these collections, I think it's fine to increase these limits to a reasonably large upper bound.