### PR TITLE
Disable SSL by default, make it configurable

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -91,8 +91,7 @@ config :ret, Ret.Repo,
   database: "ret_dev",
   hostname: if(env_db_host == "", do: "localhost", else: env_db_host),
   template: "template0",
-  pool_size: 10,
-  ssl: true
+  pool_size: 10
 
 config :ret, RetWeb.Plugs.HeaderAuthorization,
   header_name: "x-ret-admin-access-key",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -41,7 +41,6 @@ config :ret, Ret.Repo,
   database: "ret_production",
   hostname: "localhost",
   template: "template0",
-  ssl: true,
   pool_size: 10
 
 # ## SSL Support

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -100,6 +100,9 @@ timeout = {{ cfg.db.timeout }}
 {{#if cfg.db.port }}
 port = {{ cfg.db.port }}
 {{/if}}
+{{#if cfg.db.ssl }}
+ssl = {{ cfg.db.ssl }}
+{{/if}}
 
 [ret."Elixir.Ret.Locking".session_lock_db]
 username = "{{ cfg.session_lock_db.username }}"
@@ -107,6 +110,9 @@ password = "{{ cfg.session_lock_db.password }}"
 database = "{{ cfg.session_lock_db.database }}"
 hostname = "{{ cfg.session_lock_db.hostname }}"
 port = {{ cfg.session_lock_db.port }}
+{{#if cfg.session_lock_db.ssl }}
+ssl = {{ cfg.session_lock_db.ssl }}
+{{/if}}
 
 [ret."Elixir.Ret.Habitat"]
 ip = "{{ cfg.habitat.ip }}"

--- a/lib/ret/locking.ex
+++ b/lib/ret/locking.ex
@@ -8,6 +8,7 @@ defmodule Ret.Locking do
     password = session_lock_db_config |> Keyword.get(:password)
     database = session_lock_db_config |> Keyword.get(:database)
     port = session_lock_db_config |> Keyword.get(:port)
+    ssl = session_lock_db_config |> Keyword.get(:ssl)
 
     # Set a long queue timeout here, since we need this to work even if the database is cold and 
     # is starting up (eg AWS aurora)
@@ -17,7 +18,7 @@ defmodule Ret.Locking do
         username: username,
         password: password,
         database: database,
-        ssl: true,
+        ssl: ssl || false,
         port: port,
         queue_interval: 60_000,
         after_connect_timeout: 60_000,


### PR DESCRIPTION
It turned out that on AWS we don't want to force SSL, because in the self hosted case pgbouncer (communicating over localhost) is fine to be in the clear (and it'd be more complex to set up TLS over localhost, so not worth it.)

So this PR exposes `ssl` as a configuration value, off by default, when communicating with the database.