### PR TITLE
Feature/custom csp rules

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -189,7 +189,10 @@ config :ret, Ret.JanusLoadStatus, default_janus_host: dev_janus_host, janus_port
 
 config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
 
-config :ret, RetWeb.PageController, skip_cache: true, assets_path: "storage/assets", docs_path: "storage/docs"
+config :ret, RetWeb.PageController,
+  skip_cache: true,
+  assets_path: "storage/assets",
+  docs_path: "storage/docs"
 
 config :ret, Ret.HttpUtils, insecure_ssl: true
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -147,20 +147,15 @@ websocket_hosts =
     "https://#{host}:4000 https://#{host}:8080 wss://#{host}:4000 wss://#{host}:8080 wss://#{host}:8989 wss://#{host}:9090 " <>
     "wss://#{dev_janus_host} wss://prod-janus.reticulum.io wss://#{host}:4000 wss://#{host}:8080 https://#{host}:8080 https://hubs.local:8080 wss://hubs.local:8080"
 
-script_shas =
-  "'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8='"
-
 config :ret, RetWeb.Plugs.AddCSP,
-  content_security_policy:
-    "default-src 'none'; script-src 'self' #{script_shas} #{asset_hosts} https://cdn.rawgit.com https://aframe.io https://www.google-analytics.com 'unsafe-eval'; worker-src 'self' blob:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.aframe.io #{
-      asset_hosts
-    }; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net #{asset_hosts} 'unsafe-inline'; connect-src 'self' https://#{
-      host
-    }:8080 https://sentry.prod.mozaws.net https://dpdb.webvr.rocks #{asset_hosts} #{websocket_hosts} https://cdn.aframe.io https://www.mozilla.org data: blob:; img-src 'self' #{
-      asset_hosts
-    } https://cdn.aframe.io https://cdn.jsdelivr.net data: blob:; media-src 'self' #{asset_hosts} data: blob:; frame-src 'self'; base-uri 'none'; form-action 'self'; manifest-src 'self' #{
-      asset_hosts
-    };"
+  script_src: asset_hosts,
+  font_src: asset_hosts,
+  style_src: asset_hosts,
+  connect_src:
+    "https://#{host}:8080 https://sentry.prod.mozaws.net #{asset_hosts} #{websocket_hosts} https://www.mozilla.org",
+  img_src: asset_hosts,
+  media_src: asset_hosts,
+  manifest_src: asset_hosts
 
 config :ret, Ret.Mailer, adapter: Bamboo.LocalAdapter
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -111,7 +111,6 @@ config :ret, Ret.Scheduler,
   ]
 
 config :ret, RetWeb.Plugs.HeaderAuthorization, header_name: "x-ret-admin-access-key"
-config :ret, RetWeb.Plugs.AddCSP
 
 config :ret, Ret.Mailer,
   adapter: Bamboo.SMTPAdapter,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -111,7 +111,7 @@ config :ret, Ret.Scheduler,
   ]
 
 config :ret, RetWeb.Plugs.HeaderAuthorization, header_name: "x-ret-admin-access-key"
-config :ret, RetWeb.Plugs.AddCSP, content_security_policy: nil
+config :ret, RetWeb.Plugs.AddCSP
 
 config :ret, Ret.Mailer,
   adapter: Bamboo.SMTPAdapter,

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,7 +22,7 @@ config :ret, Ret.Repo,
   pool_size: 10,
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :ret, RetWeb.Plugs.AddCSP, content_security_policy: nil
+config :ret, RetWeb.Plugs.AddCSP
 
 config :ret, Ret.Guardian,
   issuer: "ret",

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,8 +22,6 @@ config :ret, Ret.Repo,
   pool_size: 10,
   pool: Ecto.Adapters.SQL.Sandbox
 
