### PR TITLE
Fix issue with slack notifications

### DIFF
--- a/lib/ret/support.ex
+++ b/lib/ret/support.ex
@@ -36,7 +36,7 @@ defmodule Ret.Support do
   end
 
   defp notify_slack(emoji, message) do
-    with slack_url when is_binary(slack_url) <- module_config(:slack_webhook_url) do
+    with slack_url when is_binary(slack_url) and slack_url != "" <- module_config(:slack_webhook_url) do
       payload =
         %{
           "icon_emoji" => emoji,


### PR DESCRIPTION
Properly disables slack notifications if the configuration value is empty.