### PR TITLE
Serve docs directly

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -194,7 +194,7 @@ config :ret, Ret.JanusLoadStatus, default_janus_host: dev_janus_host, janus_port
 
 config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
 
-config :ret, RetWeb.PageController, skip_cache: true, assets_path: "storage/assets"
+config :ret, RetWeb.PageController, skip_cache: true, assets_path: "storage/assets", docs_path: "storage/docs"
 
 config :ret, Ret.HttpUtils, insecure_ssl: true
 

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -232,6 +232,11 @@ check_repo = {{ cfg.health.check_repo }}
 assets_path = "{{ cfg.assets.assets_path }}"
 {{/if}}
 
+{{#if cfg.assets.docs_path}}
+[ret."Elixir.RetWeb.PageController"]
+docs_path = "{{ cfg.assets.docs_path }}"
+{{/if}}
+
 [ret."Elixir.Ret.Account"]
 {{#if cfg.accounts.admin_email }}
 admin_email = "{{ cfg.accounts.admin_email }}"

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -30,6 +30,9 @@ defmodule RetWeb.PageController do
 
       true ->
         case conn.request_path do
+          "/docs" -> render_docs_index(conn)
+          "/docs/" -> render_docs_index(conn)
+          "/docs" <> _ -> render_docs(conn)
           "/thumbnail/" <> _ -> imgproxy_proxy(conn)
           "/http://" <> _ -> cors_proxy(conn)
           "/https://" <> _ -> cors_proxy(conn)
@@ -535,6 +538,20 @@ defmodule RetWeb.PageController do
 
   defp render_asset(conn) do
     static_options = Plug.Static.init(at: "/", from: module_config(:assets_path), gzip: true, brotli: true)
+    Plug.Static.call(conn, static_options)
+  end
+
+  defp render_docs_index(conn) do
+    static_options = Plug.Static.init(at: "/docs", from: module_config(:docs_path), gzip: true, brotli: true)
+
+    Plug.Static.call(
+      conn |> Map.put(:request_path, "/docs/index.html") |> Map.put(:path_info, ["docs", "index.html"]),
+      static_options
+    )
+  end
+
+  defp render_docs(conn) do
+    static_options = Plug.Static.init(at: "/docs", from: module_config(:docs_path), gzip: true, brotli: true)
     Plug.Static.call(conn, static_options)
   end
 


### PR DESCRIPTION
Drop the idea of proxying docs which seems like a bad idea due to security risk. Start serving docs directly.