### PR TITLE
Set return-path on outgoing emails to ensure bounce notifications

### DIFF
--- a/lib/ret_web/email.ex
+++ b/lib/ret_web/email.ex
@@ -5,16 +5,24 @@ defmodule RetWeb.Email do
   def auth_email(to_address, signin_args) do
     app_name = AppConfig.get_cached_config_value("translations|en|app-name")
     app_full_name = AppConfig.get_cached_config_value("translations|en|app-full-name") || app_name
+    admin_email = Application.get_env(:ret, Ret.Account)[:admin_email]
 
-    new_email()
-    |> to(to_address)
-    |> from({app_full_name, from_address()})
-    |> subject("Your #{app_name} Sign-In Link")
-    |> text_body(
-      "To sign-in to #{app_name}, please visit the link below. If you did not make this request, please ignore this e-mail.\n\n#{
-        RetWeb.Endpoint.url()
-      }/?#{URI.encode_query(signin_args)}"
-    )
+    email =
+      new_email()
+      |> to(to_address)
+      |> from({app_full_name, from_address()})
+      |> subject("Your #{app_name} Sign-In Link")
+      |> text_body(
+        "To sign-in to #{app_name}, please visit the link below. If you did not make this request, please ignore this e-mail.\n\n#{
+          RetWeb.Endpoint.url()
+        }/?#{URI.encode_query(signin_args)}"
+      )
+
+    if admin_email do
+      email |> put_header("Return-Path", admin_email)
+    else
+      email
+    end
   end
 
   def enabled? do


### PR DESCRIPTION
To properly receive bounce notifications from SES, the `Return-Path` header must be set. Since we only have the admin email address, that's what we use for now. Eventually this can be a config.

https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity-using-notifications-email.html