### PR TITLE
Discord and CSP fixes

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -143,7 +143,7 @@ websocket_hosts =
     "wss://#{dev_janus_host} wss://prod-janus.reticulum.io wss://#{host}:4000 wss://#{host}:8080 https://#{host}:8080 https://hubs.local:8080 wss://hubs.local:8080"
 
 script_shas =
-  "'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8='"
+  "'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8='"
 
 config :ret, RetWeb.Plugs.AddCSP,
   content_security_policy:

--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -198,7 +198,7 @@ defmodule Ret.DiscordClient do
 
       permissions =
         if overwrite_member do
-          (permissions &&& ~~~overwrite_member.deny) ||| overwrite_member.allow
+          (permissions &&& ~~~overwrite_member["deny"]) ||| overwrite_member["allow"]
         else
           permissions
         end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -29,8 +29,7 @@ defmodule RetWeb.PageController do
     conn
     |> append_csp("script-src", app_config_csp)
     |> put_hub_headers("scene")
-    |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
+    |> render_chunks(chunks, "text/html; charset=utf-8")
   end
 
   defp render_scene_content(nil, conn) do
@@ -55,8 +54,7 @@ defmodule RetWeb.PageController do
     conn
     |> append_csp("script-src", app_config_csp)
     |> put_hub_headers("avatar")
-    |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
+    |> render_chunks(chunks, "text/html; charset=utf-8")
   end
 
   defp render_avatar_content(nil, conn) do
@@ -268,8 +266,7 @@ defmodule RetWeb.PageController do
     conn
     |> append_csp("script-src", app_config_csp)
     |> put_hub_headers("hub")
-    |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
+    |> render_chunks(chunks, "text/html; charset=utf-8")
   end
 
   defp put_hub_headers(conn, entity_type) do
@@ -351,8 +348,7 @@ defmodule RetWeb.PageController do
     |> append_csp("script-src", app_config_csp)
     |> append_csp("script-src", available_integrations_csp)
     |> put_hub_headers("room")
-    |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
+    |> render_chunks(chunks, "text/html; charset=utf-8")
   end
 
   def generate_app_config() do

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -30,7 +30,7 @@ defmodule RetWeb.PageController do
     |> append_csp("script-src", app_config_csp)
     |> put_hub_headers("scene")
     |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks)
+    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
   end
 
   defp render_scene_content(nil, conn) do
@@ -56,7 +56,7 @@ defmodule RetWeb.PageController do
     |> append_csp("script-src", app_config_csp)
     |> put_hub_headers("avatar")
     |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks)
+    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
   end
 
   defp render_avatar_content(nil, conn) do
@@ -269,7 +269,7 @@ defmodule RetWeb.PageController do
     |> append_csp("script-src", app_config_csp)
     |> put_hub_headers("hub")
     |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks)
+    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
   end
 
   defp put_hub_headers(conn, entity_type) do
@@ -352,7 +352,7 @@ defmodule RetWeb.PageController do
     |> append_csp("script-src", available_integrations_csp)
     |> put_hub_headers("room")
     |> put_resp_header("content-type", "text/html; charset=utf-8")
-    |> send_resp(200, chunks)
+    |> send_resp(200, chunks |> List.flatten() |> Enum.join("\n"))
   end
 
   def generate_app_config() do

--- a/lib/ret_web/views/api/v1/project_view.ex
+++ b/lib/ret_web/views/api/v1/project_view.ex
@@ -1,6 +1,6 @@
 defmodule RetWeb.Api.V1.ProjectView do
   use RetWeb, :view
-  alias Ret.{OwnedFile, Scene}
+  alias Ret.{OwnedFile}
 
   defp url_for_file(%Ret.OwnedFile{} = f), do: f |> OwnedFile.uri_for() |> URI.to_string()
   defp url_for_file(_), do: nil

--- a/test/ret/discord_client_test.exs
+++ b/test/ret/discord_client_test.exs
@@ -42,7 +42,8 @@ defmodule Ret.DiscordClientTest do
     Cachex.put(:discord_api, "/channels/#{@restricted_channel_id}", %{
       "permission_overwrites" => [
         %{"id" => @community_id, "allow" => @none, "deny" => @view_channel},
-        %{"id" => @moderator_role, "allow" => @view_channel, "deny" => @none}
+        %{"id" => @moderator_role, "allow" => @view_channel, "deny" => @none},
+        %{"id" => @regular_user_id, "allow" => @none, "deny" => @none}
       ]
     })
 


### PR DESCRIPTION
- Fix permissions overwrite in discord client
- Output newlines consistently in page_controller. We were only formatting page chunks with newlines on certain pages. This caused the google analytics script CSP to be correct on most pages, but incorrect on the link page. This changes the page controller to output newlines on all pages, which will require a new CSP SHA for the GA script.