### PR TITLE
Feature/admin email

### DIFF
--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -158,6 +158,11 @@ node_gauges_enabled = {{ cfg.stats.node_gauges_enabled }}
 check_repo = {{ cfg.health.check_repo }}
 {{/if}}
 
+[ret."Elixir.Ret.Account"]
+{{#if cfg.accounts.admin_email }}
+admin_email = "{{ cfg.accounts.admin_email }}"
+{{/if}}
+
 [web_push_encryption.vapid_details]
 subject = "{{ cfg.web_push.subject }}"
 public_key = "{{ cfg.web_push.public_key }}"

--- a/lib/ret/account.ex
+++ b/lib/ret/account.ex
@@ -39,7 +39,7 @@ defmodule Ret.Account do
       is_admin = with admin_email when is_binary(admin_email) <- module_config(:admin_email) do
         identifier_hash === admin_email |> identifier_hash_for_email
       else
-        false
+        _ -> false
       end
 
       Repo.insert!(%Account{login: %Login{identifier_hash: identifier_hash}, is_admin: is_admin})

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -64,7 +64,7 @@ defmodule RetWeb.Api.V1.MediaSearchController do
     end
   end
 
-  def index(conn, %{"source" => source} = params) when source in ["favorites"] do
+  def index(conn, %{"source" => source}) when source in ["favorites"] do
     conn |> send_resp(401, "Missing account id for favorites search.")
   end
 


### PR DESCRIPTION
Changes the bootstrapping account process to no longer just grant admin access to the first account, but instead depend upon the `admin_email` config being set to determine which account, if any, should be assumed to be an administrator.