### PR TITLE
Don't return content type for youtube-dl queries

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -127,9 +127,13 @@ defmodule Ret.MediaResolver do
             {:commit,
              media_url
              |> URI.parse()
-             |> resolved(%{
-               expected_content_type: "video/*"
-             })}
+             |> resolved(
+               %{
+                 # TODO we would like to return a content type here but need to understand the response
+                 # from youtube-dl better to do so confidently, as it will not always be video
+                 # expected_content_type: "video/*"
+               }
+             )}
           end
 
         _ ->


### PR DESCRIPTION
Looks like we can not safely assume content type returned from youtube-dl queries are videos after all. An mp3 still returns a 200 response, but is not recognized as a video. For now just reverting returning of content type. Ideally we would look at the response and be able to decide, but it would need some more work to understand all the possible responses.

fixes https://github.com/mozilla/hubs/issues/2802