### PR TITLE
Fix sketchfab model parsing

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -347,6 +347,13 @@ defmodule Ret.MediaResolver do
   end
 
   defp resolve_sketchfab_model(model_id, api_key, version \\ 1) do
+    model_id =
+      if model_id |> String.contains?("-") do
+        model_id |> String.split("-") |> List.last()
+      else
+        model_id
+      end
+
     cached_file_result =
       CachedFile.fetch(
         "sketchfab-#{model_id}-#{version}",


### PR DESCRIPTION
Sketchfab has updated their model id slugs, so we need to adjust the parsing algorithm.