### PR TITLE
Bump hackney to fix TLS related issues

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Ret.Mixfile do
       {:plug_cowboy, "~> 2.0"},
       {:distillery, "~> 2.0"},
       {:peerage, "~> 1.0"},
+      {:hackney, "~> 1.16.0", override: true},
       {:httpoison, "~> 1.5"},
       {:poison, "~> 3.1"},
       {:ecto_autoslug_field, "~> 2.0"},


### PR DESCRIPTION
In some platforms like Mac Catalina there seems to be some TLS related incompatibility between the hackney version  that we were using and the OS. That caused an error when accessing the admin at https://hubs.local:4000/?skipadmin:
```Missing file index.html. Please try again.```

Bumping the hackney version to 1.16.0 seems to fix that issues for Mac and WSL.