### PR TITLE
Fix resolving of youtube live urls

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -76,7 +76,8 @@ defmodule Ret.MediaResolver do
 
       # YouTube returns a 'expire' which has timestamp of expiration.
       resolved_media =
-        with parsed_youtube_query <- URI.decode_query(youtube_query),
+        with youtube_query when is_binary(youtube_query) <- youtube_query,
+             parsed_youtube_query <- URI.decode_query(youtube_query),
              expire when is_binary(expire) <- Map.get(parsed_youtube_query, "expire"),
              {expire_s, _} <- Integer.parse(expire),
              ttl_s <- expire_s - System.system_time(:second) do

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -90,6 +90,7 @@ defmodule RetWeb.Api.V1.MediaController do
       version: version
     }
 
+    # Status can be :commit, :ignore, or :error
     case Cachex.fetch(:media_urls, query) do
       {_status, nil} ->
         conn |> send_resp(404, "")
@@ -101,8 +102,8 @@ defmodule RetWeb.Api.V1.MediaController do
 
         render_resolved_media(conn, resolved_media)
 
-      _ ->
-        conn |> send_resp(404, "")
+      {:error, e} ->
+        conn |> send_resp(500, e)
     end
   end
 


### PR DESCRIPTION
We were previously assuming all resolved youtube urls would have a querystring with expires params, this is not true for live videos. This was previously throwing an error since we tried to call `URI.decode_query` on `nil`, now handling this sort of error as a 500 instead of a 404 and actually returning the error so that we can tell the difference between internal errors and things that actually couldn't be resolved at the source.

Fixes https://github.com/mozilla/hubs/issues/2431