### PR TITLE
Fix config toml for google poly api key

### DIFF
--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -156,9 +156,11 @@ deviantart_client_secret = "{{ cfg.resolver.deviantart_client_secret }}"
 {{/if}}
 {{ #if cfg.resolver.imgur_mashape_api_key }}
 imgur_mashape_api_key = "{{ cfg.resolver.imgur_mashape_api_key }}"
+imgur_client_id = "{{ cfg.resolver.imgur_client_id }}"
+{{/if}}
+{{ #if cfg.resolver.google_poly_api_key }}
 google_poly_api_key = "{{ cfg.resolver.google_poly_api_key }}"
 {{/if}}
-imgur_client_id = "{{ cfg.resolver.imgur_client_id }}"
 {{ #if cfg.resolver.youtube_api_key }}
 youtube_api_key = "{{ cfg.resolver.youtube_api_key }}"
 {{/if}}


### PR DESCRIPTION
A typo in #280 caused google poly api keys to be ignored in hubs cloud instances.