### PR TITLE
Add dev-janus.reticulum.io to dev config

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -160,7 +160,7 @@ config :ret, RetWeb.Plugs.AddCSP,
   font_src: asset_hosts,
   style_src: asset_hosts,
   connect_src:
-    "https://#{host}:8080 https://sentry.prod.mozaws.net #{asset_hosts} #{websocket_hosts} https://www.mozilla.org",
+    "https://#{host}:8080 https://sentry.prod.mozaws.net #{asset_hosts} #{websocket_hosts} https://www.mozilla.org https://dev-janus.reticulum.io",
   img_src: asset_hosts,
   media_src: asset_hosts,
   manifest_src: asset_hosts


### PR DESCRIPTION
When running hubs and reticulum locally, hubs fails to connect to the dev-janus server via `https` because its only entries in the CSP are `wss`. This adds the `https` entry for dev-janus.reticulum.io to the CSP so that the fetch to it from hubs succeeds. (https://github.com/mozilla/hubs/blob/dbc29edb69b277471b3b1ae66f0e0a1536923293/src/hub.js#L558)