### PR TITLE
Allow direct POSTs to media api

### DIFF
--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -80,7 +80,6 @@ defmodule RetWeb.Router do
 
     scope "/v1", as: :api_v1 do
       get("/meta", Api.V1.MetaController, :show)
-      resources("/media", Api.V1.MediaController, only: [:create])
       get("/avatars/:id/base.gltf", Api.V1.AvatarController, :show_base_gltf)
       get("/avatars/:id/avatar.gltf", Api.V1.AvatarController, :show_avatar_gltf)
       get("/oauth/:type", Api.V1.OAuthController, :show)
@@ -125,6 +124,16 @@ defmodule RetWeb.Router do
       resources("/app_configs", Api.V1.AppConfigController, only: [:index, :create])
       resources("/accounts", Api.V1.AccountController, only: [:create])
       resources("/accounts/search", Api.V1.AccountSearchController, only: [:create])
+    end
+  end
+
+  # Directly accessible APIs.
+  # Permit direct file uploads without intermediate ALB/Cloudfront/CDN proxying.
+  scope "/api", RetWeb do
+    pipe_through([:secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: []))
+
+    scope "/v1", as: :api_v1 do
+      resources("/media", Api.V1.MediaController, only: [:create])
     end
   end
 


### PR DESCRIPTION
Hubs Cloud installations have request timeouts going to reticulum of 30s due to the fact that Cloudfront is typically sitting in front of all requests. (This is only the case if the stack is not using an ALB.)

To resolve this, long running requests can be directed to the server directly instead of going through the Cloudfront endpoint. The only API that this seems relevant for is the media resolver + uploader API. This PR updates the API so that it can be hit directly (and won't be redirected to the canonical domain.)