### PR TITLE
Set search_path before running migration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,7 +39,7 @@ config :logger, :console,
 
 config :ret, Ret.Repo,
   migration_source: "schema_migrations",
-  after_connect: {Ret.Repo, :set_search_path, ["public, ret0"]},
+  after_connect: {Ret.Repo, :set_search_path, ["ret0, public"]},
   # Downloads from Sketchfab to file cache hold connections open
   ownership_timeout: 60_000,
   timeout: 60_000

--- a/lib/ret/migration.ex
+++ b/lib/ret/migration.ex
@@ -1,0 +1,11 @@
+defmodule Ret.Migration do
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Migration
+
+      def after_begin() do
+        repo().query!("set search_path=ret0, public")
+      end
+    end
+  end
+end

--- a/priv/repo/migrations/20170917234137_create_sharding_ids.exs
+++ b/priv/repo/migrations/20170917234137_create_sharding_ids.exs
@@ -1,11 +1,11 @@
-
 defmodule Ret.Repo.Migrations.CreateShardingIds do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     execute("create schema ret0")
     execute("create sequence ret0.table_id_seq")
-    execute """
+
+    execute("""
     CREATE OR REPLACE FUNCTION ret0.next_id(OUT result bigint) AS $$
     DECLARE
     our_epoch bigint := 1505706041000;
@@ -21,10 +21,10 @@ defmodule Ret.Repo.Migrations.CreateShardingIds do
     result := result | (seq_id);
     END;
     $$ LANGUAGE PLPGSQL;
-    """
+    """)
   end
 
   def down do
-    execute "DROP SCHEMA ret0 CASCADE"
+    execute("DROP SCHEMA ret0 CASCADE")
   end
 end

--- a/priv/repo/migrations/20170917234138_create_users.exs
+++ b/priv/repo/migrations/20170917234138_create_users.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateUsers do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:users, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180322000442_drop_users_table.exs
+++ b/priv/repo/migrations/20180322000442_drop_users_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.DropUsersTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     drop(table(:users, prefix: "ret0"))

--- a/priv/repo/migrations/20180322000712_create_hubs_table.exs
+++ b/priv/repo/migrations/20180322000712_create_hubs_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateHubsTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:hubs, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180408231444_create_session_stats_table.exs
+++ b/priv/repo/migrations/20180408231444_create_session_stats_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateSessionStatsTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   @max_year 2030
 

--- a/priv/repo/migrations/20180409012805_add_max_occupants_to_hub.exs
+++ b/priv/repo/migrations/20180409012805_add_max_occupants_to_hub.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddMaxOccupantsToHub do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20180412225707_create_node_stats_table.exs
+++ b/priv/repo/migrations/20180412225707_create_node_stats_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.NodeStatsTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   @max_year 2022
 

--- a/priv/repo/migrations/20180416203936_add_entry_mode_to_hub.exs
+++ b/priv/repo/migrations/20180416203936_add_entry_mode_to_hub.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddEntryModeToHub do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     Ret.Hub.EntryMode.create_type()

--- a/priv/repo/migrations/20180802004115_extend_scene_column.exs
+++ b/priv/repo/migrations/20180802004115_extend_scene_column.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.ExtendSceneColumn do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20180808191456_add_has_media_objects_bit.exs
+++ b/priv/repo/migrations/20180808191456_add_has_media_objects_bit.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddHasMediaObjectsBit do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20180830224453_create_account.exs
+++ b/priv/repo/migrations/20180830224453_create_account.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateAccount do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:accounts, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180830224557_create_login.exs
+++ b/priv/repo/migrations/20180830224557_create_login.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateLogin do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:logins, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180831012904_create_login_tokens.exs
+++ b/priv/repo/migrations/20180831012904_create_login_tokens.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateLoginTokens do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:login_tokens, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180904221221_create_state_enums.exs
+++ b/priv/repo/migrations/20180904221221_create_state_enums.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateStateEnums do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     Ret.OwnedFile.State.create_type()

--- a/priv/repo/migrations/20180904221223_create_owned_files_table.exs
+++ b/priv/repo/migrations/20180904221223_create_owned_files_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateFilesTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:owned_files, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180904222223_create_scenes_table.exs
+++ b/priv/repo/migrations/20180904222223_create_scenes_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateScenesTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:scenes, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
+++ b/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddSupportSubscriptionsTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:support_subscriptions, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20180919002949_add_attribution_to_scene.exs
+++ b/priv/repo/migrations/20180919002949_add_attribution_to_scene.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddAttributionToScene do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("scenes") do

--- a/priv/repo/migrations/20180919235959_add_licensing_columns_to_scenes.exs
+++ b/priv/repo/migrations/20180919235959_add_licensing_columns_to_scenes.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddLicensingColumnsToScenes do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("scenes") do

