### PR TITLE
Add PATCH api for admin account management

### DIFF
--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -26,6 +26,27 @@ defmodule RetWeb.Api.V1.AccountController do
     exec_api_create(conn, params, @record_schema, &process_account_create_record/2)
   end
 
+  def update(conn, params) do
+    exec_api_create(conn, params, @record_schema, &process_account_update_record/2)
+  end
+
+  defp process_account_update_record(%{"email" => email} = params, source) do
+    if !Account.exists_for_email?(email) do
+      {:error, [{:RECORD_DOES_NOT_EXIST, "Account with email does not exist.", source}]}
+    else
+      account = Account.account_for_email(email)
+
+      account =
+        if params["name"] do
+          account |> Account.set_identity!(params["name"])
+        else
+          account
+        end
+
+      {:ok, {200, Phoenix.View.render(AccountView, "create.json", account: account, email: email)}}
+    end
+  end
+
   defp process_account_create_record(%{"email" => email} = params, source) do
     if Account.exists_for_email?(email) do
       {:error, [{:RECORD_EXISTS, "Account with email already exists.", source}]}

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -123,6 +123,7 @@ defmodule RetWeb.Router do
       pipe_through([:admin_required])
       resources("/app_configs", Api.V1.AppConfigController, only: [:index, :create])
       resources("/accounts", Api.V1.AccountController, only: [:create])
+      patch("/accounts", Api.V1.AccountController, :update)
       resources("/accounts/search", Api.V1.AccountSearchController, only: [:create])
     end
   end

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -44,6 +44,30 @@ defmodule RetWeb.AccountControllerTest do
     assert res["data"]["identity"]["name"] === "Test User"
   end
 
+  test "admins can patch account identities", %{conn: conn} do
+    create_account("testapi")
+    create_account("testapi2")
+
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> patch(
+      "/api/v1/accounts",
+      Poison.encode!(%{
+        data: [
+          %{email: "testapi@mozilla.com", name: "Test User New"},
+          %{email: "testapi2@mozilla.com", name: "Test User 2 New"}
+        ]
+      })
+    )
+    |> response(207)
+
+    account = Account.account_for_email("testapi@mozilla.com")
+    assert account.identity.name === "Test User New"
+
+    account = Account.account_for_email("testapi2@mozilla.com")
+    assert account.identity.name === "Test User 2 New"
+  end
+
   test "admins can create multiple acounts, and have validation errors", %{conn: conn} do
     req =
       conn


### PR DESCRIPTION
Adds a PATCH end point to the accounts API. It accepts the same form of data as the existing POST API and will update the names on one or more accounts. If an account is not found for the email, it returns an error for that record.