### PR TITLE
Properly return json responses as application/json

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,7 +21,8 @@ config :mime, :types, %{
   "model/gltf-binary" => ["glb"],
   "application/vnd.spoke.scene" => ["spoke"],
   "application/vnd.pgrst.object+json" => ["json"],
-  "application/wasm" => ["wasm"],
+  "application/json" => ["json"],
+  "application/wasm" => ["wasm"]
 }
 
 # Configures the endpoint


### PR DESCRIPTION
Fixes an issue where JSON response from reticulum are having their Content-Type set to `application.vnd.pgrst.object+json`