--- a/priv/repo/migrations/20180920000254_add_scene_to_hubs.exs
+++ b/priv/repo/migrations/20180920000254_add_scene_to_hubs.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddSceneToHubs do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20180920032008_drop_null_constraint_on_gltf_bundle_url.exs
+++ b/priv/repo/migrations/20180920032008_drop_null_constraint_on_gltf_bundle_url.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.DropNullConstraintOnGltfBundleUrl do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20180920222237_extend_attribution_column.exs
+++ b/priv/repo/migrations/20180920222237_extend_attribution_column.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.ExtendAttributionColumn do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("scenes") do

--- a/priv/repo/migrations/20180924005229_add_entry_codes_to_hubs.exs
+++ b/priv/repo/migrations/20180924005229_add_entry_codes_to_hubs.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddEntryCodesToHubs do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20181015020416_add_web_push_subscriptions.exs
+++ b/priv/repo/migrations/20181015020416_add_web_push_subscriptions.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddWebPushSubscriptions do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:web_push_subscriptions, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20181024050853_add_room_objects.exs
+++ b/priv/repo/migrations/20181024050853_add_room_objects.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateRoomObjectsTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:room_objects, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20181102010842_add_attributions_to_scene.exs
+++ b/priv/repo/migrations/20181102010842_add_attributions_to_scene.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddAttributionsToScene do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("scenes") do

--- a/priv/repo/migrations/20181102011004_migrate_attributions.exs
+++ b/priv/repo/migrations/20181102011004_migrate_attributions.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.MigrateAttributions do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     execute("update scenes set attributions = json_build_object('extras', scenes.attribution)")

--- a/priv/repo/migrations/20181113033726_add_account_to_room_objects.exs
+++ b/priv/repo/migrations/20181113033726_add_account_to_room_objects.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddAccountToRoomObjects do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("room_objects") do

--- a/priv/repo/migrations/20181127021310_add_inactive_to_owned_file_state_enum.exs
+++ b/priv/repo/migrations/20181127021310_add_inactive_to_owned_file_state_enum.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddInactiveToOwnedFileStateEnum do
-  use Ecto.Migration
+  use Ret.Migration
   @disable_ddl_transaction true
 
   def change do

--- a/priv/repo/migrations/20181128022000_add_min_token_issued_at_to_account.exs
+++ b/priv/repo/migrations/20181128022000_add_min_token_issued_at_to_account.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddMinTokenIssuedAtToAccount do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     epoch = DateTime.from_unix!(0, :second) |> DateTime.truncate(:second) |> DateTime.to_iso8601()

--- a/priv/repo/migrations/20181227040710_add_host_to_hub.exs
+++ b/priv/repo/migrations/20181227040710_add_host_to_hub.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddHostToHub do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190114122412_add_created_by_to_hubs.exs
+++ b/priv/repo/migrations/20190114122412_add_created_by_to_hubs.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddCreatedByToHubs do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190114232257_add_reviewed_at_to_scenes.exs
+++ b/priv/repo/migrations/20190114232257_add_reviewed_at_to_scenes.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddReviewedAtToScenes do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("scenes") do

--- a/priv/repo/migrations/20190115003917_add_scene_listings.exs
+++ b/priv/repo/migrations/20190115003917_add_scene_listings.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddSceneListings do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     Ret.SceneListing.State.create_type()

--- a/priv/repo/migrations/20190125190651_alter_object_type_column_to_bigint.exs
+++ b/priv/repo/migrations/20190125190651_alter_object_type_column_to_bigint.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AlterObjectTypeColumnToBigint do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190130052213_add_is_admin_column.exs
+++ b/priv/repo/migrations/20190130052213_add_is_admin_column.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddIsAdminColumn do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("accounts") do

--- a/priv/repo/migrations/20190131231854_create_avatars.exs
+++ b/priv/repo/migrations/20190131231854_create_avatars.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateAvatars do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:avatars, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20190208014624_add_scene_listing_id_to_hubs.exs
+++ b/priv/repo/migrations/20190208014624_add_scene_listing_id_to_hubs.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddSceneListingIdToHubs do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190305181357_add_hub_bindings_table.exs
+++ b/priv/repo/migrations/20190305181357_add_hub_bindings_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddHubBindingsTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     Ret.HubBinding.Type.create_type()

--- a/priv/repo/migrations/20190305190955_add_oauth_providers_table.exs
+++ b/priv/repo/migrations/20190305190955_add_oauth_providers_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddOauthProvidersTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     Ret.OAuthProvider.Source.create_type()

--- a/priv/repo/migrations/20190306032224_create_projects.exs
+++ b/priv/repo/migrations/20190306032224_create_projects.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateProjects do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:projects, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20190312171503_add_removed_state_to_scenes.exs
+++ b/priv/repo/migrations/20190312171503_add_removed_state_to_scenes.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddRemovedStateToScenes do
-  use Ecto.Migration
+  use Ret.Migration
   @disable_ddl_transaction true
 
   def change do

--- a/priv/repo/migrations/20190322222314_add_cached_files.exs
+++ b/priv/repo/migrations/20190322222314_add_cached_files.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddCachedFiles do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:cached_files, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20190329004012_create_asset_type_enum.exs
+++ b/priv/repo/migrations/20190329004012_create_asset_type_enum.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateAssetTypeEnum do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     Ret.Asset.Type.create_type()

