### PR TITLE
Add proper hub headers to link pages

### DIFF
--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -117,12 +117,24 @@ defmodule RetWeb.PageController do
     |> render_avatar_content(conn)
   end
 
-  def render_for_path("/link", _params, conn), do: conn |> render_page("link.html", :hubs, "link-meta.html")
-  def render_for_path("/link/", _params, conn), do: conn |> render_page("link.html", :hubs, "link-meta.html")
+  def render_for_path("/link", _params, conn),
+    do:
+      conn
+      |> put_hub_headers("hub")
+      |> render_page("link.html", :hubs, "link-meta.html")
+
+  def render_for_path("/link/", _params, conn),
+    do:
+      conn
+      |> put_hub_headers("hub")
+      |> render_page("link.html", :hubs, "link-meta.html")
 
   def render_for_path("/link/" <> hub_identifier_and_slug, _params, conn) do
     hub_identifier = hub_identifier_and_slug |> String.split("/") |> List.first()
-    conn |> redirect_to_hub_identifier(hub_identifier)
+
+    conn
+    |> put_hub_headers("link")
+    |> redirect_to_hub_identifier(hub_identifier)
   end
 
   def render_for_path("/discord", _params, conn), do: conn |> render_page("discord.html")

--- a/mix.lock
+++ b/mix.lock
@@ -85,7 +85,7 @@
   "rabbit_common": {:git, "https://github.com/jbrisbin/rabbit_common.git", "9c1965273032ffb79ec0ff80b250e5d0b4608aa7", [ref: ""]},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "retry": {:hex, :retry, "0.13.0", "bb9b2713f70f39337837852337ad280c77662574f4fb852a8386c269f3d734c4", [:mix], [], "hexpm"},
-  "reverse_proxy_plug": {:git, "https://github.com/mozillareality/reverse_proxy_plug.git", "49fb43eea8c8bcbc8fd6f08b9d043dbaf89ea779", [branch: "reticulum/master"]},
+  "reverse_proxy_plug": {:git, "https://github.com/mozillareality/reverse_proxy_plug.git", "cc1dc8ce075c59fbf019c73d42200d7b0ba2ac3a", [branch: "reticulum/master"]},
   "scrivener": {:hex, :scrivener, "2.7.0", "fa94cdea21fad0649921d8066b1833d18d296217bfdf4a5389a2f45ee857b773", [:mix], [], "hexpm"},
   "scrivener_ecto": {:hex, :scrivener_ecto, "2.2.0", "53d5f1ba28f35f17891cf526ee102f8f225b7024d1cdaf8984875467158c9c5e", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm"},
   "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm"},


### PR DESCRIPTION
Fixes issues with resolving short links on client because we were not handling redirects properly in reticulum-based cors proxy and were not including the proper HTTP headers in responses.