### PR TITLE
Add PosgreSQL config step for a local dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,8 @@ default_janus_csp_rule =
       do: "wss://#{default_janus_host}:#{janus_port} https://#{default_janus_host}:#{janus_port} https://#{default_janus_host}:#{janus_port}/meta",
       else: ""
 ```
+
+4. Update the PosgreSQL database connection string:
+```
+   psql-userdb="host=hubs.local dbname=ret_dev user=postgres password=postgres options='-c search_path=coturn' connect_timeout=30"
+```


### PR DESCRIPTION
Coturn needs the schema in the PSQL connection string to be able to connect to the `coturn` schema in the Reticulum database.