### PR TITLE
Add db warmer job, exclude discord from member count

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -102,6 +102,11 @@ config :ret, Ret.Scheduler,
 
     # Flush stats to db every 5 minutes
     {{:cron, "*/5 * * * *"}, {Ret.StatsJob, :save_node_stats, []}},
+
+    # Keep database warm when connected users
+    {{:cron, "*/3 * * * *"}, {Ret.DbWarmerJob, :warm_db_if_has_ccu, []}},
+
+    # Various maintenence routines
     {{:cron, "0 10 * * *"}, {Ret.Storage, :vacuum, []}},
     {{:cron, "3 10 * * *"}, {Ret.Storage, :demote_inactive_owned_files, []}},
     {{:cron, "4 10 * * *"}, {Ret.LoginToken, :expire_stale, []}},

--- a/lib/ret/db_warmer_job.ex
+++ b/lib/ret/db_warmer_job.ex
@@ -1,0 +1,14 @@
+defmodule Ret.DbWarmerJob do
+  import Ecto.Query
+
+  # Routine run to keep database up when there are any CCU.
+  # For AWS aurora, database shuts down if not being used.
+  def warm_db_if_has_ccu do
+    member_count = RetWeb.Presence.present_member_count()
+
+    if member_count > 0 do
+      # Ping DB to keep up
+      from(h in Ret.Hub, limit: 0) |> Ret.Repo.all()
+    end
+  end
+end

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -241,8 +241,14 @@ defmodule Ret.Hub do
   end
 
   def member_count_for(%Hub{hub_sid: hub_sid}) do
-    RetWeb.Presence.list("hub:#{hub_sid}") |> Enum.count()
+    RetWeb.Presence.list("hub:#{hub_sid}")
+    |> Map.values()
+    |> Enum.map(&presence_entry_to_member_count/1)
+    |> Enum.sum()
   end
+
+  defp presence_entry_to_member_count(%{metas: [%{context: %{"discord" => true}}]}), do: 0
+  defp presence_entry_to_member_count(_presence_entry), do: 1
 
   defp changeset_for_new_entry_code(%Hub{} = hub) do
     hub

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -240,7 +240,9 @@ defmodule Ret.Hub do
     scene_listing.screenshot_owned_file |> Ret.OwnedFile.uri_for() |> URI.to_string()
   end
 
-  def member_count_for(%Hub{hub_sid: hub_sid}) do
+  def member_count_for(%Hub{hub_sid: hub_sid}), do: member_count_for(hub_sid)
+
+  def member_count_for(hub_sid) do
     RetWeb.Presence.list("hub:#{hub_sid}")
     |> Map.values()
     |> Enum.map(&presence_entry_to_member_count/1)

--- a/lib/ret_web/channels/presence.ex
+++ b/lib/ret_web/channels/presence.ex
@@ -19,6 +19,13 @@ defmodule RetWeb.Presence do
     |> length
   end
 
+  def present_member_count do
+    RetWeb.Presence.present_hub_sids()
+    |> Enum.map(&Ret.Repo.get_by(Ret.Hub, hub_sid: &1))
+    |> Enum.map(&Ret.Hub.member_count_for/1)
+    |> Enum.sum()
+  end
+
   defp present_sessions do
     list("ret")
   end

--- a/lib/ret_web/channels/presence.ex
+++ b/lib/ret_web/channels/presence.ex
@@ -21,7 +21,6 @@ defmodule RetWeb.Presence do
 
   def present_member_count do
     RetWeb.Presence.present_hub_sids()
-    |> Enum.map(&Ret.Repo.get_by(Ret.Hub, hub_sid: &1))
     |> Enum.map(&Ret.Hub.member_count_for/1)
     |> Enum.sum()
   end


### PR DESCRIPTION
The AWS Aurora database we use for Hubs Cloud shuts down after 5 minutes of no database activity. However, this is problematic when there are people in a room, since it means the next request which uses the database (such as pinning an object) can take up to a minute to complete. As such, this PR sets things up so if there are any CCU in a room on your server the database will stay up.

Additionally, this updates the member count concept to exclude the discord bot, so 'empty' rooms appear as such even if the bot is monitoring them.