### PR TITLE
Basic v1 account creation API

### DIFF
--- a/lib/ret/json_schema_api_error_formatter.ex
+++ b/lib/ret/json_schema_api_error_formatter.ex
@@ -1,0 +1,6 @@
+defmodule Ret.JsonSchemaApiErrorFormatter do
+  def format(errors) do
+    ExJsonSchema.Validator.Error.StringFormatter.format(errors)
+    |> Enum.map(&{:MALFORMED_RECORD, elem(&1, 0), elem(&1, 1)})
+  end
+end

--- a/lib/ret/string_utils.ex
+++ b/lib/ret/string_utils.ex
@@ -1,3 +1,0 @@
-defmodule Ret.StringUtils do
-  def valid_email?(email), do: Regex.match?(~r/^[A-Za-z0-9\._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/, email)
-end

--- a/lib/ret/string_utils.ex
+++ b/lib/ret/string_utils.ex
@@ -1,0 +1,3 @@
+defmodule Ret.StringUtils do
+  def valid_email?(email), do: Regex.match?(~r/^[A-Za-z0-9\._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/, email)
+end

--- a/lib/ret_web.ex
+++ b/lib/ret_web.ex
@@ -29,8 +29,9 @@ defmodule RetWeb do
 
   def view do
     quote do
-      use Phoenix.View, root: "lib/ret_web/templates",
-                        namespace: RetWeb
+      use Phoenix.View,
+        root: "lib/ret_web/templates",
+        namespace: RetWeb
 
       # Import convenience functions from controllers
       import Phoenix.Controller, only: [get_flash: 2, view_module: 1]

--- a/lib/ret_web/api_helpers.ex
+++ b/lib/ret_web/api_helpers.ex
@@ -1,0 +1,85 @@
+defmodule RetWeb.ApiHelpers do
+  import Plug.Conn
+
+  # In an API create routine, call this with a handler.
+  # The handler will get passed the (validated) record and source and should return either:
+  #   { :ok, { http_status, result } }
+  #   { :error, [ { code, details, source } ] }
+  # TODO dialyzer this
+  def exec_api_create(conn, %{"data" => data}, schema, handler), do: process_create_records(conn, data, schema, handler)
+
+  def exec_api_create(conn, _invalid_params, _schema, _handler) do
+    conn |> send_error_resp([{:MALFORMED_REQUEST, "Missing 'data' property in request.", nil}])
+  end
+
+  defp process_create_records(conn, record, schema, handler) when is_map(record) do
+    case ExJsonSchema.Validator.validate(schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
+      :ok ->
+        case handler.(record, "data") do
+          {:ok, {status, result}} ->
+            conn |> send_resp(status, %{"data" => result} |> Poison.encode!())
+
+          {:error, errors} ->
+            conn |> send_error_resp(errors)
+        end
+
+      {:error, errors} ->
+        conn
+        |> send_error_resp(
+          Enum.map(errors, fn {code, detail, source} -> {code, detail, source |> String.replace(~r/^#/, "data")} end)
+        )
+    end
+  end
+
+  defp process_create_records(conn, records, schema, handler) when is_list(records) do
+    results =
+      records
+      |> Enum.with_index()
+      |> Enum.map(fn {record, index} ->
+        case ExJsonSchema.Validator.validate(schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
+          :ok ->
+            case handler.(record, "data[#{index}]") do
+              {:ok, {status, result}} ->
+                %{status: status, body: %{"data" => result}}
+
+              {:error, errors} ->
+                %{status: 400, body: to_error_multi_request_response(errors)}
+            end
+
+          {:error, errors} ->
+            %{
+              status: 400,
+              body:
+                to_error_multi_request_response(
+                  Enum.map(errors, fn {code, detail, source} ->
+                    {code, detail, source |> String.replace(~r/^#/, "data[#{index}]")}
+                  end)
+                )
+            }
+        end
+      end)
+
+    conn |> send_resp(207, results |> Poison.encode!())
+  end
+
+  defp process_create_records(conn, _record, _schema, _handler) do
+    conn
+    |> send_error_resp([{:MALFORMED_RECORD, "Malformed record in 'data' property.", "data"}])
+  end
+
+  defp send_error_resp(conn, [{:RECORD_EXISTS, _detail, _source}] = errors), do: conn |> send_error_resp(409, errors)
+  defp send_error_resp(conn, errors), do: send_error_resp(conn, 400, errors)
+
+  defp send_error_resp(conn, status, errors) do
+    conn
+    |> send_resp(
+      status,
+      %{errors: Enum.map(errors, fn {code, detail, source} -> %{code: code, detail: detail, source: source} end)}
+      |> Poison.encode!()
+    )
+  end
+
+  defp to_error_multi_request_response(errors) do
+    %{errors: Enum.map(errors, fn {code, detail, source} -> %{code: code, detail: detail, source: source} end)}
+  end
+end

--- a/lib/ret_web/api_helpers.ex
+++ b/lib/ret_web/api_helpers.ex
@@ -6,18 +6,19 @@ defmodule RetWeb.ApiHelpers do
   #   { :ok, { http_status, result } }
   #   { :error, [ { code, details, source } ] }
   # TODO dialyzer this
-  def exec_api_create(conn, %{"data" => data}, schema, handler), do: process_create_records(conn, data, schema, handler)
+  def exec_api_create(conn, %{"records" => records}, schema, handler),
+    do: process_create_records(conn, records, schema, handler)
 
   def exec_api_create(conn, _invalid_params, _schema, _handler) do
-    conn |> send_error_resp([{:MALFORMED_REQUEST, "Missing 'data' property in request.", nil}])
+    conn |> send_error_resp([{:MALFORMED_REQUEST, "Missing 'records' property in request.", nil}])
   end
 
   defp process_create_records(conn, record, schema, handler) when is_map(record) do
     case ExJsonSchema.Validator.validate(schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
       :ok ->
-        case handler.(record, "data") do
+        case handler.(record, "records") do
           {:ok, {status, result}} ->
-            conn |> send_resp(status, %{"data" => result} |> Poison.encode!())
+            conn |> send_resp(status, %{"records" => result} |> Poison.encode!())
 
           {:error, errors} ->
             conn |> send_error_resp(errors)
@@ -26,7 +27,7 @@ defmodule RetWeb.ApiHelpers do
       {:error, errors} ->
         conn
         |> send_error_resp(
-          Enum.map(errors, fn {code, detail, source} -> {code, detail, source |> String.replace(~r/^#/, "data")} end)
+          Enum.map(errors, fn {code, detail, source} -> {code, detail, source |> String.replace(~r/^#/, "records")} end)
         )
     end
   end
@@ -38,9 +39,9 @@ defmodule RetWeb.ApiHelpers do
       |> Enum.map(fn {record, index} ->
         case ExJsonSchema.Validator.validate(schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
           :ok ->
-            case handler.(record, "data[#{index}]") do
+            case handler.(record, "records[#{index}]") do
               {:ok, {status, result}} ->
-                %{status: status, body: %{"data" => result}}
+                %{status: status, body: %{"records" => result}}
 
               {:error, errors} ->
                 %{status: 400, body: to_error_multi_request_response(errors)}
@@ -52,7 +53,7 @@ defmodule RetWeb.ApiHelpers do
               body:
                 to_error_multi_request_response(
                   Enum.map(errors, fn {code, detail, source} ->
-                    {code, detail, source |> String.replace(~r/^#/, "data[#{index}]")}
+                    {code, detail, source |> String.replace(~r/^#/, "records[#{index}]")}
                   end)
                 )
             }
@@ -64,7 +65,7 @@ defmodule RetWeb.ApiHelpers do
 
   defp process_create_records(conn, _record, _schema, _handler) do
     conn
-    |> send_error_resp([{:MALFORMED_RECORD, "Malformed record in 'data' property.", "data"}])
+    |> send_error_resp([{:MALFORMED_RECORD, "Malformed record in 'records' property.", "records"}])
   end
 
   defp send_error_resp(conn, [{:RECORD_EXISTS, _detail, _source}] = errors), do: conn |> send_error_resp(409, errors)

--- a/lib/ret_web/api_helpers.ex
+++ b/lib/ret_web/api_helpers.ex
@@ -7,13 +7,13 @@ defmodule RetWeb.ApiHelpers do
   #   { :error, [ { code, details, source } ] }
   # TODO dialyzer this
   def exec_api_create(conn, %{"records" => records}, schema, handler),
-    do: process_create_records(conn, records, schema, handler)
+    do: create_records(conn, records, schema, handler)
 
   def exec_api_create(conn, _invalid_params, _schema, _handler) do
     conn |> send_error_resp([{:MALFORMED_REQUEST, "Missing 'records' property in request.", nil}])
   end
 
-  defp process_create_records(conn, record, schema, handler) when is_map(record) do
+  defp create_records(conn, record, schema, handler) when is_map(record) do
     case ExJsonSchema.Validator.validate(schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
       :ok ->
         case handler.(record, "records") do
@@ -32,7 +32,7 @@ defmodule RetWeb.ApiHelpers do
     end
   end
 
-  defp process_create_records(conn, records, schema, handler) when is_list(records) do
+  defp create_records(conn, records, schema, handler) when is_list(records) do
     results =
       records
       |> Enum.with_index()
@@ -63,7 +63,7 @@ defmodule RetWeb.ApiHelpers do
     conn |> send_resp(207, results |> Poison.encode!())
   end
 
-  defp process_create_records(conn, _record, _schema, _handler) do
+  defp create_records(conn, _record, _schema, _handler) do
     conn
     |> send_error_resp([{:MALFORMED_RECORD, "Malformed record in 'records' property.", "records"}])
   end

--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -1,7 +1,7 @@
 defmodule RetWeb.Api.V1.AccountController do
   use RetWeb, :controller
 
-  alias Ret.{Account, Repo}
+  alias Ret.{Account}
 
   # TODO move to a file
   @record_schema %{
@@ -17,15 +17,17 @@ defmodule RetWeb.Api.V1.AccountController do
                  |> ExJsonSchema.Schema.resolve()
 
   def create(conn, params) do
-    exec_create(conn, params, &process_account_create_record/3)
+    exec_create(conn, params, &process_account_create_record/2)
   end
 
-  defp process_account_create_record(conn, %{"email" => email}, source) do
-    {:ok, {200, "OK"}}
-    # case result do
-    #  :ok -> render(conn, "create.json", hub: hub)
-    #  :error -> conn |> send_resp(422, "invalid hub")
-    # end
+  defp process_account_create_record(%{"email" => email}, source) do
+    if Account.exists_for_email?(email) do
+      {:error, [{:RECORD_EXISTS, "Account with email already exists.", source}]}
+    else
+      # TODO return account info
+      Account.find_or_create_account_for_email(email)
+      {:ok, {200, "OK"}}
+    end
   end
 
   # Utility functions
@@ -38,7 +40,7 @@ defmodule RetWeb.Api.V1.AccountController do
   defp process_create_records(conn, record, handler) when is_map(record) do
     case ExJsonSchema.Validator.validate(@record_schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
       :ok ->
-        case handler.(conn, record, "data") do
+        case handler.(record, "data") do
           {:ok, {status, body}} ->
             conn |> send_resp(status, body)
 
@@ -54,15 +56,18 @@ defmodule RetWeb.Api.V1.AccountController do
     end
   end
 
-  defp process_create_records(conn, _record, handler) do
+  defp process_create_records(conn, _record, _handler) do
     conn
     |> send_error_resp([{:MALFORMED_RECORD, "Malformed record in 'data' property.", "data"}])
   end
 
-  defp send_error_resp(conn, errors) do
+  defp send_error_resp(conn, [{:RECORD_EXISTS, _detail, _source}] = errors), do: conn |> send_error_resp(409, errors)
+  defp send_error_resp(conn, errors), do: send_error_resp(conn, 400, errors)
+
+  defp send_error_resp(conn, status, errors) do
     conn
     |> send_resp(
-      400,
+      status,
       %{errors: Enum.map(errors, fn {code, detail, source} -> %{code: code, detail: detail, source: source} end)}
       |> Poison.encode!()
     )

--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -31,6 +31,4 @@ defmodule RetWeb.Api.V1.AccountController do
       {:ok, {200, Phoenix.View.render(AccountView, "create.json", account: account, email: email)}}
     end
   end
-
-  # Utility functions
 end

--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -1,5 +1,6 @@
 defmodule RetWeb.Api.V1.AccountController do
   use RetWeb, :controller
+  import RetWeb.ApiHelpers
 
   alias Ret.{Account}
   alias RetWeb.Api.V1.{AccountView}
@@ -18,7 +19,7 @@ defmodule RetWeb.Api.V1.AccountController do
                  |> ExJsonSchema.Schema.resolve()
 
   def create(conn, params) do
-    exec_create(conn, params, &process_account_create_record/2)
+    exec_api_create(conn, params, @record_schema, &process_account_create_record/2)
   end
 
   defp process_account_create_record(%{"email" => email}, source) do
@@ -32,80 +33,4 @@ defmodule RetWeb.Api.V1.AccountController do
   end
 
   # Utility functions
-  defp exec_create(conn, %{"data" => data}, handler), do: process_create_records(conn, data, handler)
-
-  defp exec_create(conn, _invalid_params, _handler) do
-    conn |> send_error_resp([{:MALFORMED_REQUEST, "Missing 'data' property in request.", nil}])
-  end
-
-  defp process_create_records(conn, record, handler) when is_map(record) do
-    case ExJsonSchema.Validator.validate(@record_schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
-      :ok ->
-        case handler.(record, "data") do
-          {:ok, {status, result}} ->
-            conn |> send_resp(status, %{"data" => result} |> Poison.encode!())
-
-          {:error, errors} ->
-            conn |> send_error_resp(errors)
-        end
-
-      {:error, errors} ->
-        conn
-        |> send_error_resp(
-          Enum.map(errors, fn {code, detail, source} -> {code, detail, source |> String.replace(~r/^#/, "data")} end)
-        )
-    end
-  end
-
-  defp process_create_records(conn, records, handler) when is_list(records) do
-    results =
-      records
-      |> Enum.with_index()
-      |> Enum.map(fn {record, index} ->
-        case ExJsonSchema.Validator.validate(@record_schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
-          :ok ->
-            case handler.(record, "data[#{index}]") do
-              {:ok, {status, result}} ->
-                %{status: status, body: %{"data" => result}}
-
-              {:error, errors} ->
-                %{status: 400, body: to_error_multi_request_response(errors)}
-            end
-
-          {:error, errors} ->
-            %{
-              status: 400,
-              body:
-                to_error_multi_request_response(
-                  Enum.map(errors, fn {code, detail, source} ->
-                    {code, detail, source |> String.replace(~r/^#/, "data[#{index}]")}
-                  end)
-                )
-            }
-        end
-      end)
-
-    conn |> send_resp(207, results |> Poison.encode!())
-  end
-
-  defp process_create_records(conn, _record, _handler) do
-    conn
-    |> send_error_resp([{:MALFORMED_RECORD, "Malformed record in 'data' property.", "data"}])
-  end
-
-  defp send_error_resp(conn, [{:RECORD_EXISTS, _detail, _source}] = errors), do: conn |> send_error_resp(409, errors)
-  defp send_error_resp(conn, errors), do: send_error_resp(conn, 400, errors)
-
-  defp send_error_resp(conn, status, errors) do
-    conn
-    |> send_resp(
-      status,
-      %{errors: Enum.map(errors, fn {code, detail, source} -> %{code: code, detail: detail, source: source} end)}
-      |> Poison.encode!()
-    )
-  end
-
-  defp to_error_multi_request_response(errors) do
-    %{errors: Enum.map(errors, fn {code, detail, source} -> %{code: code, detail: detail, source: source} end)}
-  end
 end

--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -1,0 +1,27 @@
+defmodule RetWeb.Api.V1.AccountController do
+  use RetWeb, :controller
+
+  alias Ret.{Account, Repo}
+
+  def create(conn, params) do
+    account = Guardian.Plug.current_resource(conn)
+
+    if account.is_admin do
+      exec_create(conn, params)
+    else
+      conn |> send_resp(401, "unauthorized")
+    end
+  end
+
+  defp exec_create(conn, %{"data" => data}) do
+    conn |> send_resp(200, "OK")
+    # case result do
+    #  :ok -> render(conn, "create.json", hub: hub)
+    #  :error -> conn |> send_resp(422, "invalid hub")
+    # end
+  end
+
+  defp exec_create(conn, _invalid_params) do
+    conn |> send_resp(400, "Missing 'data' property in POST")
+  end
+end

--- a/lib/ret_web/controllers/api/v1/account_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_search_controller.ex
@@ -1,0 +1,15 @@
+defmodule RetWeb.Api.V1.AccountSearchController do
+  use RetWeb, :controller
+
+  alias Ret.{Account}
+  alias RetWeb.Api.V1.{AccountView}
+
+  def create(conn, %{"email" => email}) do
+    with %Account{} = account <- Account.account_for_email(email) do
+      record = Phoenix.View.render(AccountView, "show.json", account: account)
+      conn |> send_resp(200, %{records: [record]} |> Poison.encode!())
+    else
+      _ -> conn |> put_status(:not_found) |> halt()
+    end
+  end
+end

--- a/lib/ret_web/controllers/api/v1/account_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_search_controller.ex
@@ -4,6 +4,7 @@ defmodule RetWeb.Api.V1.AccountSearchController do
   alias Ret.{Account}
   alias RetWeb.Api.V1.{AccountView}
 
+  # Account lookup, is a POST because lookup contains sensitive information
   def create(conn, %{"email" => email}) do
     with %Account{} = account <- Account.account_for_email(email) do
       record = Phoenix.View.render(AccountView, "show.json", account: account)

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -123,7 +123,8 @@ defmodule RetWeb.Router do
     scope "/v1", as: :api_v1 do
       pipe_through([:admin_required])
       resources("/app_configs", Api.V1.AppConfigController, only: [:index, :create])
-      resources("/accounts", Api.V1.AccountController, only: [:index, :create])
+      resources("/accounts", Api.V1.AccountController, only: [:create])
+      resources("/accounts/search", Api.V1.AccountSearchController, only: [:create])
     end
   end
 

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -123,6 +123,7 @@ defmodule RetWeb.Router do
     scope "/v1", as: :api_v1 do
       pipe_through([:admin_required])
       resources("/app_configs", Api.V1.AppConfigController, only: [:index, :create])
+      resources("/accounts", Api.V1.AccountController, only: [:index, :create])
     end
   end
 

--- a/lib/ret_web/views/api/v1/account_view.ex
+++ b/lib/ret_web/views/api/v1/account_view.ex
@@ -7,4 +7,10 @@ defmodule RetWeb.Api.V1.AccountView do
       email: email
     }
   end
+
+  def render("show.json", %{account: account}) do
+    %{
+      id: "#{account.account_id}"
+    }
+  end
 end

--- a/lib/ret_web/views/api/v1/account_view.ex
+++ b/lib/ret_web/views/api/v1/account_view.ex
@@ -1,0 +1,8 @@
+defmodule RetWeb.Api.V1.AccountView do
+  use RetWeb, :view
+  alias Ret.{Account}
+
+  def render("create.json", %{account: account}) do
+    %{}
+  end
+end

--- a/lib/ret_web/views/api/v1/account_view.ex
+++ b/lib/ret_web/views/api/v1/account_view.ex
@@ -1,8 +1,10 @@
 defmodule RetWeb.Api.V1.AccountView do
   use RetWeb, :view
-  alias Ret.{Account}
 
-  def render("create.json", %{account: account}) do
-    %{}
+  def render("create.json", %{account: account, email: email}) do
+    %{
+      id: "#{account.account_id}",
+      email: email
+    }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -77,7 +77,8 @@ defmodule Ret.Mixfile do
        git: "https://github.com/mozillareality/reverse_proxy_plug.git", branch: "reticulum/master"},
       {:oauther, "~> 1.1"},
       {:jason, "~> 1.1"},
-      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false}
+      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
+      {:ex_json_schema, "~> 0.7.3"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -33,6 +33,7 @@
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
   "elixometer": {:git, "https://github.com/pinterest/elixometer.git", "0ef0f2036014e8edc292ec2d3077142af975df73", []},
   "eternal": {:hex, :eternal, "1.2.1", "d5b6b2499ba876c57be2581b5b999ee9bdf861c647401066d3eeed111d096bc4", [:mix], [], "hexpm"},
+  "ex_json_schema": {:hex, :ex_json_schema, "0.7.3", "3289bf2edf57eb1ae0d5af35bc6d6c37d7e6d935f72e0120c7f0704510956049", [:mix], [], "hexpm"},
   "exometer": {:git, "https://github.com/Feuerlabs/exometer.git", "7a7bd8d2b52de4d90f65aa3f6044b0e988319b9e", []},
   "exometer_collectd": {:git, "https://github.com/Feuerlabs/exometer_collectd.git", "38c583dda6149478e285e2cab3088a833ea0e571", []},
   "exometer_core": {:git, "https://github.com/Feuerlabs/exometer_core.git", "39c05718533185d6a3b4b7185cb94b90bbd81a3d", []},

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -1,0 +1,22 @@
+defmodule RetWeb.AccountControllerTest do
+  use RetWeb.ConnCase
+  import Ret.TestHelpers
+
+  alias Ret.{Repo, Account}
+
+  setup %{conn: conn} do
+    {:ok, admin_account: admin_account} = create_admin_account("test")
+    {:ok, token, _params} = admin_account |> Ret.Guardian.encode_and_sign()
+    {:ok, account: admin_account, conn: conn |> Plug.Conn.put_req_header("authorization", "bearer: " <> token)}
+  end
+
+  test "admins can create accounts", %{conn: conn} do
+    # req = conn |> api_v1_account_path(:create, %{"account" => %{name: name}})
+    # conn |> post(req)
+  end
+
+  test "should return 400 if missing data in params", %{conn: conn, account: account} do
+    req = conn |> api_v1_account_path(:create, %{})
+    conn |> post(req) |> response(400)
+  end
+end

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -35,4 +35,9 @@ defmodule RetWeb.AccountControllerTest do
     req = conn |> api_v1_account_path(:create, %{"data" => %{}})
     conn |> post(req) |> response(400)
   end
+
+  test "should return 409 if account exists", %{conn: conn} do
+    req = conn |> api_v1_account_path(:create, %{"data" => %{email: "test@mozilla.com"}})
+    res = conn |> post(req) |> response(409)
+  end
 end

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -2,7 +2,7 @@ defmodule RetWeb.AccountControllerTest do
   use RetWeb.ConnCase
   import Ret.TestHelpers
 
-  alias Ret.{Repo, Account}
+  alias Ret.{Account}
 
   setup %{conn: conn} do
     {:ok, admin_account: admin_account} = create_admin_account("test")
@@ -12,32 +12,35 @@ defmodule RetWeb.AccountControllerTest do
 
   test "admins can create accounts", %{conn: conn} do
     req = conn |> api_v1_account_path(:create, %{"data" => %{email: "testapi@mozilla.com"}})
-    res = conn |> post(req) |> response(200)
-    # assert Account.account_for_email("testapi@mozilla.com")
+    res = conn |> post(req) |> response(200) |> Poison.decode!()
+
+    account = Account.account_for_email("testapi@mozilla.com")
+    assert account
+    assert res["data"]["id"] === "#{account.account_id}"
   end
 
   test "should return 400 if email is invalid", %{conn: conn} do
     req = conn |> api_v1_account_path(:create, %{"data" => %{email: "invalidemail"}})
-    res = conn |> post(req) |> response(400)
+    conn |> post(req) |> response(400)
   end
 
-  test "should return 400 if missing data in params", %{conn: conn, account: account} do
+  test "should return 400 if missing data in params", %{conn: conn} do
     req = conn |> api_v1_account_path(:create, %{})
     conn |> post(req) |> response(400)
   end
 
-  test "should return 400 if data is malformed", %{conn: conn, account: account} do
+  test "should return 400 if data is malformed", %{conn: conn} do
     req = conn |> api_v1_account_path(:create, %{"data" => 123})
     conn |> post(req) |> response(400)
   end
 
-  test "should return 400 if email is missing on root record", %{conn: conn, account: account} do
+  test "should return 400 if email is missing on root record", %{conn: conn} do
     req = conn |> api_v1_account_path(:create, %{"data" => %{}})
     conn |> post(req) |> response(400)
   end
 
   test "should return 409 if account exists", %{conn: conn} do
     req = conn |> api_v1_account_path(:create, %{"data" => %{email: "test@mozilla.com"}})
-    res = conn |> post(req) |> response(409)
+    conn |> post(req) |> response(409)
   end
 end

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -11,12 +11,28 @@ defmodule RetWeb.AccountControllerTest do
   end
 
   test "admins can create accounts", %{conn: conn} do
-    # req = conn |> api_v1_account_path(:create, %{"account" => %{name: name}})
-    # conn |> post(req)
+    req = conn |> api_v1_account_path(:create, %{"data" => %{email: "testapi@mozilla.com"}})
+    res = conn |> post(req) |> response(200)
+    # assert Account.account_for_email("testapi@mozilla.com")
+  end
+
+  test "should return 400 if email is invalid", %{conn: conn} do
+    req = conn |> api_v1_account_path(:create, %{"data" => %{email: "invalidemail"}})
+    res = conn |> post(req) |> response(400)
   end
 
   test "should return 400 if missing data in params", %{conn: conn, account: account} do
     req = conn |> api_v1_account_path(:create, %{})
+    conn |> post(req) |> response(400)
+  end
+
+  test "should return 400 if data is malformed", %{conn: conn, account: account} do
+    req = conn |> api_v1_account_path(:create, %{"data" => 123})
+    conn |> post(req) |> response(400)
+  end
+
+  test "should return 400 if email is missing on root record", %{conn: conn, account: account} do
+    req = conn |> api_v1_account_path(:create, %{"data" => %{}})
     conn |> post(req) |> response(400)
   end
 end

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -14,7 +14,7 @@ defmodule RetWeb.AccountControllerTest do
     account = create_random_account()
     {:ok, token, _params} = account |> Ret.Guardian.encode_and_sign()
     conn = conn |> Plug.Conn.put_req_header("authorization", "bearer: " <> token)
-    req = conn |> api_v1_account_path(:create, %{"data" => %{email: "testapi@mozilla.com"}})
+    req = conn |> api_v1_account_path(:create, %{records: %{email: "testapi@mozilla.com"}})
     conn = conn |> post(req)
 
     assert conn.status === 401
@@ -22,21 +22,21 @@ defmodule RetWeb.AccountControllerTest do
   end
 
   test "admins can create accounts", %{conn: conn} do
-    req = conn |> api_v1_account_path(:create, %{"data" => %{email: "testapi@mozilla.com"}})
+    req = conn |> api_v1_account_path(:create, %{records: %{email: "testapi@mozilla.com"}})
     res = conn |> post(req) |> response(200) |> Poison.decode!()
 
     account = Account.account_for_email("testapi@mozilla.com")
 
     assert account
-    assert res["data"]["id"] === "#{account.account_id}"
-    assert res["data"]["email"] === "testapi@mozilla.com"
+    assert res["records"]["id"] === "#{account.account_id}"
+    assert res["records"]["email"] === "testapi@mozilla.com"
   end
 
   test "admins can create multiple acounts, and have validation errors", %{conn: conn} do
     req =
       conn
       |> api_v1_account_path(:create, %{
-        "data" => [%{email: "testapi1@mozilla.com"}, %{email: "testapi2@mozilla.com"}, %{email: "invalidemail"}]
+        records: [%{email: "testapi1@mozilla.com"}, %{email: "testapi2@mozilla.com"}, %{email: "invalidemail"}]
       })
 
     res = conn |> post(req) |> response(207) |> Poison.decode!()
@@ -50,37 +50,66 @@ defmodule RetWeb.AccountControllerTest do
     assert account1
     assert account2
     assert result1["status"] === 200
-    assert result1["body"]["data"]["id"] === "#{account1.account_id}"
-    assert result1["body"]["data"]["email"] === "testapi1@mozilla.com"
+    assert result1["body"]["records"]["id"] === "#{account1.account_id}"
+    assert result1["body"]["records"]["email"] === "testapi1@mozilla.com"
     assert result2["status"] === 200
-    assert result2["body"]["data"]["id"] === "#{account2.account_id}"
-    assert result2["body"]["data"]["email"] === "testapi2@mozilla.com"
+    assert result2["body"]["records"]["id"] === "#{account2.account_id}"
+    assert result2["body"]["records"]["email"] === "testapi2@mozilla.com"
     assert result3["status"] === 400
     assert result3["body"]["errors"] |> Enum.at(0) |> Map.get("code") === "MALFORMED_RECORD"
   end
 
   test "should return 400 if email is invalid", %{conn: conn} do
-    req = conn |> api_v1_account_path(:create, %{"data" => %{email: "invalidemail"}})
+    req = conn |> api_v1_account_path(:create, %{records: %{email: "invalidemail"}})
     conn |> post(req) |> response(400)
   end
 
-  test "should return 400 if missing data in params", %{conn: conn} do
+  test "should return 400 if missing records in params", %{conn: conn} do
     req = conn |> api_v1_account_path(:create, %{})
     conn |> post(req) |> response(400)
   end
 
-  test "should return 400 if data is malformed", %{conn: conn} do
-    req = conn |> api_v1_account_path(:create, %{"data" => 123})
+  test "should return 400 if records is malformed", %{conn: conn} do
+    req = conn |> api_v1_account_path(:create, %{records: 123})
     conn |> post(req) |> response(400)
   end
 
   test "should return 400 if email is missing on root record", %{conn: conn} do
-    req = conn |> api_v1_account_path(:create, %{"data" => %{}})
+    req = conn |> api_v1_account_path(:create, %{records: %{}})
     conn |> post(req) |> response(400)
   end
 
   test "should return 409 if account exists", %{conn: conn} do
-    req = conn |> api_v1_account_path(:create, %{"data" => %{email: "test@mozilla.com"}})
+    req = conn |> api_v1_account_path(:create, %{records: %{email: "test@mozilla.com"}})
     conn |> post(req) |> response(409)
+  end
+
+  test "non-admins cannot search for accounts", %{conn: conn} do
+    account = create_random_account()
+    {:ok, token, _params} = account |> Ret.Guardian.encode_and_sign()
+    conn = conn |> Plug.Conn.put_req_header("authorization", "bearer: " <> token)
+    req = conn |> api_v1_account_search_path(:create, %{email: "unknown@mozilla.com"})
+    conn = conn |> post(req)
+
+    assert conn.status === 401
+    assert conn.state === :unset
+  end
+
+  test "should return 404 if no such account exists", %{conn: conn} do
+    req = conn |> api_v1_account_search_path(:create, %{email: "unknown@mozilla.com"})
+    conn = conn |> post(req)
+
+    assert conn.status === 404
+    assert conn.state === :unset
+  end
+
+  test "should return account if account exists", %{conn: conn} do
+    req = conn |> api_v1_account_search_path(:create, %{email: "test@mozilla.com"})
+    res = conn |> post(req) |> response(200) |> Poison.decode!()
+
+    account = Account.account_for_email("test@mozilla.com")
+    record = res["records"] |> Enum.at(0)
+
+    assert record["id"] === "#{account.account_id}"
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -28,12 +28,30 @@ defmodule Ret.TestHelpers do
 
   def create_random_account(), do: create_account(Ret.Sids.generate_sid())
 
-  def create_account(prefix) when is_binary(prefix) do
-    Account.find_or_create_account_for_email("#{prefix}@mozilla.com")
+  def create_account(prefix, is_admin \\ false)
+
+  def create_account(prefix, is_admin) when is_binary(prefix) do
+    account = Account.find_or_create_account_for_email("#{prefix}@mozilla.com")
+
+    if is_admin do
+      # Currently admin bits not set via any reticulum APIs, so avoid adding them to code for now.
+      Ecto.Adapters.SQL.query!(
+        Ret.Repo,
+        "update ret0.accounts set is_admin = 't' where account_id = #{account.account_id}"
+      )
+
+      Account.find_or_create_account_for_email("#{prefix}@mozilla.com")
+    else
+      account
+    end
   end
 
-  def create_account(_) do
+  def create_account(_, _is_admin) do
     {:ok, account: create_account("test"), account2: create_account("test2")}
+  end
+
+  def create_admin_account(_) do
+    {:ok, admin_account: create_account("test", true)}
   end
 
   def create_owned_file(%{account: account}) do


### PR DESCRIPTION
Adds a basic API for creating accounts and looking up accounts by email, accessible to administrator accounts only.

The create API attempts to be a first stab at a idiomatic public API. It has a few characteristics:

- Allows single or multiple record posting, with multiple records being handled via an HTTP 207 response
- Uses JSON schema for validation
- Has fairly robust error handling (at least compared to what we've had in the past :))

Note the lookup API uses a POST because otherwise emails would risk being logged somewhere.