### PR TITLE
Quick fixes to public rooms PR

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -136,7 +136,7 @@ defmodule Ret.Hub do
   end
 
   def add_promotion_to_changeset(changeset, attrs) do
-    changeset |> put_change(:allow_promotion, attrs["allow_promotion"])
+    changeset |> put_change(:allow_promotion, !!attrs["allow_promotion"])
   end
 
   def changeset_for_new_seen_occupant_count(%Hub{} = hub, occupant_count) do

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -310,7 +310,7 @@ defmodule RetWeb.PageController do
   end
 
   defp render_index(conn, _method) do
-    conn |> render_homepage_content(AppConfig.get_config_value("features|default_room_id"))
+    conn |> render_homepage_content(get_app_config_value("features|default_room_id"))
   end
 
   defp put_hub_headers(conn, entity_type) do


### PR DESCRIPTION
Adds caching to the "default room" check on the index page, and a null check for `allow_promotion` on room settings API (for backwards compat).