### PR TITLE
OpenID Connect Login

### DIFF
--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -299,6 +299,21 @@ realm = "{{ cfg.turn.realm }}"
 public_tls_ports = "{{ cfg.turn.public_tls_ports }}"
 {{/if}}
 
+{{#if cfg.oidc }}
+{{#with cfg.oidc }}
+[ret."Elixir.RetWeb.OIDCAuthChannel"]
+{{ toToml auth_endpoint }}
+{{ toToml token_endpoint }}
+{{ toToml scopes }}
+{{ toToml client_id }}
+{{ toToml client_secret }}
+
+[ret."Elixir.Ret.RemoteOIDCToken"]
+{{ toToml allowed_algos }}
+{{ toToml verification_secret_jwk_set }}
+{{/with}}
+{{/if}}
+
 [web_push_encryption.vapid_details]
 subject = "{{ cfg.web_push.subject }}"
 public_key = "{{ cfg.web_push.public_key }}"

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -302,15 +302,17 @@ public_tls_ports = "{{ cfg.turn.public_tls_ports }}"
 {{#if cfg.oidc }}
 {{#with cfg.oidc }}
 [ret."Elixir.RetWeb.OIDCAuthChannel"]
-{{ toToml auth_endpoint }}
-{{ toToml token_endpoint }}
-{{ toToml scopes }}
-{{ toToml client_id }}
-{{ toToml client_secret }}
+auth_endpoint = {{ toToml auth_endpoint }}
+token_endpoint = {{ toToml token_endpoint }}
+scopes = {{ toToml scopes }}
+client_id = {{ toToml client_id }}
+client_secret = {{ toToml client_secret }}
 
 [ret."Elixir.Ret.RemoteOIDCToken"]
-{{ toToml allowed_algos }}
-{{ toToml verification_secret_jwk_set }}
+allowed_algos = {{ toToml allowed_algos }}
+verification_secret_jwk_set = """
+{{ verification_secret_jwk_set }}
+"""
 {{/with}}
 {{/if}}
 

--- a/lib/ret/oauth_token.ex
+++ b/lib/ret/oauth_token.ex
@@ -36,6 +36,20 @@ defmodule Ret.OAuthToken do
 
     token
   end
+
+  def token_for_oidc_request(topic_key, session_id) do
+    {:ok, token, _claims} =
+      Ret.OAuthToken.encode_and_sign(
+        # OAuthTokens do not have a resource associated with them
+        nil,
+        %{topic_key: topic_key, session_id: session_id, aud: :ret_oidc},
+        allowed_algos: ["HS512"],
+        ttl: {10, :minutes},
+        allowed_drift: 60 * 1000
+      )
+
+    token
+  end
 end
 
 defmodule Ret.OAuthTokenSecretFetcher do

--- a/lib/ret/remote_oidc_token.ex
+++ b/lib/ret/remote_oidc_token.ex
@@ -22,8 +22,8 @@ defmodule Ret.RemoteOIDCTokenSecretsFetcher do
   end
 
   def fetch_verifying_secret(mod, %{"kid" => kid, "typ" => "JWT"}, _opts) do
-    # TODO implement read through cache that hits discovery endpoint instead of hardcoding keys in config
-    case Application.get_env(:ret, mod)[:verification_jwks]
+    # TODO implement read through cache that hits discovery endpoint instead of hardcoding keys in config as per https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys
+    case Application.get_env(:ret, mod)[:verification_secret_jwk_set]
          |> Poison.decode!()
          |> Map.get("keys")
          |> Enum.find(&(Map.get(&1, "kid") == kid)) do

--- a/lib/ret/remote_oidc_token.ex
+++ b/lib/ret/remote_oidc_token.ex
@@ -1,0 +1,25 @@
+defmodule Ret.RemoteOIDCToken do
+  @moduledoc """
+  This represents an OpenID Connect token returned from a remote service.
+  The public keys will be configured by an admin for a particular setup.
+  """
+  use Guardian,
+    otp_app: :ret,
+    secret_fetcher: Ret.RemoteOIDCTokenSecretsFetcher
+
+  def subject_for_token(_, _), do: {:ok, nil}
+  def resource_from_claims(_), do: {:ok, nil}
+end
+
+defmodule Ret.RemoteOIDCTokenSecretsFetcher do
+  def fetch_signing_secret(_mod, _opts) do
+    {:error, :not_implemented}
+  end
+
+  def fetch_verifying_secret(mod, token_headers, _opts) do
+    IO.inspect(token_headers)
+
+    # TODO use KID to look up the key. Do we want to bake it into the config at setup time? Fetch and cache? Should it be optional?
+    {:ok, Application.get_env(:ret, mod)[:verification_key] |> JOSE.JWK.from_pem()} |> IO.inspect()
+  end
+end

--- a/lib/ret_web/channels/oidc_auth_channel.ex
+++ b/lib/ret_web/channels/oidc_auth_channel.ex
@@ -101,7 +101,7 @@ defmodule RetWeb.OIDCAuthChannel do
       # {:error, error} ->
       #   {:reply, {:error, %{message: error}}, socket}
 
-      v ->
+      _ ->
         {:reply, {:error, %{message: "error fetching or verifying token"}}, socket}
     end
   end

--- a/lib/ret_web/channels/oidc_auth_channel.ex
+++ b/lib/ret_web/channels/oidc_auth_channel.ex
@@ -74,7 +74,7 @@ defmodule RetWeb.OIDCAuthChannel do
          when topic_key == expected_topic_key <- OAuthToken.decode_and_verify(state),
          {:ok,
           %{
-            "access_token" => access_token,
+            "access_token" => _access_token,
             "id_token" => raw_id_token
           }} <- fetch_oidc_tokens(code),
          {:ok,
@@ -113,6 +113,10 @@ defmodule RetWeb.OIDCAuthChannel do
     end
   end
 
+  def handle_in(_event, _payload, socket) do
+    {:noreply, socket}
+  end
+
   def fetch_oidc_tokens(oauth_code) do
     body =
       {:form,
@@ -140,10 +144,6 @@ defmodule RetWeb.OIDCAuthChannel do
   #   |> Poison.decode!()
   #   |> IO.inspect()
   # end
-
-  def handle_in(_event, _payload, socket) do
-    {:noreply, socket}
-  end
 
   def handle_info(:close_channel, socket) do
     GenServer.cast(self(), :close)

--- a/lib/ret_web/channels/oidc_auth_channel.ex
+++ b/lib/ret_web/channels/oidc_auth_channel.ex
@@ -31,7 +31,7 @@ defmodule RetWeb.OIDCAuthChannel do
         response_type: "code",
         response_mode: "query",
         client_id: module_config(:client_id),
-        scope: module_config(:scopes),
+        scope: "openid profile",
         state: state,
         nonce: nonce,
         redirect_uri: get_redirect_uri()
@@ -119,7 +119,7 @@ defmodule RetWeb.OIDCAuthChannel do
          grant_type: "authorization_code",
          redirect_uri: get_redirect_uri(),
          code: oauth_code,
-         scope: module_config(:scopes)
+         scope: "openid profile"
        ]}
 
     headers = [{"content-type", "application/x-www-form-urlencoded"}]

--- a/lib/ret_web/channels/oidc_auth_channel.ex
+++ b/lib/ret_web/channels/oidc_auth_channel.ex
@@ -1,0 +1,202 @@
+defmodule RetWeb.OIDCAuthChannel do
+  @moduledoc "Ret Web Channel for OIDC Authentication"
+
+  use RetWeb, :channel
+  import Canada, only: [can?: 2]
+
+  alias Ret.{Statix, Account, OAuthToken}
+
+  intercept(["auth_credentials"])
+
+  def join("oidc:" <> _topic_key, _payload, socket) do
+    # Expire channel in 5 minutes
+    Process.send_after(self(), :channel_expired, 60 * 1000 * 5)
+
+    # Rate limit joins to reduce attack surface
+    :timer.sleep(500)
+
+    Statix.increment("ret.channels.oidc.joins.ok")
+    {:ok, %{session_id: socket.assigns.session_id}, socket}
+  end
+
+  defp module_config(key) do
+    Application.get_env(:ret, __MODULE__)[key]
+  end
+
+  defp get_redirect_uri(), do: RetWeb.Endpoint.url() <> "/verify"
+
+  defp get_authorize_url(state, nonce) do
+    "#{module_config(:endpoint)}authorize?" <>
+      URI.encode_query(%{
+        response_type: "code",
+        response_mode: "query",
+        client_id: module_config(:client_id),
+        scope: module_config(:scopes),
+        state: state,
+        nonce: nonce,
+        redirect_uri: get_redirect_uri()
+      })
+  end
+
+  def handle_in("auth_request", _payload, socket) do
+    if Map.get(socket.assigns, :nonce) do
+      {:reply, {:error, "Already started an auth request on this session"}, socket}
+    else
+      "oidc:" <> topic_key = socket.topic
+      oidc_state = Ret.OAuthToken.token_for_oidc_request(topic_key, socket.assigns.session_id)
+      nonce = SecureRandom.uuid()
+      authorize_url = get_authorize_url(oidc_state, nonce)
+
+      socket = socket |> assign(:nonce, nonce)
+
+      IO.inspect("Started oauth flow with oidc_state #{oidc_state}, authorize_url: #{authorize_url}")
+      {:reply, {:ok, %{authorize_url: authorize_url}}, socket}
+    end
+  end
+
+  def handle_in("auth_verified", %{"token" => code, "payload" => state}, socket) do
+    Process.send_after(self(), :close_channel, 1000 * 5)
+
+    IO.inspect("Verify OIDC auth!!!!!")
+
+    # Slow down token guessing
+    :timer.sleep(500)
+
+    "oidc:" <> expected_topic_key = socket.topic
+
+    # TODO since we already have session_id secured by a token on the other end using a JWT for state may be overkill
+    case OAuthToken.decode_and_verify(state) do
+      {:ok,
+       %{
+         "topic_key" => topic_key,
+         "session_id" => session_id,
+         "aud" => "ret_oidc"
+       }}
+      when topic_key == expected_topic_key ->
+        %{
+          "access_token" => access_token,
+          "id_token" => raw_id_token
+        } = fetch_oidc_access_token(code)
+
+        # TODO lookup pubkey by kid in header
+        %JOSE.JWS{fields: %{"kid" => kid}} = JOSE.JWT.peek_protected(raw_id_token)
+        IO.inspect(kid)
+
+        pub_key = module_config(:verification_key) |> JOSE.JWK.from_pem()
+
+        case JOSE.JWT.verify_strict(pub_key, module_config(:allowed_algos), raw_id_token)
+             |> IO.inspect() do
+          {true,
+           %JOSE.JWT{
+             fields: %{
+               "aud" => _aud,
+               "nonce" => nonce,
+               "preferred_username" => remote_username,
+               "sub" => remote_user_id
+             }
+           }, _jws} ->
+            # TODO we may want to verify some more fields like issuer and expiration time
+
+            # %{"sub" => remote_user_id, "preferred_username" => remote_username} =
+            #   fetch_oidc_user_info(access_token) |> IO.inspect()
+
+            broadcast_credentials_and_payload(
+              remote_user_id,
+              %{email: remote_username},
+              %{session_id: session_id, nonce: nonce},
+              socket
+            )
+
+            {:reply, :ok, socket}
+
+          {false, _jwt, _jws} ->
+            {:reply, {:error, %{msg: "invalid OIDC token from endpoint"}}, socket}
+
+          {:error, _} ->
+            {:reply, {:error, %{msg: "error verifying token"}}, socket}
+        end
+
+      # TODO we may want to be less specific about errors
+      {:ok, _} ->
+        {:reply, {:error, %{msg: "Invalid topic key"}}, socket}
+
+      {:error, error} ->
+        {:reply, {:error, error}, socket}
+    end
+  end
+
+  def fetch_oidc_access_token(oauth_code) do
+    body = {
+      :form,
+      [
+        client_id: module_config(:client_id),
+        client_secret: module_config(:client_secret),
+        grant_type: "authorization_code",
+        redirect_uri: get_redirect_uri(),
+        code: oauth_code,
+        scope: module_config(:scopes)
+      ]
+    }
+
+    # todo handle error response
+    "#{module_config(:endpoint)}token"
+    |> Ret.HttpUtils.retry_post_until_success(body, [{"content-type", "application/x-www-form-urlencoded"}])
+    |> Map.get(:body)
+    |> Poison.decode!()
+  end
+
+  # def fetch_oidc_user_info(access_token) do
+  #   "#{module_config(:endpoint)}userinfo"
+  #   |> Ret.HttpUtils.retry_get_until_success([{"authorization", "Bearer #{access_token}"}])
+  #   |> Map.get(:body)
+  #   |> Poison.decode!()
+  #   |> IO.inspect()
+  # end
+
+  def handle_in(_event, _payload, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_info(:close_channel, socket) do
+    GenServer.cast(self(), :close)
+    {:noreply, socket}
+  end
+
+  def handle_info(:channel_expired, socket) do
+    GenServer.cast(self(), :close)
+    {:noreply, socket}
+  end
+
+  def handle_out(
+        "auth_credentials" = event,
+        %{credentials: credentials, user_info: user_info, verification_info: verification_info},
+        socket
+      ) do
+    Process.send_after(self(), :close_channel, 1000 * 5)
+    IO.inspect("checking creds")
+    IO.inspect(socket)
+    IO.inspect(verification_info)
+
+    if Map.get(socket.assigns, :session_id) == Map.get(verification_info, :session_id) and
+         Map.get(socket.assigns, :nonce) == Map.get(verification_info, :nonce) do
+      IO.inspect("sending creds")
+      push(socket, event, %{credentials: credentials, user_info: user_info})
+    end
+
+    {:noreply, socket}
+  end
+
+  defp broadcast_credentials_and_payload(nil, _user_info, _verification_info, _socket), do: nil
+
+  defp broadcast_credentials_and_payload(identifier_hash, user_info, verification_info, socket) do
+    account_creation_enabled = can?(nil, create_account())
+    account = identifier_hash |> Account.account_for_login_identifier_hash(account_creation_enabled)
+    credentials = account |> Account.credentials_for_account()
+
+    broadcast!(socket, "auth_credentials", %{
+      credentials: credentials,
+      user_info: user_info,
+      verification_info: verification_info
+    })
+  end
+end

--- a/lib/ret_web/channels/oidc_auth_channel.ex
+++ b/lib/ret_web/channels/oidc_auth_channel.ex
@@ -26,7 +26,7 @@ defmodule RetWeb.OIDCAuthChannel do
   defp get_redirect_uri(), do: RetWeb.Endpoint.url() <> "/verify"
 
   defp get_authorize_url(state, nonce) do
-    "#{module_config(:endpoint)}authorize?" <>
+    "#{module_config(:auth_endpoint)}?" <>
       URI.encode_query(%{
         response_type: "code",
         response_mode: "query",
@@ -121,14 +121,14 @@ defmodule RetWeb.OIDCAuthChannel do
 
     headers = [{"content-type", "application/x-www-form-urlencoded"}]
 
-    case Ret.HttpUtils.retry_post_until_success("#{module_config(:endpoint)}token", body, headers) do
+    case Ret.HttpUtils.retry_post_until_success("#{module_config(:token_endpoint)}", body, headers) do
       %HTTPoison.Response{body: body} -> body |> Poison.decode()
       _ -> {:error, "Failed to fetch tokens"}
     end
   end
 
   # def fetch_oidc_user_info(access_token) do
-  #   "#{module_config(:endpoint)}userinfo"
+  #   "#{module_config(:userinfo_endpoint)}"
   #   |> Ret.HttpUtils.retry_get_until_success([{"authorization", "Bearer #{access_token}"}])
   #   |> Map.get(:body)
   #   |> Poison.decode!()

--- a/lib/ret_web/channels/session_socket.ex
+++ b/lib/ret_web/channels/session_socket.ex
@@ -5,6 +5,7 @@ defmodule RetWeb.SessionSocket do
   channel("hub:*", RetWeb.HubChannel)
   channel("link:*", RetWeb.LinkChannel)
   channel("auth:*", RetWeb.AuthChannel)
+  channel("oidc:*", RetWeb.OIDCAuthChannel)
 
   def id(socket) do
     "session:#{socket.assigns.session_id}"


### PR DESCRIPTION
This implements the basic pieces needed for OpenID Connect login. With this and some client changes we should be able to roll out enough to at least test this as a login method on Hubs Cloud. Before rolling it out more widely we would likely need to figure out what we want to do around edge cases, like switching login providers when accounts exist, how to setup the initial admin account when using a third party provider. (this later part could also simplify the setup process for Hubs Cloud since it would get rid of the email sending requirement, but also probably means a CloudFormation template update).

Some of the layers of security here feel a bit redundant, but maybe that's ok. The session_id on a socket is already secured by a token, which guarantees the only socket getting a token back is the one that started the request, so encoding the state as a JWT is probably overkill, but we already had the mechanism in place, and it does provide an added layer including additional replay protection due to the short lived timestamp on the token. The nonce is part of the openid spec and confirms that the id token you get back is in fact for the same request that started it (since the id server will only accept this nonce once).

Currently we rely on the user manually keeping the public signing keys up to date on their instance. We eventually would want to read-through cache this.

Accompanying client PR: https://github.com/mozilla/hubs/pull/3331

If you like videos, and already understand OAuth pretty well, the last 10 minutes of this talk is a good quick primer on OpenID Connect (the rest of the talk is also a decent into to OAuth) https://youtu.be/996OiexHze0?t=2820