### PR TITLE
Add update hub route

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -58,6 +58,22 @@ defmodule Ret.Hub do
     pin_objects: false
   }
 
+  @hub_preloads [
+    scene: Scene.scene_preloads(),
+    scene_listing: [
+      :model_owned_file,
+      :screenshot_owned_file,
+      :scene_owned_file,
+      :project,
+      :account,
+      scene: Scene.scene_preloads()
+    ],
+    web_push_subscriptions: [],
+    hub_bindings: [],
+    created_by_account: [],
+    hub_role_memberships: []
+  ]
+
   schema "hubs" do
     field(:name, :string)
     field(:description, :string)
@@ -143,6 +159,11 @@ defmodule Ret.Hub do
 
     changeset
     |> put_change(:member_permissions, member_permissions)
+  end
+
+  def maybe_add_promotion_to_changeset(changeset, account, hub, attrs) do
+    can_change_promotion = account |> can?(update_hub_promotion(hub))
+    if can_change_promotion, do: changeset |> add_promotion_to_changeset(attrs), else: changeset
   end
 
   def add_promotion_to_changeset(changeset, attrs) do

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -74,6 +74,8 @@ defmodule Ret.Hub do
     hub_role_memberships: []
   ]
 
+  def hub_preloads, do: @hub_preloads
+
   schema "hubs" do
     field(:name, :string)
     field(:description, :string)

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -670,6 +670,12 @@ defmodule Ret.MediaSearch do
       else
         %{preview: %{url: "#{RetWeb.Endpoint.url()}/app-thumbnail.png"}}
       end
+    
+    scene_id = if scene_or_scene_listing do
+      scene_or_scene_listing.scene_sid
+    else
+      nil
+    end
 
     %{
       id: hub.hub_sid,
@@ -680,7 +686,7 @@ defmodule Ret.MediaSearch do
       lobby_count: hub |> Hub.lobby_count_for(),
       name: hub.name,
       description: hub.description,
-      scene_id: hub.scene.scene_sid,
+      scene_id: scene_id,
       user_data: hub.user_data,
       images: images
     }

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -680,6 +680,7 @@ defmodule Ret.MediaSearch do
       lobby_count: hub |> Hub.lobby_count_for(),
       name: hub.name,
       description: hub.description,
+      scene_id: hub.scene.scene_sid,
       user_data: hub.user_data,
       images: images
     }

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -57,7 +57,7 @@ defmodule RetWeb.Api.V1.HubController do
               hub
               |> Hub.add_attrs_to_changeset(params["hub"])
               |> Hub.changeset_for_new_scene(params["hub"])
-              |> Hub.add_member_permissions_to_changeset(hub, scene)
+              |> Hub.add_member_permissions_to_changeset(scene)
               |> Hub.maybe_add_promotion_to_changeset(account, hub, params["hub"])
               |> Repo.update!()
               |> Repo.preload(Hub.hub_preloads())

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -47,7 +47,7 @@ defmodule RetWeb.Api.V1.HubController do
 
   def update(conn, %{"id" => hub_sid, "hub" => %{"scene_id" => scene_id}} = params) do
     account = Guardian.Plug.current_resource(conn)
-    scene = 
+
     case Scene.scene_or_scene_listing_by_sid(scene_id) do
       nil -> conn |> send_resp(422, "scene not found")
       scene ->

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -81,7 +81,7 @@ defmodule RetWeb.Api.V1.HubController do
       changeset |> Hub.add_member_permissions_to_changeset(hub_params)
     end
 
-    if not is_nil("allow_promotion") do
+    if not is_nil(hub_params["allow_promotion"]) do
       changeset |> Hub.maybe_add_promotion_to_changeset(account, hub, hub_params)
     end
 

--- a/test/ret_web/controllers/api/hub_controller_test.exs
+++ b/test/ret_web/controllers/api/hub_controller_test.exs
@@ -45,6 +45,45 @@ defmodule RetWeb.HubControllerTest do
     assert created_hub.user_data["test"] == "Hello World"
   end
 
+  test "non-room owners can't update a hub", %{conn: conn} do
+    %{"hub_id" => hub_id} =
+      conn
+      |> create_hub("Test Hub")
+      |> json_response(200)
+
+    
+    conn
+    |> update_hub(hub_id, %{ name: "New Name" })
+    |> response(401)
+  end
+
+  @tag :authenticated
+  test "The room owner can update a hub", %{conn: conn} do
+    %{"hub_id" => hub_id} =
+      conn
+      |> create_hub("Test Hub")
+      |> json_response(200)
+
+    %{"hubs" => hubs} =
+      conn
+      |> update_hub(hub_id, %{ name: "New Name" })
+      |> json_response(200)
+    
+    assert Enum.at(hubs, 0)["name"] === "New Name"
+  end
+
+  @tag :authenticated
+  test "An error is returned of the scene cannot be found", %{conn: conn} do
+    %{"hub_id" => hub_id} =
+      conn
+      |> create_hub("Test Hub")
+      |> json_response(200)
+
+    conn
+    |> update_hub(hub_id, %{ name: "New Name", scene_id: "badscene" })
+    |> response(422)
+  end
+
   defp create_hub(conn, name) do
     create_hub_with_attrs(conn, %{ name: name })
   end
@@ -52,5 +91,10 @@ defmodule RetWeb.HubControllerTest do
   defp create_hub_with_attrs(conn, attrs) do
     req = conn |> api_v1_hub_path(:create, %{"hub" => attrs})
     conn |> post(req)
+  end
+
+  defp update_hub(conn, hub_id, attrs) do
+    req = conn |> api_v1_hub_path(:update, hub_id, %{"hub" => attrs})
+    conn |> patch(req)
   end
 end


### PR DESCRIPTION
This PR adds the update route for hubs and the `scene_id` field to hubs views and media search results. This allows us to manage existing rooms via http.