### PR TITLE
Revert "Add update hub route"

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -61,24 +61,6 @@ defmodule Ret.Hub do
     spawn_emoji: false
   }
 
-  @hub_preloads [
-    scene: Scene.scene_preloads(),
-    scene_listing: [
-      :model_owned_file,
-      :screenshot_owned_file,
-      :scene_owned_file,
-      :project,
-      :account,
-      scene: Scene.scene_preloads()
-    ],
-    web_push_subscriptions: [],
-    hub_bindings: [],
-    created_by_account: [],
-    hub_role_memberships: []
-  ]
-
-  def hub_preloads, do: @hub_preloads
-
   schema "hubs" do
     field(:name, :string)
     field(:description, :string)
@@ -164,11 +146,6 @@ defmodule Ret.Hub do
 
     changeset
     |> put_change(:member_permissions, member_permissions)
-  end
-
-  def maybe_add_promotion_to_changeset(changeset, account, hub, attrs) do
-    can_change_promotion = account |> can?(update_hub_promotion(hub))
-    if can_change_promotion, do: changeset |> add_promotion_to_changeset(attrs), else: changeset
   end
 
   def add_promotion_to_changeset(changeset, attrs) do

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -670,12 +670,6 @@ defmodule Ret.MediaSearch do
       else
         %{preview: %{url: "#{RetWeb.Endpoint.url()}/app-thumbnail.png"}}
       end
-    
-    scene_id = if scene_or_scene_listing do
-      scene_or_scene_listing.scene_sid
-    else
-      nil
-    end
 
     %{
       id: hub.hub_sid,
@@ -686,7 +680,6 @@ defmodule Ret.MediaSearch do
       lobby_count: hub |> Hub.lobby_count_for(),
       name: hub.name,
       description: hub.description,
-      scene_id: scene_id,
       user_data: hub.user_data,
       images: images
     }

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -37,11 +37,27 @@ defmodule RetWeb.HubChannel do
     "maybe-nafr"
   ])
 
+  @hub_preloads [
+    scene: Scene.scene_preloads(),
+    scene_listing: [
+      :model_owned_file,
+      :screenshot_owned_file,
+      :scene_owned_file,
+      :project,
+      :account,
+      scene: Scene.scene_preloads()
+    ],
+    web_push_subscriptions: [],
+    hub_bindings: [],
+    created_by_account: [],
+    hub_role_memberships: []
+  ]
+
   def join("hub:" <> hub_sid, %{"profile" => profile, "context" => context} = params, socket) do
     hub =
       Hub
       |> Repo.get_by(hub_sid: hub_sid)
-      |> Repo.preload(Hub.hub_preloads())
+      |> Repo.preload(@hub_preloads)
 
     socket
     |> assign(:profile, profile)
@@ -290,7 +306,7 @@ defmodule RetWeb.HubChannel do
       {:ok, %Account{} = account, _claims} ->
         socket = Guardian.Phoenix.Socket.put_current_resource(socket, account)
 
-        hub = socket |> hub_for_socket |> Repo.preload(Hub.hub_preloads())
+        hub = socket |> hub_for_socket |> Repo.preload(@hub_preloads)
 
         hub =
           if creator_assignment_token do
@@ -415,9 +431,9 @@ defmodule RetWeb.HubChannel do
       hub
       |> Hub.add_attrs_to_changeset(payload)
       |> Hub.add_member_permissions_to_changeset(payload)
-      |> Hub.maybe_add_promotion_to_changeset(account, hub, payload)
+      |> maybe_add_promotion_to_changeset(account, hub, payload)
       |> Repo.update!()
-      |> Repo.preload(Hub.hub_preloads())
+      |> Repo.preload(@hub_preloads)
       |> broadcast_hub_refresh!(socket, stale_fields)
     end
 
@@ -444,7 +460,7 @@ defmodule RetWeb.HubChannel do
           hub |> Hub.changeset_for_new_environment_url(url)
       end
       |> Repo.update!()
-      |> Repo.preload(Hub.hub_preloads(), force: true)
+      |> Repo.preload(@hub_preloads, force: true)
       |> broadcast_hub_refresh!(socket, ["scene"])
     end
 
@@ -682,7 +698,7 @@ defmodule RetWeb.HubChannel do
       hub
       |> Hub.changeset_for_entry_mode(entry_mode)
       |> Repo.update!()
-      |> Repo.preload(Hub.hub_preloads())
+      |> Repo.preload(@hub_preloads)
       |> broadcast_hub_refresh!(socket, ["entry_mode"])
     end
 
@@ -1106,6 +1122,11 @@ defmodule RetWeb.HubChannel do
 
   defp payload_without_from(payload) do
     payload |> Map.delete(:from_session_id)
