### PR TITLE
Fix cert path resolution on non-WSL Windows

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -25,8 +25,8 @@ config :ret, RetWeb.Endpoint,
     port: 4000,
     otp_app: :ret,
     cipher_suite: :strong,
-    keyfile: "#{System.get_env("PWD")}/priv/dev-ssl.key",
-    certfile: "#{System.get_env("PWD")}/priv/dev-ssl.cert"
+    keyfile: "#{File.cwd!()}/priv/dev-ssl.key",
+    certfile: "#{File.cwd!()}/priv/dev-ssl.cert"
   ],
   cors_proxy_url: [scheme: "https", host: cors_proxy_host, port: 4000],
   assets_url: [scheme: "https", host: assets_host, port: 4000],


### PR DESCRIPTION
`System.get_env("PWD")` was returning an empty string and causing errors when running the dev server. This PR fixes it by using the `File.cwd!` function instead which works cross platform.