### PR TITLE
Add handle_info function for :channel_expired

### DIFF
--- a/lib/ret_web/channels/auth_channel.ex
+++ b/lib/ret_web/channels/auth_channel.ex
@@ -81,6 +81,11 @@ defmodule RetWeb.AuthChannel do
     {:noreply, socket}
   end
 
+  def handle_info(:channel_expired, socket) do
+    GenServer.cast(self(), :close)
+    {:noreply, socket}
+  end
+
   def handle_out("auth_credentials" = event, payload, socket) do
     Process.send_after(self(), :close_channel, 1000 * 5)
     push(socket, event, payload)


### PR DESCRIPTION
I think we should merge this. There's a lot of noise in the sentry logs and I don't know how much of an impact this has on reliability.