### PR TITLE
Admin only plug returns 401 correctly

### DIFF
--- a/lib/ret_web/plugs/admin_only.ex
+++ b/lib/ret_web/plugs/admin_only.ex
@@ -12,8 +12,7 @@ defmodule RetWeb.Plugs.AdminOnly do
       conn
     else
       conn
-      |> resp(401, "Not authorized")
-      |> send_resp()
+      |> send_resp(401, "Not authorized")
       |> halt()
     end
   end

--- a/lib/ret_web/plugs/admin_only.ex
+++ b/lib/ret_web/plugs/admin_only.ex
@@ -7,7 +7,6 @@ defmodule RetWeb.Plugs.AdminOnly do
   def call(conn, _opts) do
     # Put account in into assigns for Canary to consume.
     account = Guardian.Plug.current_resource(conn)
-    main_host = RetWeb.Endpoint.config(:url)[:host]
 
     if account && account.is_admin do
       conn

--- a/lib/ret_web/plugs/admin_only.ex
+++ b/lib/ret_web/plugs/admin_only.ex
@@ -7,12 +7,14 @@ defmodule RetWeb.Plugs.AdminOnly do
   def call(conn, _opts) do
     # Put account in into assigns for Canary to consume.
     account = Guardian.Plug.current_resource(conn)
+    main_host = RetWeb.Endpoint.config(:url)[:host]
 
     if account && account.is_admin do
       conn
     else
       conn
-      |> put_status(:unauthorized)
+      |> resp(401, "Not authorized")
+      |> send_resp()
       |> halt()
     end
   end

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -17,8 +17,11 @@ defmodule RetWeb.AccountControllerTest do
     req = conn |> api_v1_account_path(:create, %{data: %{email: "testapi@mozilla.com"}})
     conn = conn |> post(req)
 
+    exists = Account.exists_for_email?("testapi@mozilla.com")
+
     assert conn.status === 401
-    assert conn.state === :unset
+    assert conn.resp_body === "Not authorized"
+    assert exists === false
   end
 
   test "admins can create accounts", %{conn: conn} do
@@ -128,7 +131,7 @@ defmodule RetWeb.AccountControllerTest do
     conn = conn |> post(req)
 
     assert conn.status === 401
-    assert conn.state === :unset
+    assert conn.resp_body === "Not authorized"
   end
 
   test "should return 404 if no such account exists", %{conn: conn} do

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -17,11 +17,9 @@ defmodule RetWeb.AccountControllerTest do
     req = conn |> api_v1_account_path(:create, %{data: %{email: "testapi@mozilla.com"}})
     conn = conn |> post(req)
 
-    exists = Account.exists_for_email?("testapi@mozilla.com")
-
+    assert !Account.exists_for_email?("testapi@mozilla.com")
     assert conn.status === 401
     assert conn.resp_body === "Not authorized"
-    assert exists === false
   end
 
   test "admins can create accounts", %{conn: conn} do


### PR DESCRIPTION
With just put_status, the response that failed on the :admin_only step would receive a 500 response. 

This returns a 402 for unauthorized. 