-config :ret, RetWeb.Plugs.AddCSP
-
 config :ret, Ret.Guardian,
   issuer: "ret",
   secret_key: "47iqPEdWcfE7xRnyaxKDLt9OGEtkQG3SycHBEMOuT2qARmoESnhc76IgCUjaQIwX"

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -237,6 +237,14 @@ check_repo = {{ cfg.health.check_repo }}
 {{#if cfg.assets.assets_path}}
 [ret."Elixir.RetWeb.PageController"]
 assets_path = "{{ cfg.assets.assets_path }}"
+extra_index_headers = "{{ cfg.pages.extra_index_headers }}"
+extra_room_headers = "{{ cfg.pages.extra_room_headers }}"
+extra_avatar_headers = "{{ cfg.pages.extra_avatar_headers }}"
+extra_scene_headers = "{{ cfg.pages.extra_scene_headers }}"
+extra_index_script = "{{ cfg.pages.extra_index_script }}"
+extra_room_script = "{{ cfg.pages.extra_room_script }}"
+extra_avatar_script = "{{ cfg.pages.extra_avatar_script }}"
+extra_scene_script = "{{ cfg.pages.extra_scene_script }}"
 {{/if}}
 
 {{#if cfg.assets.docs_path}}

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -235,6 +235,9 @@ assets_path = "{{ cfg.assets.assets_path }}"
 {{#if cfg.extra_headers}}
 {{ toToml cfg.extra_headers }}
 {{/if}}
+{{#if cfg.extra_html}}
+{{ toToml cfg.extra_html }}
+{{/if}}
 {{#if cfg.extra_scripts}}
 {{ toToml cfg.extra_scripts }}
 {{/if}}

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -208,7 +208,9 @@ password = {{ toToml cfg.email.password }}
 slack_webhook_url = "{{ cfg.support.slack_webhook_url }}"
 
 [ret."Elixir.RetWeb.Plugs.AddCSP"]
+{{#if cfg.extra_csp}}
 {{ toToml cfg.extra_csp }}
+{{/if}}
 
 [ret."Ret.Repo.Migrations.AdminSchemaInit"]
 postgrest_password = "{{ cfg.db.postgrest_password }}"
@@ -230,8 +232,12 @@ check_repo = {{ cfg.health.check_repo }}
 {{#if cfg.assets.assets_path}}
 assets_path = "{{ cfg.assets.assets_path }}"
 {{/if}}
+{{#if cfg.extra_headers}}
 {{ toToml cfg.extra_headers }}
+{{/if}}
+{{#if cfg.extra_scripts}}
 {{ toToml cfg.extra_scripts }}
+{{/if}}
 
 {{#if cfg.assets.docs_path}}
 [ret."Elixir.RetWeb.PageController"]

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -209,7 +209,14 @@ password = "{{ cfg.email.password }}"
 slack_webhook_url = "{{ cfg.support.slack_webhook_url }}"
 
 [ret."Elixir.RetWeb.Plugs.AddCSP"]
-content_security_policy = "{{ cfg.security.csp }}"
+script_src = "{{ cfg.security.csp_script_src }}"
+font_src = "{{ cfg.security.csp_font_src }}"
+style_src = "{{ cfg.security.csp_style_src }}"
+connect_src = "{{ cfg.security.csp_connect_src }}"
+img_src = "{{ cfg.security.csp_img_src }}"
+media_src = "{{ cfg.security.csp_media_src }}"
+manifest_src = "{{ cfg.security.csp_manifest_src }}"
+form_action = "{{ cfg.security.csp_form_action }}"
 
 [ret."Ret.Repo.Migrations.AdminSchemaInit"]
 postgrest_password = "{{ cfg.db.postgrest_password }}"

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -11,10 +11,7 @@ bot_token = {{ toToml cfg.discord_client.bot_token }}
 
 {{ #if cfg.twitter_client.consumer_secret }}
 [ret."Elixir.Ret.TwitterClient"]
-consumer_key = "{{ cfg.twitter_client.consumer_key }}"
-consumer_secret = "{{ cfg.twitter_client.consumer_secret }}"
-access_token = "{{ cfg.twitter_client.access_token }}"
-access_token_secret = "{{ cfg.twitter_client.access_token_secret }}"
+{{ toToml cfg.twitter_client }}
 {{/if}}
 
 [ret."Elixir.RetWeb.Endpoint".https]

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -5,9 +5,9 @@ pool = "{{ cfg.ret.pool }}"
 header_value = "{{ cfg.phx.admin_access_key }}"
 
 [ret."Elixir.Ret.DiscordClient"]
-client_id = "{{ cfg.discord_client.client_id }}"
-client_secret = "{{ cfg.discord_client.client_secret }}"
-bot_token = "{{ cfg.discord_client.bot_token }}"
+client_id = {{ toToml cfg.discord_client.client_id }}
+client_secret = {{ toToml cfg.discord_client.client_secret }}
+bot_token = {{ toToml cfg.discord_client.bot_token }}
 
 {{ #if cfg.twitter_client.consumer_secret }}
 [ret."Elixir.Ret.TwitterClient"]
@@ -148,31 +148,31 @@ bot_access_key = "{{ cfg.ret.bot_access_key }}"
 [ret."Elixir.Ret.MediaResolver"]
 ytdl_host = "{{ cfg.resolver.ytdl_host }}"
 {{ #if cfg.resolver.giphy_api_key }}
-giphy_api_key = "{{ cfg.resolver.giphy_api_key }}"
+giphy_api_key = {{ toToml cfg.resolver.giphy_api_key }}
 {{/if}}
 {{ #if cfg.resolver.deviantart_client_id }}
-deviantart_client_id = "{{ cfg.resolver.deviantart_client_id }}"
-deviantart_client_secret = "{{ cfg.resolver.deviantart_client_secret }}"
+deviantart_client_id = {{ toToml cfg.resolver.deviantart_client_id }}
+deviantart_client_secret = {{ toToml cfg.resolver.deviantart_client_secret }}
 {{/if}}
 {{ #if cfg.resolver.imgur_mashape_api_key }}
-imgur_mashape_api_key = "{{ cfg.resolver.imgur_mashape_api_key }}"
-google_poly_api_key = "{{ cfg.resolver.google_poly_api_key }}"
+imgur_mashape_api_key = {{ toToml cfg.resolver.imgur_mashape_api_key }}
+google_poly_api_key = {{ toToml cfg.resolver.google_poly_api_key }}
 {{/if}}
-imgur_client_id = "{{ cfg.resolver.imgur_client_id }}"
+imgur_client_id = {{ toToml cfg.resolver.imgur_client_id }}
 {{ #if cfg.resolver.youtube_api_key }}
-youtube_api_key = "{{ cfg.resolver.youtube_api_key }}"
+youtube_api_key = {{ toToml cfg.resolver.youtube_api_key }}
 {{/if}}
 {{ #if cfg.resolver.sketchfab_api_key }}
-sketchfab_api_key = "{{ cfg.resolver.sketchfab_api_key }}"
+sketchfab_api_key = {{ toToml cfg.resolver.sketchfab_api_key }}
 {{/if}}
 {{ #if cfg.resolver.tenor_api_key }}
-tenor_api_key = "{{ cfg.resolver.tenor_api_key }}"
+tenor_api_key = {{ toToml cfg.resolver.tenor_api_key }}
 {{/if}}
 {{ #if cfg.resolver.bing_search_api_key }}
-bing_search_api_key = "{{ cfg.resolver.bing_search_api_key }}"
+bing_search_api_key = {{ toToml cfg.resolver.bing_search_api_key }}
 {{/if}}
 {{ #if cfg.resolver.twitch_client_id }}
-twitch_client_id = "{{ cfg.resolver.twitch_client_id }}"
+twitch_client_id = {{ toToml cfg.resolver.twitch_client_id }}
 {{/if}}
 {{ #if cfg.resolver.photomnemonic_endpoint }}
 photomnemonic_endpoint = "{{ cfg.resolver.photomnemonic_endpoint }}"
@@ -197,26 +197,19 @@ host = "{{ cfg.uploads.host }}"
 quota_gb = {{ cfg.uploads.quota_gb }}
 
 [ret."Elixir.RetWeb.Email"]
-from = "{{ cfg.email.from }}"
+from = {{ toToml cfg.email.from }}
 
-[ret."Elixir.Ret.Mailer"]
-server = "{{ cfg.email.server }}"
-port = {{ cfg.email.port }}
-username = "{{ cfg.email.username }}"
-password = "{{ cfg.email.password }}"
+[ret.Elixir.Ret.Mailer]
+server = {{ toToml cfg.email.server }}
+port = {{ toToml cfg.email.port }}
+username = {{ toToml cfg.email.username }}
+password = {{ toToml cfg.email.password }}
 
 [ret."Elixir.Ret.Support"]
 slack_webhook_url = "{{ cfg.support.slack_webhook_url }}"
 
 [ret."Elixir.RetWeb.Plugs.AddCSP"]
-script_src = "{{ cfg.security.csp_script_src }}"
-font_src = "{{ cfg.security.csp_font_src }}"
-style_src = "{{ cfg.security.csp_style_src }}"
-connect_src = "{{ cfg.security.csp_connect_src }}"
-img_src = "{{ cfg.security.csp_img_src }}"
-media_src = "{{ cfg.security.csp_media_src }}"
-manifest_src = "{{ cfg.security.csp_manifest_src }}"
-form_action = "{{ cfg.security.csp_form_action }}"
+{{ toToml cfg.extra_csp }}
 
 [ret."Ret.Repo.Migrations.AdminSchemaInit"]
 postgrest_password = "{{ cfg.db.postgrest_password }}"
@@ -234,18 +227,12 @@ node_gauges_enabled = {{ cfg.stats.node_gauges_enabled }}
 check_repo = {{ cfg.health.check_repo }}
 {{/if}}
 
-{{#if cfg.assets.assets_path}}
 [ret."Elixir.RetWeb.PageController"]
+{{#if cfg.assets.assets_path}}
 assets_path = "{{ cfg.assets.assets_path }}"
-extra_index_headers = "{{ cfg.pages.extra_index_headers }}"
-extra_room_headers = "{{ cfg.pages.extra_room_headers }}"
-extra_avatar_headers = "{{ cfg.pages.extra_avatar_headers }}"
-extra_scene_headers = "{{ cfg.pages.extra_scene_headers }}"
-extra_index_script = "{{ cfg.pages.extra_index_script }}"
-extra_room_script = "{{ cfg.pages.extra_room_script }}"
-extra_avatar_script = "{{ cfg.pages.extra_avatar_script }}"
-extra_scene_script = "{{ cfg.pages.extra_scene_script }}"
 {{/if}}
+{{ toToml cfg.extra_headers }}
+{{ toToml cfg.extra_scripts }}
 
 {{#if cfg.assets.docs_path}}
 [ret."Elixir.RetWeb.PageController"]

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -51,7 +51,7 @@ defmodule RetWeb.PageController do
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
         extra_script: {:safe, get_extra_script(:scene) |> with_script_tags},
-        extra_html: {:safe, get_extra_html(:scene) }
+        extra_html: {:safe, get_extra_html(:scene)}
       )
 
     case try_chunks_for_page(conn, "scene.html", :hubs) do
@@ -84,7 +84,7 @@ defmodule RetWeb.PageController do
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
         extra_script: {:safe, get_extra_script(:avatar) |> with_script_tags},
-        extra_html: {:safe, get_extra_html(:avatar) }
+        extra_html: {:safe, get_extra_html(:avatar)}
       )
 
     case try_chunks_for_page(conn, "avatar.html", :hubs) do
@@ -118,7 +118,7 @@ defmodule RetWeb.PageController do
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
         extra_script: {:safe, get_extra_script(:index) |> with_script_tags},
-        extra_html: {:safe, get_extra_html(:index) }
+        extra_html: {:safe, get_extra_html(:index)}
       )
 
     case try_chunks_for_page(conn, "index.html", :hubs) do
@@ -410,7 +410,7 @@ defmodule RetWeb.PageController do
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
         extra_script: {:safe, get_extra_script(:room) |> with_script_tags},
-        extra_html: {:safe, get_extra_html(:room) }
+        extra_html: {:safe, get_extra_html(:room)}
       )
 
     case try_chunks_for_page(conn, "hub.html", :hubs) do
@@ -614,14 +614,12 @@ defmodule RetWeb.PageController do
   end
 
   defp extra_header_to_tuple(header) do
-    [name | rest] = header |> String.split(~r/:\s*/) |> Enum.map(&String.trim/1)
+    [name, value] = header |> String.split(~r/:\s*/, parts: 2) |> Enum.map(&String.trim/1)
 
     name =
       name
       |> String.downcase()
       |> String.replace(~r/[^a-z0-9_-]/, "")
-
-    value = rest |> Enum.join(":")
 
     {name, value}
   end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -50,7 +50,8 @@ defmodule RetWeb.PageController do
         ret_meta: Ret.Meta.get_meta(include_repo: false),
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
-        extra_script: {:safe, get_extra_script(:scene) |> with_script_tags}
+        extra_script: {:safe, get_extra_script(:scene) |> with_script_tags},
+        extra_html: {:safe, get_extra_html(:scene) }
       )
 
     case try_chunks_for_page(conn, "scene.html", :hubs) do
@@ -82,7 +83,8 @@ defmodule RetWeb.PageController do
         ret_meta: Ret.Meta.get_meta(include_repo: false),
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
-        extra_script: {:safe, get_extra_script(:avatar) |> with_script_tags}
+        extra_script: {:safe, get_extra_script(:avatar) |> with_script_tags},
+        extra_html: {:safe, get_extra_html(:avatar) }
       )
 
     case try_chunks_for_page(conn, "avatar.html", :hubs) do
@@ -115,7 +117,8 @@ defmodule RetWeb.PageController do
         root_url: RetWeb.Endpoint.url(),
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
-        extra_script: {:safe, get_extra_script(:index) |> with_script_tags}
+        extra_script: {:safe, get_extra_script(:index) |> with_script_tags},
+        extra_html: {:safe, get_extra_html(:index) }
       )
 
     case try_chunks_for_page(conn, "index.html", :hubs) do
@@ -406,7 +409,8 @@ defmodule RetWeb.PageController do
         available_integrations_script: {:safe, available_integrations_script |> with_script_tags},
         translations: app_config["translations"]["en"],
         app_config_script: {:safe, app_config_script |> with_script_tags},
-        extra_script: {:safe, get_extra_script(:room) |> with_script_tags}
+        extra_script: {:safe, get_extra_script(:room) |> with_script_tags},
+        extra_html: {:safe, get_extra_html(:room) }
       )
 
     case try_chunks_for_page(conn, "hub.html", :hubs) do
@@ -630,6 +634,7 @@ defmodule RetWeb.PageController do
   end
 
   defp get_extra_script(key), do: module_config(:"extra_#{key}_script")
+  defp get_extra_html(key), do: module_config(:"extra_#{key}_html")
 
   defp append_script_csp(conn, nil), do: conn
   defp append_script_csp(conn, ""), do: conn

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -603,19 +603,21 @@ defmodule RetWeb.PageController do
 
   defp put_extra_response_headers(conn, key) do
     (module_config(:"extra_#{key}_headers") || "")
-    |> String.split(",")
+    |> String.split("|")
     |> Enum.map(&String.trim/1)
     |> Enum.map(&extra_header_to_tuple/1)
     |> Enum.reduce(conn, fn {name, value}, conn -> conn |> put_resp_header(name, value) end)
   end
 
-  defp extra_header_to_tuple(header) do
-    [name, value | _rest] = header |> String.split(":") |> Enum.map(&String.trim/1)
+  def extra_header_to_tuple(header) do
+    [name | rest] = header |> String.split(~r/:\s*/) |> Enum.map(&String.trim/1)
 
     name =
       name
       |> String.downcase()
       |> String.replace(~r/[^a-z0-9_-]/, "")
+
+    value = rest |> Enum.join(":")
 
     {name, value}
   end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -613,7 +613,7 @@ defmodule RetWeb.PageController do
     |> Enum.reduce(conn, fn {name, value}, conn -> conn |> put_resp_header(name, value) end)
   end
 
-  def extra_header_to_tuple(header) do
+  defp extra_header_to_tuple(header) do
     [name | rest] = header |> String.split(~r/:\s*/) |> Enum.map(&String.trim/1)
 
     name =

--- a/lib/ret_web/plugs/add_csp.ex
+++ b/lib/ret_web/plugs/add_csp.ex
@@ -60,7 +60,7 @@ defmodule RetWeb.Plugs.AddCSP do
         "https://#{ret_host}:#{ret_port} wss://#{ret_host}:#{janus_port} wss://#{ret_host}:#{ret_port}"
       end
 
-    "default-src 'none'; manifest-src 'self'; script-src #{custom_rules[:script_src]} #{storage_url} #{assets_url} 'self' 'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-buF6N8Z4p2PuaaeRUjm7mxBpPNf4XlCT9Fep83YabbM=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' https://www.google-analytics.com #{
+    "default-src 'none'; manifest-src 'self'; script-src #{custom_rules[:script_src]} #{storage_url} #{assets_url} 'self' 'unsafe-eval' 'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-buF6N8Z4p2PuaaeRUjm7mxBpPNf4XlCT9Fep83YabbM=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' https://www.google-analytics.com #{
       storage_url
     } #{assets_url} https://aframe.io https://www.youtube.com https://s.ytimg.com; child-src #{custom_rules[:child_src]} 'self' blob:; worker-src #{
       custom_rules[:worker_src]

--- a/lib/ret_web/plugs/add_csp.ex
+++ b/lib/ret_web/plugs/add_csp.ex
@@ -79,7 +79,7 @@ defmodule RetWeb.Plugs.AddCSP do
     } https://www.youtube.com https://docs.google.com 'self'; base-uri 'none'; form-action #{custom_rules[:form_action]} 'self';"
   end
 
-  def get_custom_rules do
+  defp get_custom_rules do
     @customizable_rule_types
     |> Enum.map(fn rule ->
       {rule, Application.get_env(:ret, __MODULE__)[rule] || ""}

--- a/lib/ret_web/plugs/add_csp.ex
+++ b/lib/ret_web/plugs/add_csp.ex
@@ -1,28 +1,38 @@
 defmodule RetWeb.Plugs.AddCSP do
+  @customizable_rule_types [
+    :script_src,
+    :font_src,
+    :connect_src,
+    :style_src,
+    :img_src,
+    :media_src,
+    :frame_src,
+    :child_src,
+    :worker_src,
+    :manifest_src,
+    :form_action
+  ]
+
   def init(default), do: default
 
   def call(conn, _options) do
-    config_csp = Application.get_env(:ret, RetWeb.Plugs.AddCSP)[:content_security_policy]
-
     csp =
-      if config_csp && config_csp != "" do
-        config_csp
-      else
-        case Cachex.get(:assets, :csp) do
-          {:ok, nil} ->
-            csp = generate_csp()
-            Cachex.put(:assets, :csp, csp, ttl: :timer.seconds(15))
-            csp
+      case Cachex.get(:assets, :csp) do
+        {:ok, nil} ->
+          csp = generate_csp()
+          Cachex.put(:assets, :csp, csp, ttl: :timer.seconds(15))
+          csp
 
-          {:ok, csp} ->
-            csp
-        end
+        {:ok, csp} ->
+          csp
       end
 
     conn |> Plug.Conn.put_resp_header("content-security-policy", csp)
   end
 
-  defp generate_csp() do
+  def generate_csp() do
+    custom_rules = get_custom_rules()
+
     assets_url =
       if RetWeb.Endpoint.config(:assets_url)[:host] != "" do
         "https://#{RetWeb.Endpoint.config(:assets_url)[:host]}"
@@ -50,21 +60,31 @@ defmodule RetWeb.Plugs.AddCSP do
         "https://#{ret_host}:#{ret_port} wss://#{ret_host}:#{janus_port} wss://#{ret_host}:#{ret_port}"
       end
 
-    "default-src 'none'; manifest-src 'self'; script-src #{storage_url} #{assets_url} 'self' 'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-buF6N8Z4p2PuaaeRUjm7mxBpPNf4XlCT9Fep83YabbM=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' https://www.google-analytics.com #{
+    "default-src 'none'; manifest-src 'self'; script-src #{custom_rules[:script_src]} #{storage_url} #{assets_url} 'self' 'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-buF6N8Z4p2PuaaeRUjm7mxBpPNf4XlCT9Fep83YabbM=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' https://www.google-analytics.com #{
       storage_url
-    } #{assets_url} https://aframe.io https://www.youtube.com https://s.ytimg.com 'unsafe-eval'; prefetch-src 'self' #{
+    } #{assets_url} https://aframe.io https://www.youtube.com https://s.ytimg.com; child-src #{custom_rules[:child_src]} 'self' blob:; worker-src #{
+      custom_rules[:worker_src]
+    } #{storage_url} #{assets_url} 'self' blob:; font-src #{custom_rules[:font_src]} 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net https://fonts.gstatic.com https://cdn.aframe.io #{
       storage_url
-    } #{assets_url}; child-src 'self' blob:; worker-src #{storage_url} #{assets_url} 'self' blob:; font-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net https://fonts.gstatic.com https://cdn.aframe.io #{
-      storage_url
-    } #{assets_url} #{cors_proxy_url}; style-src 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net #{
+    } #{assets_url} #{cors_proxy_url}; style-src #{custom_rules[:style_src]} 'self' https://fonts.googleapis.com https://cdn.jsdelivr.net #{
       cors_proxy_url
-    } #{storage_url} #{assets_url} 'unsafe-inline'; connect-src 'self' #{cors_proxy_url} #{storage_url} #{assets_url} #{
-      link_url
-    } https://dpdb.webvr.rocks #{thumbnail_url} #{ret_direct_connect} https://cdn.aframe.io https://www.youtube.com https://api.github.com data: blob:; img-src 'self' https://www.google-analytics.com #{
+    } #{storage_url} #{assets_url} 'unsafe-inline'; connect-src #{custom_rules[:connect_src]} 'self' #{cors_proxy_url} #{
       storage_url
-    } #{assets_url} #{cors_proxy_url} #{thumbnail_url} https://cdn.aframe.io https://www.youtube.com https://user-images.githubusercontent.com https://cdn.jsdelivr.net data: blob:; media-src 'self' #{
-      cors_proxy_url
-    } #{storage_url} #{assets_url} #{thumbnail_url} https://www.youtube.com *.googlevideo.com data: blob:; frame-src https://www.youtube.com https://docs.google.com 'self'; base-uri 'none'; form-action 'self';"
+    } #{assets_url} #{link_url} https://dpdb.webvr.rocks #{thumbnail_url} #{ret_direct_connect} https://cdn.aframe.io https://www.youtube.com https://api.github.com data: blob:; img-src #{
+      custom_rules[:img_src]
+    } 'self' https://www.google-analytics.com #{storage_url} #{assets_url} #{cors_proxy_url} #{thumbnail_url} https://cdn.aframe.io https://www.youtube.com https://user-images.githubusercontent.com https://cdn.jsdelivr.net data: blob:; media-src #{
+      custom_rules[:media_src]
+    } 'self' #{cors_proxy_url} #{storage_url} #{assets_url} #{thumbnail_url} https://www.youtube.com *.googlevideo.com data: blob:; frame-src #{
+      custom_rules[:frame_src]
+    } https://www.youtube.com https://docs.google.com 'self'; base-uri 'none'; form-action #{custom_rules[:form_action]} 'self';"
+  end
+
+  def get_custom_rules do
+    @customizable_rule_types
+    |> Enum.map(fn rule ->
+      {rule, Application.get_env(:ret, __MODULE__)[rule] || ""}
+    end)
+    |> Map.new()
   end
 
   defp config_url(key) do

--- a/lib/ret_web/plugs/add_csp.ex
+++ b/lib/ret_web/plugs/add_csp.ex
@@ -60,7 +60,7 @@ defmodule RetWeb.Plugs.AddCSP do
         "https://#{ret_host}:#{ret_port} wss://#{ret_host}:#{janus_port} wss://#{ret_host}:#{ret_port}"
       end
 
-    "default-src 'none'; manifest-src 'self'; script-src #{custom_rules[:script_src]} #{storage_url} #{assets_url} 'self' 'unsafe-eval' 'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-buF6N8Z4p2PuaaeRUjm7mxBpPNf4XlCT9Fep83YabbM=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' https://www.google-analytics.com #{
+    "default-src 'none'; manifest-src #{custom_rules[:manifest_src]} 'self'; script-src #{custom_rules[:script_src]} #{storage_url} #{assets_url} 'self' 'unsafe-eval' 'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-buF6N8Z4p2PuaaeRUjm7mxBpPNf4XlCT9Fep83YabbM=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' https://www.google-analytics.com #{
       storage_url
     } #{assets_url} https://aframe.io https://www.youtube.com https://s.ytimg.com; child-src #{custom_rules[:child_src]} 'self' blob:; worker-src #{
       custom_rules[:worker_src]

--- a/lib/ret_web/templates/page/avatar-meta.html.eex
+++ b/lib/ret_web/templates/page/avatar-meta.html.eex
@@ -20,3 +20,4 @@
 
 <%= @app_config_script %>
 <%= @extra_script %>
+<%= @extra_html %>

--- a/lib/ret_web/templates/page/avatar-meta.html.eex
+++ b/lib/ret_web/templates/page/avatar-meta.html.eex
@@ -19,5 +19,5 @@
 <title><%= @avatar.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
 
 <%= @app_config_script %>
-<%= @extra_script %>
 <%= @extra_html %>
+<%= @extra_script %>

--- a/lib/ret_web/templates/page/avatar-meta.html.eex
+++ b/lib/ret_web/templates/page/avatar-meta.html.eex
@@ -19,3 +19,4 @@
 <title><%= @avatar.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
 
 <%= @app_config_script %>
+<%= @extra_script %>

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -29,3 +29,4 @@
 
 <%= @available_integrations_script %>
 <%= @app_config_script %>
+<%= @extra_script %>

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -30,3 +30,4 @@
 <%= @available_integrations_script %>
 <%= @app_config_script %>
 <%= @extra_script %>
+<%= @extra_html %>

--- a/lib/ret_web/templates/page/hub-meta.html.eex
+++ b/lib/ret_web/templates/page/hub-meta.html.eex
@@ -29,5 +29,5 @@
 
 <%= @available_integrations_script %>
 <%= @app_config_script %>
-<%= @extra_script %>
 <%= @extra_html %>
+<%= @extra_script %>

--- a/lib/ret_web/templates/page/index-meta.html.eex
+++ b/lib/ret_web/templates/page/index-meta.html.eex
@@ -34,3 +34,4 @@
 <title><%= @translations["app-name"] %> - <%= @translations["app-tagline"] %></title>
 
 <%= @app_config_script %>
+<%= @extra_script %>

--- a/lib/ret_web/templates/page/index-meta.html.eex
+++ b/lib/ret_web/templates/page/index-meta.html.eex
@@ -33,5 +33,5 @@
 
 <title><%= @translations["app-name"] %> - <%= @translations["app-tagline"] %></title>
 <%= @app_config_script %>
-<%= @extra_script %>
 <%= @extra_html %>
+<%= @extra_script %>

--- a/lib/ret_web/templates/page/index-meta.html.eex
+++ b/lib/ret_web/templates/page/index-meta.html.eex
@@ -32,6 +32,6 @@
 <link rel="apple-touch-icon" href="/app-icon.png">
 
 <title><%= @translations["app-name"] %> - <%= @translations["app-tagline"] %></title>
-
 <%= @app_config_script %>
 <%= @extra_script %>
+<%= @extra_html %>

--- a/lib/ret_web/templates/page/scene-meta.html.eex
+++ b/lib/ret_web/templates/page/scene-meta.html.eex
@@ -25,6 +25,6 @@
 
 <title><%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
 <%= @app_config_script %>
-<%= @extra_script %>
 <%= @extra_html %>
+<%= @extra_script %>
 <% end %>

--- a/lib/ret_web/templates/page/scene-meta.html.eex
+++ b/lib/ret_web/templates/page/scene-meta.html.eex
@@ -26,4 +26,5 @@
 <title><%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
 <%= @app_config_script %>
 <%= @extra_script %>
+<%= @extra_html %>
 <% end %>

--- a/lib/ret_web/templates/page/scene-meta.html.eex
+++ b/lib/ret_web/templates/page/scene-meta.html.eex
@@ -25,4 +25,5 @@
 
 <title><%= @scene.name %> | <%= @translations["app-full-name"] || @translations["app-name"] %></title>
 <%= @app_config_script %>
+<%= @extra_script %>
 <% end %>


### PR DESCRIPTION
Goes with https://github.com/MozillaReality/ita/pull/8

Adds support for administrator set CSP rules, HTTP headers, and custom scripts. Individual headers and scripts can be set for the homepage, room, scene, and avatar pages.

Did a bunch of refactoring in page controller to make it so scripts are slightly more nicely handled.

I also realized a fairly major problem: we were not doing any kind of string escaping in the template injection in habitat. The net result is you could break reticulum in the admin console by putting a string with a quote in it in one of the configs. Fortunately, there's a simple fix: use the `toToml` helper, which conveniently injects habitat configs as toml. This also came in quite handy for the new CSP/http/script features. In general, we should probably use `toToml` for all new configs -- I was nervous about paving over *all* of them since the current semantics we have now always add quotes. So, if a value was registered as `null` in the habitat ring, it would appear as an empty string in the generated config.toml, whereas if we converted it via `toToml`, I suspect it would end up as a `null` (and `nil` in Elixir.)

Note that when pushing this out we'll need to do a bunch of refactoring of our own configs for the CSP in hubs.mozilla.com configs -- this drops the legacy "full CSP override" mechanism which was not very useful, since the server generates the CSP now. The new method is to add additional rules beyond the ones the server generates.