### PR TITLE
Better resolving of dropbox urls

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -41,6 +41,20 @@ defmodule Ret.MediaResolver do
     {:commit, nil}
   end
 
+  # auto convert dropbox urls to "raw" urls
+  def resolve(%MediaResolverQuery{url: %URI{host: "www.dropbox.com", path: "/s/" <> _rest} = url} = query, root_host) do
+    {:commit,
+     url
+     |> Map.put(
+       :query,
+       URI.decode_query(url.query)
+       |> Map.delete("dl")
+       |> Map.put("raw", 1)
+       |> URI.encode_query()
+     )
+     |> resolved()}
+  end
+
   # Necessary short circuit around google.com root_host to skip YT-DL check for Poly
   def resolve(%MediaResolverQuery{url: %URI{host: "poly.google.com"}} = query, root_host) do
     rate_limited_resolve(query, root_host, @poly_rate_limit, fn ->

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -42,7 +42,7 @@ defmodule Ret.MediaResolver do
   end
 
   # auto convert dropbox urls to "raw" urls
-  def resolve(%MediaResolverQuery{url: %URI{host: "www.dropbox.com", path: "/s/" <> _rest} = url} = query, root_host) do
+  def resolve(%MediaResolverQuery{url: %URI{host: "www.dropbox.com", path: "/s/" <> _rest} = url}, _root_host) do
     {:commit,
      url
      |> Map.put(


### PR DESCRIPTION
Resolve links like https://www.dropbox.com/s/rds4qdmo5jvzw2l/2020-02-29%2009.23.19-1.jpg?dl=0 to their "raw" form "https://www.dropbox.com/s/rds4qdmo5jvzw2l/2020-02-29%2009.23.19-1.jpg?raw=1" which can be directly loaded through our CORS proxy.

closes #363