### PR TITLE
Add statix measurement of rate_limited responses

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -191,6 +191,7 @@ defmodule Ret.MediaResolver do
             {:offline_stream, body}
 
           String.contains?(body, "HTTPError 429") ->
+            Statix.increment("ret.media_resolver.ytdl.rate_limited")
             {:rate_limited, body}
 
           true ->


### PR DESCRIPTION
We frequently get complaints about certain video services not working. In order for us to better understand how frequently users encounter issue this is on HMC, this PR adds a measurement that will increment every time it happens.