--- a/priv/repo/migrations/20190329004026_create_assets_tables.exs
+++ b/priv/repo/migrations/20190329004026_create_assets_tables.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateAssetsTables do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:assets, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20190424010558_add_thumbnail_to_avatar.exs
+++ b/priv/repo/migrations/20190424010558_add_thumbnail_to_avatar.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddThumbnailToAvatar do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table(:avatars) do

--- a/priv/repo/migrations/20190501221754_create_avatar_listings.exs
+++ b/priv/repo/migrations/20190501221754_create_avatar_listings.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateAvatarListings do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     Ret.AvatarListing.State.create_type()

--- a/priv/repo/migrations/20190503170158_add_creator_assignment_token.exs
+++ b/priv/repo/migrations/20190503170158_add_creator_assignment_token.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddCreatorAssignmentToken do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
+++ b/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.UpdateAvatarConstraints do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     drop constraint(:avatars, :gltf_or_parent)

--- a/priv/repo/migrations/20190514175300_add_last_active_at.exs
+++ b/priv/repo/migrations/20190514175300_add_last_active_at.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddLastActiveAt do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190605002622_add_embed_token_to_hubs.exs
+++ b/priv/repo/migrations/20190605002622_add_embed_token_to_hubs.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddEmbedTokenToHubs do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190605213019_add_embedded_flag_to_hubs.exs
+++ b/priv/repo/migrations/20190605213019_add_embedded_flag_to_hubs.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddEmbeddedFlagToHubs do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190606012330_add_account_hub_favorites.exs
+++ b/priv/repo/migrations/20190606012330_add_account_hub_favorites.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddAccountHubFavorites do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:account_favorites, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
+++ b/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
@@ -1,6 +1,6 @@
 defmodule Ret.Repo.Migrations.AddPermissionsToHubs do
   use Bitwise
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("hubs") do

--- a/priv/repo/migrations/20190614211950_add_twitter_to_oauth_type.exs
+++ b/priv/repo/migrations/20190614211950_add_twitter_to_oauth_type.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddTwitterToOauthType do
-  use Ecto.Migration
+  use Ret.Migration
   @disable_ddl_transaction true
 
   def change do

--- a/priv/repo/migrations/20190615010958_add_provider_access_tokens.exs
+++ b/priv/repo/migrations/20190615010958_add_provider_access_tokens.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddProviderAccessTokens do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("oauth_providers") do

--- a/priv/repo/migrations/20190703224946_add_login_token_payload_keys.exs
+++ b/priv/repo/migrations/20190703224946_add_login_token_payload_keys.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddLoginTokenPayloadKeys do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("login_tokens") do

--- a/priv/repo/migrations/20190717173132_create_hub_role_memberships.exs
+++ b/priv/repo/migrations/20190717173132_create_hub_role_memberships.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateHubRoleMemberships do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:hub_role_memberships, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
+++ b/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddAvatarListingsAccount do
-  use Ecto.Migration
+  use Ret.Migration
   import Ecto.Query
 
   alias Ret.{Repo, Avatar}

--- a/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
+++ b/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddAvatarListingsRemovedState do
-  use Ecto.Migration
+  use Ret.Migration
   import Ecto.Query
   alias Ret.{Repo, AvatarListing}
 

--- a/priv/repo/migrations/20190904000046_admin_schema_init.exs
+++ b/priv/repo/migrations/20190904000046_admin_schema_init.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AdminSchemaInit do
-  use Ecto.Migration
+  use Ret.Migration
   @disable_ddl_transaction true
 
   def up do

--- a/priv/repo/migrations/20191011184435_create_app_configs_table.exs
+++ b/priv/repo/migrations/20191011184435_create_app_configs_table.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.CreateAppConfigsTable do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     create table(:app_configs, prefix: "ret0", primary_key: false) do

--- a/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
+++ b/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddImportedFromColumns do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("avatars") do

--- a/priv/repo/migrations/20191015184128_add_fk_lookup_on_listings.exs
+++ b/priv/repo/migrations/20191015184128_add_fk_lookup_on_listings.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     execute("""

--- a/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
+++ b/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
-  use Ecto.Migration
+  use Ret.Migration
 
   def up do
     # Drops scene listings view and featured, pending scenes view

--- a/priv/repo/migrations/20191111234010_add_parenting_to_scenes.exs
+++ b/priv/repo/migrations/20191111234010_add_parenting_to_scenes.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddParentingToScenes do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("scenes") do

--- a/priv/repo/migrations/20191121222742_add_parent_to_projects.exs
+++ b/priv/repo/migrations/20191121222742_add_parent_to_projects.exs
@@ -1,5 +1,5 @@
 defmodule Ret.Repo.Migrations.AddParentToProjects do
-  use Ecto.Migration
+  use Ret.Migration
 
   def change do
     alter table("projects") do


### PR DESCRIPTION
It seems there is an issue with `after_connect` not retaining the search path properly during the initial migration in self hosted instances. (Perhaps the search path is being altered by ecto during migration table setup.) This forces the search path to be set before each migration individually.