### PR TITLE
Explicitly installs node v10+ to prevent yarn install fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM elixir:1.5
-RUN apt-get update -qq && apt-get install -y inotify-tools nodejs nodejs-legacy
+RUN apt-get update -qq && apt-get install -y inotify-tools 
+RUN curl -sL https://deb.nodesource.com/setup_10.x |  bash -
+RUN apt-get install -y nodejs
 RUN curl -so- -L https://yarnpkg.com/install.sh | bash
 RUN mkdir /ret
 WORKDIR	/ret


### PR DESCRIPTION
Hi, 

We're working on a hubs project at work and I'm trying to get a local version of reticulum up and running locally. 

I cloned the repository, read through the readme, and looked through the file structure. I spotted the Dockerfile and docker-compose and saw that the Dockerfile covered the steps outlined in the readme, so I hopped in the terminal and fired a `docker-compose build`. When I did I an error when yarn was being installed:

<img width="1108" alt="Screen Shot 2020-09-18 at 9 59 21 AM" src="https://user-images.githubusercontent.com/2437424/93617706-ed050e00-f99b-11ea-98d6-d2b905474347.png">

I went to the yarn repository and [found a closed issue about this specific error](https://github.com/yarnpkg/yarn/issues/6914).

The gist is that this error will happen if you try to install an up to date version of of yarn with an older version of node. 

Looking through the Dockerfile I saw that the version of node being installed was whatever the package manager currently had available (i.e. `apt-get install -y nodejs`) and when I spit out the version number it was back at v4:

<img width="1792" alt="Screen Shot 2020-09-18 at 10 17 05 AM" src="https://user-images.githubusercontent.com/2437424/93618010-57b64980-f99c-11ea-9cac-6937940e7dbc.png">

So, I updated the Dockerfile to explicitly pull node v10.x (suggested in the yarn thread) when installing which resolved the issue. 

<img width="1792" alt="Screen Shot 2020-09-18 at 10 49 04 AM" src="https://user-images.githubusercontent.com/2437424/93618364-c3001b80-f99c-11ea-86f1-a456732eb137.png">

So, I thought I'd pass along the fix :)