+  end
+
+  defp maybe_add_promotion_to_changeset(changeset, account, hub, payload) do
+    can_change_promotion = account |> can?(update_hub_promotion(hub))
+    if can_change_promotion, do: changeset |> Hub.add_promotion_to_changeset(payload), else: changeset
   end
 
   defp assign_has_blocks(socket) do

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -45,52 +45,6 @@ defmodule RetWeb.Api.V1.HubController do
     end
   end
 
-  def update(conn, %{"id" => hub_sid, "hub" => hub_params}) do
-    account = Guardian.Plug.current_resource(conn)
-
-    case Hub |> Repo.get_by(hub_sid: hub_sid) |> Repo.preload([:created_by_account, :hub_bindings, :hub_role_memberships]) do
-      %Hub{} = hub -> 
-        if account |> can?(update_hub(hub)) do
-          update_with_hub(conn, account, hub, hub_params)
-        else
-          conn |> send_resp(401, "You cannot update this hub")
-        end
-      _ -> conn |> send_resp(404, "not found")
-    end
-  end
-
-  defp update_with_hub(conn, account, hub, hub_params) do
-    if is_nil(hub_params["scene_id"]) do
-      update_with_hub_and_scene(conn, account, hub, nil, hub_params)
-    else
-      case Scene.scene_or_scene_listing_by_sid(hub_params["scene_id"]) do
-        nil -> conn |> send_resp(422, "scene not found")
-        scene -> update_with_hub_and_scene(conn, account, hub, scene, hub_params)
-      end
-    end
-  end
-
-  defp update_with_hub_and_scene(conn, account, hub, scene, hub_params) do
-    changeset = hub |> Hub.add_attrs_to_changeset(hub_params)
-    
-    if not is_nil(scene) do
-      changeset |> Hub.changeset_for_new_scene(scene)
-    end
-
-    if not is_nil(hub_params["member_permissions"]) do
-      changeset |> Hub.add_member_permissions_to_changeset(hub_params)
-    end
-
-    if not is_nil(hub_params["allow_promotion"]) do
-      changeset |> Hub.maybe_add_promotion_to_changeset(account, hub, hub_params)
-    end
-
-    hub = changeset |> Repo.update!() |> Repo.preload(Hub.hub_preloads())
-
-    conn |> render("show.json", %{ hub: hub, embeddable: account |> can?(embed_hub(hub))})
-  end
-
-
   def delete(conn, %{"id" => hub_sid}) do
     Hub
     |> Repo.get_by(hub_sid: hub_sid)

--- a/test/ret_web/controllers/api/hub_controller_test.exs
+++ b/test/ret_web/controllers/api/hub_controller_test.exs
@@ -45,45 +45,6 @@ defmodule RetWeb.HubControllerTest do
     assert created_hub.user_data["test"] == "Hello World"
   end
 
-  test "non-room owners can't update a hub", %{conn: conn} do
-    %{"hub_id" => hub_id} =
-      conn
-      |> create_hub("Test Hub")
-      |> json_response(200)
-
-    
-    conn
-    |> update_hub(hub_id, %{ name: "New Name" })
-    |> response(401)
-  end
-
-  @tag :authenticated
-  test "The room owner can update a hub", %{conn: conn} do
-    %{"hub_id" => hub_id} =
-      conn
-      |> create_hub("Test Hub")
-      |> json_response(200)
-
-    %{"hubs" => hubs} =
-      conn
-      |> update_hub(hub_id, %{ name: "New Name" })
-      |> json_response(200)
-    
-    assert Enum.at(hubs, 0)["name"] === "New Name"
-  end
-
-  @tag :authenticated
-  test "An error is returned of the scene cannot be found", %{conn: conn} do
-    %{"hub_id" => hub_id} =
-      conn
-      |> create_hub("Test Hub")
-      |> json_response(200)
-
-    conn
-    |> update_hub(hub_id, %{ name: "New Name", scene_id: "badscene" })
-    |> response(422)
-  end
-
   defp create_hub(conn, name) do
     create_hub_with_attrs(conn, %{ name: name })
   end
@@ -91,10 +52,5 @@ defmodule RetWeb.HubControllerTest do
   defp create_hub_with_attrs(conn, attrs) do
     req = conn |> api_v1_hub_path(:create, %{"hub" => attrs})
     conn |> post(req)
-  end
-
-  defp update_hub(conn, hub_id, attrs) do
-    req = conn |> api_v1_hub_path(:update, hub_id, %{"hub" => attrs})
-    conn |> patch(req)
   end
 end


### PR DESCRIPTION
Reverts mozilla/reticulum#336

The compiler deadlocked, probably due to some circular dependency. I'm not 100% sure what yet.