### PR TITLE
Pass account along to scene rendering

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -698,7 +698,7 @@ defmodule RetWeb.HubChannel do
     account = Guardian.Phoenix.Socket.current_resource(socket)
 
     response =
-      HubView.render("show.json", %{hub: hub, embeddable: account |> can?(embed_hub(hub))})
+      HubView.render("show.json", %{hub: hub, embeddable: account |> can?(embed_hub(hub)), account: account})
       |> Map.put(:session_id, socket.assigns.session_id)
       |> Map.put(:stale_fields, stale_fields)
 

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -12,19 +12,19 @@ defmodule RetWeb.Api.V1.HubView do
     }
   end
 
-  def render("show.json", %{hub: %Hub{scene: %Scene{}} = hub, embeddable: embeddable}) do
-    hub |> render_with_scene(embeddable)
+  def render("show.json", %{hub: %Hub{scene: %Scene{}} = hub, embeddable: embeddable} = params) do
+    hub |> render_with_scene(embeddable, params[:account])
   end
 
-  def render("show.json", %{hub: %Hub{scene_listing: %SceneListing{}} = hub, embeddable: embeddable}) do
-    hub |> render_with_scene(embeddable)
+  def render("show.json", %{hub: %Hub{scene_listing: %SceneListing{}} = hub, embeddable: embeddable} = params) do
+    hub |> render_with_scene(embeddable, params[:account])
   end
 
   def render("show.json", %{hub: hub}) do
     hub |> render_with_scene_asset(:gltf_bundle, hub.default_environment_gltf_bundle_url)
   end
 
-  def render_with_scene(hub, embeddable) do
+  defp render_with_scene(hub, embeddable, account) do
     %{
       hubs: [
         %{
@@ -35,7 +35,7 @@ defmodule RetWeb.Api.V1.HubView do
           entry_mode: hub.entry_mode,
           host: hub.host,
           port: janus_port(),
-          scene: RetWeb.Api.V1.SceneView.render_scene(hub.scene || hub.scene_listing, nil),
+          scene: RetWeb.Api.V1.SceneView.render_scene(hub.scene || hub.scene_listing, account),
           embed_token:
             if embeddable do
               hub.embed_token


### PR DESCRIPTION
This fixes a bug where when we render the `scene` for a hub when connecting to a room, we fail to pass the `account` for the user along to the renderer, which results in a `null` `account_id` in the response regardless of if the user who is logged in created the scene.

Without this PR, the scene link in the room and scene info dialog will be disabled, even if logged in as the scene creator.