### PR TITLE
404 in case where youtube also fails to grab a screenshot

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -88,7 +88,7 @@ defmodule Ret.MediaResolver do
 
           {:commit, resolved_media}
 
-        # Faild to resolve, fall through as a 404
+        # Failed to resolve, fall through as a 404
         _ ->
           {:commit, nil}
       end

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -70,24 +70,28 @@ defmodule Ret.MediaResolver do
   # Also compute ttl here based upon expire, to localize youtube.com specific logic.
   def resolve(%MediaResolverQuery{} = query, "youtube.com" = root_host) do
     rate_limited_resolve(query, root_host, @youtube_rate_limit, fn ->
-      res = resolve_with_ytdl(query, root_host, query |> ytdl_format(root_host))
+      case resolve_with_ytdl(query, root_host, query |> ytdl_format(root_host)) do
+        # resolved either as a youtube video or screenshot url
+        {:commit, %Ret.ResolvedMedia{uri: %URI{query: youtube_query}} = resolved_media} ->
+          # YouTube returns a 'expire' which has timestamp of expiration.
+          resolved_media =
+            with youtube_query when is_binary(youtube_query) <- youtube_query,
+                 parsed_youtube_query <- URI.decode_query(youtube_query),
+                 expire when is_binary(expire) <- Map.get(parsed_youtube_query, "expire"),
+                 {expire_s, _} <- Integer.parse(expire),
+                 ttl_s <- expire_s - System.system_time(:second) do
+              # Expire a minute early
+              resolved_media |> Map.put(:ttl, ttl_s * 1000 - 60000)
+            else
+              _ -> resolved_media
+            end
 
-      {:commit, %Ret.ResolvedMedia{uri: %URI{query: youtube_query}} = resolved_media} = res
+          {:commit, resolved_media}
 
-      # YouTube returns a 'expire' which has timestamp of expiration.
-      resolved_media =
-        with youtube_query when is_binary(youtube_query) <- youtube_query,
-             parsed_youtube_query <- URI.decode_query(youtube_query),
-             expire when is_binary(expire) <- Map.get(parsed_youtube_query, "expire"),
-             {expire_s, _} <- Integer.parse(expire),
-             ttl_s <- expire_s - System.system_time(:second) do
-          # Expire a minute early
-          resolved_media |> Map.put(:ttl, ttl_s * 1000 - 60000)
-        else
-          _ -> resolved_media
-        end
-
-      {:commit, resolved_media}
+        # Faild to resolve, fall through as a 404
+        _ ->
+          {:commit, nil}
+      end
     end)
   end
 

--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -90,7 +90,6 @@ defmodule RetWeb.Api.V1.MediaController do
       version: version
     }
 
-    # Status can be :commit, :ignore, or :error
     case Cachex.fetch(:media_urls, query) do
       {_status, nil} ->
         conn |> send_resp(404, "")
@@ -104,6 +103,9 @@ defmodule RetWeb.Api.V1.MediaController do
 
       {:error, e} ->
         conn |> send_resp(500, e)
+
+      _ ->
+        conn |> send_resp(500, "Error resolving media")
     end
   end
 


### PR DESCRIPTION
This was hitting an error and returning 500, not a big deal but investigated to find out why, and its better explicitly handled than happening to fail.