### PR TITLE
Add dynamic robots.txt

### DIFF
--- a/assets/static/robots.txt
+++ b/assets/static/robots.txt
@@ -1,5 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -32,6 +32,7 @@ config :ret, RetWeb.Endpoint,
   check_origin: false,
   secret_key_base: "txlMOtlaY5x3crvOCko4uV5PM29ul3zGo1oBGNO3cDXx+7GHLKqt0gR9qzgThxb5",
   allowed_origins: "*",
+  allow_crawlers: true,
   watchers: [
     node: [
       "node_modules/brunch/bin/brunch",

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -24,6 +24,7 @@ keyfile = "{{ pkg.svc_files_path }}/ssl.key"
 [ret."Elixir.RetWeb.Endpoint"]
 allowed_origins = "{{ cfg.security.cors_origins }}"
 secret_key_base = "{{ cfg.phx.secret_key }}"
+allow_crawlers = {{ cfg.phx.allow_crawlers }}
 
 {{#if cfg.phx.secondary_url_host }}
 [ret."Elixir.RetWeb.Endpoint".secondary_url]

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -9,6 +9,7 @@ url_host_prefix = ""
 static_url_host_prefix = ""
 admin_access_key = ""
 secondary_url_host = ""
+allow_crawlers = true
 
 [guardian]
 secret_key = "txlMOtlaY5x3crvOCko4uV5PM29ul3zGo1oBGNO3cDXx+7GHLKqt0gR9qzgThxb5"

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -174,6 +174,14 @@ defmodule RetWeb.PageController do
 
   def render_for_path("/admin", _params, conn), do: conn |> render_page("admin.html", :admin)
 
+  def render_for_path("/robots.txt", _params, conn) do
+    allow_crawlers = Application.get_env(:ret, RetWeb.Endpoint)[:allow_crawlers] || false
+    robots_txt = Phoenix.View.render_to_string(RetWeb.PageView, "robots.txt", allow_crawlers: allow_crawlers)
+
+    conn
+    |> send_resp(200, robots_txt)
+  end
+
   def render_for_path("/" <> path, params, conn) do
     embed_token = params["embed_token"]
 

--- a/lib/ret_web/endpoint.ex
+++ b/lib/ret_web/endpoint.ex
@@ -15,21 +15,6 @@ defmodule RetWeb.Endpoint do
     end
   end
 
-  # Serve at "/" the static files from "priv/static" directory.
-  #
-  # You should set gzip to true if you are running phoenix.digest
-  # when deploying your static files in production.
-  plug(
-    Plug.Static,
-    at: "/",
-    from: :ret,
-    gzip: false,
-    # Due to cloudfront, we want to include max-age in responses	
-    cache_control_for_etags: "public, max-age=31536000",
-    only: ~w(robots.txt),
-    headers: [{"access-control-allow-origin", "*"}]
-  )
-
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do

--- a/lib/ret_web/templates/page/robots.txt.eex
+++ b/lib/ret_web/templates/page/robots.txt.eex
@@ -1,0 +1,13 @@
+<%=if @allow_crawlers do %>
+User-agent: *
+Allow: /
+<% else %>
+User-agent: *
+Disallow: /
+
+User-agent: Twitterbot
+Allow: /
+
+User-agent: facebookexternalhit
+Allow: /
+<% end %>

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -1,5 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /


### PR DESCRIPTION
Adds the ability to disallow crawlers, which will serve up a robots.txt denying all crawling other than twitter or facebook image unfurling bots.

Note this will be off by default in `ita` for self hosted instances.