### PR TITLE
Improve Quality of 360 Youtube Videos

### DIFF
--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -102,6 +102,10 @@ defmodule RetWeb.Api.V1.MediaController do
     end
   end
 
+  defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, audio_uri: audio_uri, meta: meta} = res) do
+    conn |> render("show.json", origin: uri |> URI.to_string(), origin_audio: audio_uri |> URI.to_string(), meta: meta)
+  end
+
   defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}) do
     conn |> render("show.json", origin: uri |> URI.to_string(), meta: meta)
   end

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -102,7 +102,8 @@ defmodule RetWeb.Api.V1.MediaController do
     end
   end
 
-  defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, audio_uri: audio_uri, meta: meta} = res) do
+  defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, audio_uri: audio_uri, meta: meta} = res)
+       when audio_uri != nil do
     conn |> render("show.json", origin: uri |> URI.to_string(), origin_audio: audio_uri |> URI.to_string(), meta: meta)
   end
 

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -2,6 +2,9 @@ defmodule RetWeb.Api.V1.MediaController do
   use RetWeb, :controller
   use Retry
 
+  def create(conn, %{"media" => %{"url" => url, "quality" => quality}, "version" => version}),
+    do: resolve_and_render(conn, url, version, String.to_atom(quality))
+
   def create(conn, %{"media" => %{"url" => url}, "version" => version}), do: resolve_and_render(conn, url, version)
   def create(conn, %{"media" => %{"url" => url}}), do: resolve_and_render(conn, url, 1)
 
@@ -69,7 +72,9 @@ defmodule RetWeb.Api.V1.MediaController do
     end
   end
 
-  defp resolve_and_render(conn, url, version) do
+  defp resolve_and_render(conn, url, version, quality \\ nil) do
+    quality = quality || default_quality(conn)
+
     ua =
       conn
       |> Plug.Conn.get_req_header("user-agent")
@@ -77,12 +82,11 @@ defmodule RetWeb.Api.V1.MediaController do
       |> UAParser.parse()
 
     supports_webm = ua.family != "Safari" && ua.family != "Mobile Safari"
-    low_resolution = ua.os.family == "Android" || ua.os.family == "iOS"
 
     query = %Ret.MediaResolverQuery{
       url: url,
       supports_webm: supports_webm,
-      low_resolution: low_resolution,
+      quality: quality,
       version: version
     }
 
@@ -100,5 +104,19 @@ defmodule RetWeb.Api.V1.MediaController do
 
   defp render_resolved_media(conn, %Ret.ResolvedMedia{uri: uri, meta: meta}) do
     conn |> render("show.json", origin: uri |> URI.to_string(), meta: meta)
+  end
+
+  defp default_quality(conn) do
+    ua =
+      conn
+      |> Plug.Conn.get_req_header("user-agent")
+      |> List.first()
+      |> UAParser.parse()
+
+    if ua.os.family == "Android" || ua.os.family == "iOS" do
+      :low
+    else
+      :high
+    end
   end
 end

--- a/lib/ret_web/views/api/v1/media_view.ex
+++ b/lib/ret_web/views/api/v1/media_view.ex
@@ -9,6 +9,10 @@ defmodule RetWeb.Api.V1.MediaView do
     %{file_id: file_id, origin: origin, meta: meta}
   end
 
+  def render("show.json", %{origin: origin, origin_audio: origin_audio, meta: meta}) do
+    %{origin: origin, origin_audio: origin_audio, meta: meta}
+  end
+
   def render("show.json", %{origin: origin, meta: meta}) do
     %{origin: origin, meta: meta}
   end


### PR DESCRIPTION
Updates the media resolver to properly deal with youtube 360 videos. Particularly:

- Changes the boolean `low_resolution` flag to now be a `quality` measure, which can be `low`, `high`, `low_360`, or `high_360`
- Updates the API so the client now can specify quality, instead of deriving it from the user agent
- `low_360` and `high_360` now perform two `youtube-dl` requests in order to extract the video and audio streams separately. this is done because it was determined that youtube serves these up separately for 360 videos, there is no way to get an all-in-one stream.
- if there's a separate audio stream, it is returned in `origin_audio`
- deals with a change in youtube where you can't get equirectangular 360 videos unless you pass an empty user-agent string (youtube dl server has been patched to support this) -- see https://github.com/ytdl-org/youtube-dl/issues/15267#issuecomment-370122336
