### PR TITLE
Feature/hubs page resolution

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -8,7 +8,7 @@ assets_host = "hubs-assets.local"
 link_host = "hubs-link.local"
 
 # To run reticulum across a LAN for local testing, uncomment and change the line below to the LAN IP
-# host = "192.168.1.27"
+# host = cors_proxy_host = "192.168.1.27"
 
 dev_janus_host = "dev-janus.reticulum.io"
 

--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -60,8 +60,12 @@ defmodule Ret.HttpUtils do
     end
   end
 
+  def get_http_header(headers, header) do
+    headers |> Enum.find(fn h -> h |> elem(0) |> String.downcase() === header end) |> elem(1)
+  end
+
   def content_type_from_headers(headers) do
-    headers |> Enum.find(fn h -> h |> elem(0) |> String.downcase() === "content-type" end) |> elem(1)
+    headers |> get_http_header("content-type")
   end
 
   def fetch_content_type(url) do

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -244,19 +244,25 @@ defmodule Ret.MediaResolver do
         nil
 
       %HTTPoison.Response{headers: headers} ->
-        content_type = headers |> content_type_from_headers
+        case headers |> get_http_header("hub-entity-type") do
+          entity when entity != nil ->
+            uri |> opengraph_result_for_uri("text/vnd.hubs-#{entity}")
 
-        if content_type |> String.starts_with?("text/html") do
-          if !is_local_url && photomnemonic_endpoint do
-            case uri |> screenshot_commit_for_uri(content_type, version) do
-              :error -> uri |> og_tag_commit_for_uri()
-              commit -> commit
+          _ ->
+            content_type = headers |> content_type_from_headers
+
+            if content_type |> String.starts_with?("text/html") do
+              if !is_local_url && photomnemonic_endpoint do
+                case uri |> screenshot_commit_for_uri(content_type, version) do
+                  :error -> uri |> opengraph_result_for_uri()
+                  commit -> commit
+                end
+              else
+                uri |> opengraph_result_for_uri()
+              end
+            else
+              {:commit, uri |> resolved(%{expected_content_type: content_type})}
             end
-          else
-            uri |> og_tag_commit_for_uri()
-          end
-        else
-          {:commit, uri |> resolved(%{expected_content_type: content_type})}
         end
     end
   end
@@ -292,7 +298,7 @@ defmodule Ret.MediaResolver do
     end
   end
 
-  defp og_tag_commit_for_uri(uri) do
+  defp opengraph_result_for_uri(uri, expected_content_type \\ nil) do
     case uri |> URI.to_string() |> retry_get_until_success([{"Range", "bytes=0-32768"}]) do
       :error ->
         :error
@@ -313,7 +319,15 @@ defmodule Ret.MediaResolver do
             nil
           end
 
-        meta = %{expected_content_type: content_type_from_headers(resp.headers), thumbnail: thumbnail}
+        meta = %{
+          expected_content_type:
+            if expected_content_type do
+              expected_content_type
+            else
+              content_type_from_headers(resp.headers)
+            end,
+          thumbnail: thumbnail
+        }
 
         {:commit, uri |> resolved(meta)}
     end


### PR DESCRIPTION
Adds ability for reticulum media resolver to properly crawl hubs entities (rooms, avatars, scenes) and return the appropriate thumbnail + content subtype (`hubs-room`, `hubs-scene`, `hubs-avatar`)