### PR TITLE
Selectively filter packets to reduce reliance upon intercepts

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -969,7 +969,7 @@ defmodule RetWeb.HubChannel do
       end
 
     # Each channel connection needs to be aware if there are, or ever have been,
-    # embeddings of this hub (see should_intercept_naf?)
+    # embeddings of this hub (see internal_naf_event_for/2)
     socket = socket |> assign(:has_embeds, hub.embedded)
 
     push_subscription_endpoint = params["push_subscription_endpoint"]

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -492,7 +492,7 @@ defmodule RetWeb.HubChannel do
     socket =
       socket
       |> assign(:blocked_session_ids, socket.assigns.blocked_session_ids |> Map.put(session_id, true))
-      |> assign(:has_blocks, true)
+      |> assign_has_blocks
 
     broadcast_from!(socket, event, payload |> payload_with_from(socket))
     {:noreply, socket}
@@ -502,7 +502,7 @@ defmodule RetWeb.HubChannel do
     socket =
       socket
       |> assign(:blocked_session_ids, socket.assigns.blocked_session_ids |> Map.delete(session_id))
-      |> assign(:has_blocks, true)
+      |> assign_has_blocks
 
     broadcast_from!(socket, event, payload |> payload_with_from(socket))
     {:noreply, socket}
@@ -593,7 +593,7 @@ defmodule RetWeb.HubChannel do
       if socket.assigns.session_id === session_id do
         socket
         |> assign(:blocked_by_session_ids, socket.assigns.blocked_by_session_ids |> Map.put(from_session_id, true))
-        |> assign(:has_blocks, true)
+        |> assign_has_blocks
       else
         socket
       end
@@ -606,7 +606,7 @@ defmodule RetWeb.HubChannel do
       if socket.assigns.session_id === session_id do
         socket
         |> assign(:blocked_by_session_ids, socket.assigns.blocked_by_session_ids |> Map.delete(from_session_id))
-        |> assign(:has_blocks, true)
+        |> assign_has_blocks
       else
         socket
       end
@@ -1119,6 +1119,13 @@ defmodule RetWeb.HubChannel do
   defp maybe_add_promotion_to_changeset(changeset, account, hub, payload) do
     can_change_promotion = account |> can?(update_hub_promotion(hub))
     if can_change_promotion, do: changeset |> Hub.add_promotion_to_changeset(payload), else: changeset
+  end
+
+  defp assign_has_blocks(socket) do
+    has_blocks =
+      socket.assigns.blocked_session_ids |> Enum.any?() || socket.assigns.blocked_by_session_ids |> Enum.any?()
+
+    socket |> assign(:has_blocks, has_blocks)
   end
 
   # Normally, naf and nafr messages are sent as is. However, if this connection is blocking users,


### PR DESCRIPTION
It turns out that `handle_out` is quite expensive, given that it always results in N re-encodings of each message, where N is the number of subscribers to the topic. We are using `handle_out` for a variety of purposes, but the vast majority of our messages are `naf` (and now `nafr`) and hence the `handle_out` we are using there specifically leads to a ton of overhead under load.

We use `handle_out` over NAF messages to deal with two concerns:
- If a user is blocked, or is blocking people, we intercept outgoing messages to prevent delivery in both directions.
- If the user has requested (such as in an iframe) to `block_naf` messages overall. In practice, we only do this for hubs which are embedded in iframes - we run with this assumption for now in the interest of optimization.

It turns out, these are the minority of connections typically, so if we avoid the use of `handle_out` in the majority case, the performance concerns should go away.

To do so, we now no longer intercept `naf` and `nafr` directly, but instead intercept two new event types, `maybe-nafr` and `maybe-naf`, which are only used internally. When a message comes in, if the socket is blocked, has blockers, or the hub is embedded, we send the message with the filtered variant, meaning all receivers will have an opportunity to filter it.

For the blocking case, this means if user A is blocking B, user A's messages will be flagged as filterable when sent and so will user B's, meaning anytime a block happens all of user A and B's 
messages will incur the overhead of filtering (since they may be the blockee, or may be the blocker.) We could reduce this overhead somewhat by only filtering messages from the blocker (to ensure they are not delivered to blocked users for privacy) and updating the client to drop packets for blocked users on the floor, but this doesn't seem worth the extra complexity.

For the `block_naf` case, the condition is that if *anyone* in the room is blocking NAF, it means all messages must be sent over the filtered event type, to ensure those sockets blocking NAF will have them filtered. Unfortunately, the only way to have global awareness of if anyone is blocking NAF would be to register it into presence, and this seems like a bad idea given the costs of checking presence on every incoming message. However, since we only currently use the NAF blocking feature for iframe embeds, for now we can use that as the way to determine if all messages should be intercepted or not for a topic. So, if a room is embedded (meaning it was ever seen in an iframe, even if not being viewed in an iframe in the current socket connection) then we just start filtering all packets. This does mean that if we start using `block_naf` in other contexts, it will simply not work mysteriously, and we'll need to come up with some kind of method to know up-front if messages for that room need to be globally intercepted for filtering.