### PR TITLE
Basic Hub Invites

### DIFF
--- a/lib/ret/enums.ex
+++ b/lib/ret/enums.ex
@@ -1,6 +1,7 @@
 import EctoEnum
 
-defenum(Ret.Hub.EntryMode, :hub_entry_mode, [:allow, :deny], schema: "ret0")
+defenum(Ret.Hub.EntryMode, :hub_entry_mode, [:allow, :invite, :deny], schema: "ret0")
+defenum(Ret.HubInvite.State, :hub_invite_state, [:active, :revoked], schema: "ret0")
 defenum(Ret.HubBinding.Type, :hub_binding_type, [:discord, :slack], schema: "ret0")
 defenum(Ret.OAuthProvider.Source, :oauth_provider_source, [:discord, :slack, :twitter], schema: "ret0")
 defenum(Ret.OwnedFile.State, :owned_file_state, [:active, :inactive, :removed], schema: "ret0")

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -104,6 +104,7 @@ defmodule Ret.Hub do
     belongs_to(:scene_listing, Ret.SceneListing, references: :scene_listing_id)
     has_many(:web_push_subscriptions, Ret.WebPushSubscription, foreign_key: :hub_id)
     belongs_to(:created_by_account, Ret.Account, references: :account_id)
+    has_many(:hub_invites, Ret.HubInvite, foreign_key: :hub_id)
     has_many(:hub_bindings, Ret.HubBinding, foreign_key: :hub_id)
     has_many(:hub_role_memberships, Ret.HubRoleMembership, foreign_key: :hub_id)
 
@@ -213,6 +214,10 @@ defmodule Ret.Hub do
 
   def add_promotion_to_changeset(changeset, attrs) do
     changeset |> put_change(:allow_promotion, !!attrs["allow_promotion"])
+  end
+
+  def add_entry_mode_to_changeset(changeset, attrs) do
+    changeset |> put_change(:entry_mode, attrs["entry_mode"])
   end
 
   def changeset_for_new_seen_occupant_count(%Hub{} = hub, occupant_count) do

--- a/lib/ret/hub_invite.ex
+++ b/lib/ret/hub_invite.ex
@@ -1,0 +1,45 @@
+defmodule Ret.HubInvite do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Ret.{Hub, HubInvite, Repo}
+
+  @schema_prefix "ret0"
+  @primary_key {:hub_invite_id, :id, autogenerate: true}
+
+  schema "hub_invites" do
+    field(:hub_invite_sid, :string)
+    field(:state, HubInvite.State)
+    belongs_to(:hub, Hub, references: :hub_id)
+    timestamps()
+  end
+
+  def invite_for_hub(%Hub{} = hub) do
+    hub_invite = HubInvite |> Repo.get_by(hub_id: hub.hub_id, state: :active)
+
+    if hub_invite == nil do
+      hub_invite_sid = Ret.Sids.generate_sid()
+
+      change(%HubInvite{hub_id: hub.hub_id, hub_invite_sid: hub_invite_sid})
+      |> unique_constraint(:hub_invite_sid)
+      |> Repo.insert!()
+    else
+      hub_invite
+    end
+  end
+
+  def revoke_invite(hub_invite_sid) when is_binary(hub_invite_sid) do
+    hub_invite = HubInvite |> Repo.get_by(hub_invite_sid: hub_invite_sid)
+    change(hub_invite, state: :revoked) |> Repo.update!()
+  end
+
+  def active?(nil = _hub_invite_sid), do: false
+
+  def active?(hub_invite_sid) do
+    case Ret.HubInvite |> Ret.Repo.get_by(hub_invite_sid: hub_invite_sid) do
+      nil -> false
+      %Ret.HubInvite{state: :revoked} -> false
+      %Ret.HubInvite{state: :active} -> true
+    end
+  end
+end

--- a/lib/ret/hub_invite.ex
+++ b/lib/ret/hub_invite.ex
@@ -14,7 +14,7 @@ defmodule Ret.HubInvite do
     timestamps()
   end
 
