### PR TITLE
Feature/thumbnail for hubs content

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -8,7 +8,7 @@ assets_host = "hubs-assets.local"
 link_host = "hubs-link.local"
 
 # To run reticulum across a LAN for local testing, uncomment and change the line below to the LAN IP
-# host = "192.168.1.27"
+# host = cors_proxy_host = "192.168.1.27"
 
 dev_janus_host = "dev-janus.reticulum.io"
 

--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -60,8 +60,12 @@ defmodule Ret.HttpUtils do
     end
   end
 
+  def get_http_header(headers, header) do
+    headers |> Enum.find(fn h -> h |> elem(0) |> String.downcase() === header end) |> elem(1)
+  end
+
   def content_type_from_headers(headers) do
-    headers |> Enum.find(fn h -> h |> elem(0) |> String.downcase() === "content-type" end) |> elem(1)
+    headers |> get_http_header("content-type")
   end
 
   def fetch_content_type(url) do


### PR DESCRIPTION
Previously, reticulum would use photomnemonic to generate thumbnails for remote hubs rooms, but in practice this is problematic since we expose the correct thumbnail via OG tags. This PR updates reticulum to do OG tag crawling for pages which have a hub entity type.