### PR TITLE
Fix scene preloads

### DIFF
--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -475,7 +475,7 @@ defmodule Ret.MediaSearch do
     results =
       AccountFavorite
       |> where([a], a.account_id == ^account_id)
-      |> preload(hub: [scene: [:screenshot_owned_file], scene_listing: [:screenshot_owned_file]])
+      |> preload(hub: [scene: [:screenshot_owned_file], scene_listing: [:scene, :screenshot_owned_file]])
       |> order_by(^order)
       |> Repo.paginate(%{page: page_number, page_size: @page_size})
       |> result_for_page(page_number, :favorites, &favorite_to_entry/1)

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -8,16 +8,6 @@ defmodule Ret.Project do
   @schema_prefix "ret0"
   @primary_key {:project_id, :id, autogenerate: true}
 
-  @scene_preloads [
-    :parent_scene,
-    :parent_scene_listing,
-    :account,
-    :project,
-    :model_owned_file,
-    :screenshot_owned_file,
-    :scene_owned_file
-  ]
-
   schema "projects" do
     field(:project_sid, :string)
     field(:name, :string)
@@ -56,9 +46,9 @@ defmodule Ret.Project do
         :created_by_account,
         :project_owned_file,
         :thumbnail_owned_file,
-        scene: ^@scene_preloads,
-        parent_scene: ^@scene_preloads,
-        parent_scene_listing: ^@scene_preloads,
+        scene: ^Scene.scene_preloads(),
+        parent_scene: ^Scene.scene_preloads(),
+        parent_scene_listing: ^Scene.scene_preloads(),
         assets: [:asset_owned_file, :thumbnail_owned_file]
       ]
     )
@@ -72,9 +62,9 @@ defmodule Ret.Project do
         preload: [
           :project_owned_file,
           :thumbnail_owned_file,
-          scene: ^@scene_preloads,
-          parent_scene: ^@scene_preloads,
-          parent_scene_listing: ^@scene_preloads
+          scene: ^Scene.scene_preloads(),
+          parent_scene: ^Scene.scene_preloads(),
+          parent_scene_listing: ^Scene.scene_preloads()
         ]
       )
     )

--- a/lib/ret/scene_listing.ex
+++ b/lib/ret/scene_listing.ex
@@ -70,7 +70,11 @@ defmodule Ret.SceneListing do
 
     if length(results.entries) > 0 do
       scene_listing_sid = results.entries |> Enum.map(& &1[:id]) |> Enum.shuffle() |> Enum.at(0)
-      Repo.get_by(SceneListing, scene_listing_sid: scene_listing_sid) |> Repo.preload(:scene)
+
+      Repo.get_by(SceneListing, scene_listing_sid: scene_listing_sid)
+      |> Repo.preload(
+        scene: Scene.scene_preloads()
+      )
     else
       nil
     end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -25,7 +25,7 @@ defmodule RetWeb.HubChannel do
   intercept(["hub_refresh", "mute", "add_owner", "remove_owner", "naf", "message", "block", "unblock"])
 
   @hub_preloads [
-    scene: [:model_owned_file, :screenshot_owned_file, :scene_owned_file],
+    scene: Scene.scene_preloads(),
     scene_listing: [:model_owned_file, :screenshot_owned_file, :scene_owned_file, :scene],
     web_push_subscriptions: [],
     hub_bindings: [],

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -11,9 +11,9 @@ defmodule RetWeb.Api.V1.ProjectController do
     |> Repo.preload([
       :project_owned_file,
       :thumbnail_owned_file,
-      scene: [:parent_scene, :parent_scene_listing, :project],
-      parent_scene: [:parent_scene, :parent_scene_listing, :project],
-      parent_scene_listing: [:parent_scene, :parent_scene_listing, :project]
+      scene: Scene.scene_preloads(),
+      parent_scene: Scene.scene_preloads(),
+      parent_scene_listing: Scene.scene_preloads()
     ])
   end
 


### PR DESCRIPTION
Fix scene preload issues introduced from scene remixing change, and centralize them so that we are less likely to break them in the future.