-  def invite_for_hub(%Hub{} = hub) do
+  def find_or_create_invite_for_hub(%Hub{} = hub) do
     hub_invite = HubInvite |> Repo.get_by(hub_id: hub.hub_id, state: :active)
 
     if hub_invite == nil do

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -436,7 +436,7 @@ defmodule RetWeb.HubChannel do
     account = Guardian.Phoenix.Socket.current_resource(socket)
 
     if account |> can?(update_hub(hub)) do
-      hub_invite = hub |> HubInvite.invite_for_hub()
+      hub_invite = hub |> HubInvite.find_or_create_invite_for_hub()
       {:reply, {:ok, %{hub_invite_id: hub_invite && hub_invite.hub_invite_sid}}, socket}
     else
       {:reply, {:ok, %{}}, socket}
@@ -450,7 +450,7 @@ defmodule RetWeb.HubChannel do
     if account |> can?(update_hub(hub)) do
       HubInvite.revoke_invite(payload["hub_invite_id"])
       # Hubs can only have one invite for now, so we create a new one when the old one was revoked.
-      hub_invite = hub |> HubInvite.invite_for_hub()
+      hub_invite = hub |> HubInvite.find_or_create_invite_for_hub()
       {:reply, {:ok, %{hub_invite_id: hub_invite.hub_invite_sid}}, socket}
     else
       {:reply, {:ok, %{}}, socket}

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -8,6 +8,7 @@ defmodule RetWeb.HubChannel do
   alias Ret.{
     AppConfig,
     Hub,
+    HubInvite,
     Account,
     AccountFavorite,
     Identity,
@@ -54,7 +55,7 @@ defmodule RetWeb.HubChannel do
     |> perform_join(
       hub,
       context,
-      params |> Map.take(["push_subscription_endpoint", "auth_token", "perms_token", "bot_access_key"])
+      params |> Map.take(["push_subscription_endpoint", "auth_token", "perms_token", "bot_access_key", "hub_invite_id"])
     )
   end
 
@@ -72,6 +73,7 @@ defmodule RetWeb.HubChannel do
     account_has_provider_for_hub = account |> Ret.Account.matching_oauth_providers(hub) |> Enum.empty?() |> Kernel.not()
 
     account_can_join = account |> can?(join_hub(hub))
+    account_can_update = account |> can?(update_hub(hub))
 
     perms_token = params["perms_token"]
 
@@ -94,13 +96,17 @@ defmodule RetWeb.HubChannel do
           {nil, nil}
       end
 
+    has_active_invite = Ret.HubInvite.active?(params["hub_invite_id"])
+
     params =
       params
       |> Map.merge(%{
+        has_active_invite: has_active_invite,
         hub_requires_oauth: hub_requires_oauth,
         has_valid_bot_access_key: has_valid_bot_access_key,
         account_has_provider_for_hub: account_has_provider_for_hub,
         account_can_join: account_can_join,
+        account_can_update: account_can_update,
         has_perms_token: has_perms_token,
         oauth_account_id: oauth_account_id,
         oauth_source: oauth_source,
@@ -402,6 +408,7 @@ defmodule RetWeb.HubChannel do
       room_size_changed = hub.room_size != payload["room_size"]
       can_change_promotion = account |> can?(update_hub_promotion(hub))
       promotion_changed = can_change_promotion and hub.allow_promotion != payload["allow_promotion"]
+      entry_mode_changed = hub.entry_mode != payload["entry_mode"]
 
       stale_fields = []
       stale_fields = if name_changed, do: ["name" | stale_fields], else: stale_fields
@@ -409,17 +416,45 @@ defmodule RetWeb.HubChannel do
       stale_fields = if member_permissions_changed, do: ["member_permissions" | stale_fields], else: stale_fields
       stale_fields = if room_size_changed, do: ["room_size" | stale_fields], else: stale_fields
       stale_fields = if promotion_changed, do: ["allow_promotion" | stale_fields], else: stale_fields
+      stale_fields = if entry_mode_changed, do: ["entry_mode" | stale_fields], else: stale_fields
 
       hub
       |> Hub.add_attrs_to_changeset(payload)
       |> Hub.add_member_permissions_to_changeset(payload)
       |> Hub.maybe_add_promotion_to_changeset(account, hub, payload)
+      |> Hub.add_entry_mode_to_changeset(payload)
       |> Repo.update!()
       |> Repo.preload(Hub.hub_preloads())
       |> broadcast_hub_refresh!(socket, stale_fields)
     end
 
     {:noreply, socket}
+  end
+
+  def handle_in("fetch_invite", _payload, socket) do
+    hub = hub_for_socket(socket)
+    account = Guardian.Phoenix.Socket.current_resource(socket)
+
+    if account |> can?(update_hub(hub)) do
+      hub_invite = hub |> HubInvite.invite_for_hub()
+      {:reply, {:ok, %{hub_invite_id: hub_invite && hub_invite.hub_invite_sid}}, socket}
+    else
+      {:reply, {:ok, %{}}, socket}
+    end
+  end
+
+  def handle_in("revoke_invite", payload, socket) do
+    hub = hub_for_socket(socket)
+    account = Guardian.Phoenix.Socket.current_resource(socket)
+
+    if account |> can?(update_hub(hub)) do
+      HubInvite.revoke_invite(payload["hub_invite_id"])
+      # Hubs can only have one invite for now, so we create a new one when the old one was revoked.
+      hub_invite = hub |> HubInvite.invite_for_hub()
+      {:reply, {:ok, %{hub_invite_id: hub_invite.hub_invite_sid}}, socket}
+    else
+      {:reply, {:ok, %{}}, socket}
+    end
   end
 
   def handle_in("close_hub", _payload, socket) do
@@ -882,6 +917,18 @@ defmodule RetWeb.HubChannel do
          %{
            hub_requires_oauth: false,
            account_can_join: false
+         }
+       ),
+       do: deny_join()
+
+  defp join_with_hub(
+         %Hub{entry_mode: :invite},
+         _account,
+         _socket,
+         _context,
+         %{
+           has_active_invite: false,
+           account_can_update: false
          }
        ),
        do: deny_join()

--- a/priv/repo/migrations/20200730155900_add_invite_to_hub_entry_mode_enum.exs
+++ b/priv/repo/migrations/20200730155900_add_invite_to_hub_entry_mode_enum.exs
@@ -1,0 +1,8 @@
+defmodule Ret.Repo.Migrations.AddInviteToHubEntryModeEnum do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+
+  def change do
+    Ecto.Migration.execute("ALTER TYPE ret0.hub_entry_mode ADD VALUE IF NOT EXISTS 'invite'")
+  end
+end

--- a/priv/repo/migrations/20200805190647_create_hub_invites_table.exs
+++ b/priv/repo/migrations/20200805190647_create_hub_invites_table.exs
@@ -1,0 +1,18 @@
+defmodule Ret.Repo.Migrations.CreateHubInvitesTable do
+  use Ecto.Migration
+
+  def change do
+    Ret.HubInvite.State.create_type()
+
+    create table(:hub_invites, primary_key: false) do
+      add(:hub_invite_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+      add(:hub_invite_sid, :string, null: false)
+      add(:hub_id, :bigint, null: false)
+      add(:state, :hub_invite_state, null: false, default: "active")
+
+      timestamps()
+    end
+
+    create(index(:hub_invites, [:hub_invite_sid], unique: true))
+  end
+end


### PR DESCRIPTION
Introduces the idea of a `HubInvite`, which allows us to restrict access to rooms when they are in the `:invite` `entry_mode`. Hubs can have multiple invites, but this basic implementation only allows for one. Future enhancements might also include different types of invites, with expiration, usage limits, etc.
Currently, invites do not persist any data on a user's account. They are effectively just used as passwords in this initial implementation. Users must use the invite URL to access an invite-only room.
This PR also adds `hub_channel` handlers to fetch and revoke invites, and room join denial logic to enforce the invites.