### PR TITLE
If-def out slack client config so that they don't break on HMC and HC…

### DIFF
--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -9,10 +9,12 @@ client_id = {{ toToml cfg.discord_client.client_id }}
 client_secret = {{ toToml cfg.discord_client.client_secret }}
 bot_token = {{ toToml cfg.discord_client.bot_token }}
 
+{{#if cfg.slack_client.client_id}}
 [ret."Elixir.Ret.SlackClient"]
 client_id = {{ toToml cfg.slack_client.client_id }}
 client_secret = {{ toToml cfg.slack_client.client_secret }}
 bot_token = {{ toToml cfg.slack_client.bot_token }}
+{{/if}}
 
 [ret."Elixir.RetWeb.Api.V1.SlackController"]
 token = {{ toToml cfg.slack_controller.token }}


### PR DESCRIPTION
… instances that don't have values for them.

SlackClient configs are only used on HMC prod. This is currently breaking config generation on HMC dev and Hubs Cloud instances.