### PR TITLE
Add PosgreSQL config step for a local dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,8 @@ default_janus_csp_rule =
       do: "wss://#{default_janus_host}:#{janus_port} https://#{default_janus_host}:#{janus_port} https://#{default_janus_host}:#{janus_port}/meta",
       else: ""
 ```
+
+4. Edit the Dialog ocnfiguration file *turnserver.conf* and update the PosgreSQL database connection string to use the *coturn* schema from the Reticulum database:
+```
+   psql-userdb="host=hubs.local dbname=ret_dev user=postgres password=postgres options='-c search_path=coturn' connect_timeout=30"
+```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ default_janus_csp_rule =
       else: ""
 ```
 
-4. Edit the Dialog ocnfiguration file *turnserver.conf* and update the PosgreSQL database connection string to use the *coturn* schema from the Reticulum database:
+4. Edit the Dialog configuration file *turnserver.conf* and update the PostgreSQL database connection string to use the *coturn* schema from the Reticulum database:
 ```
    psql-userdb="host=hubs.local dbname=ret_dev user=postgres password=postgres options='-c search_path=coturn' connect_timeout=30"
 ```


### PR DESCRIPTION
The Coturn PSQL connection string needs to explicitly specify the `coturn` schema to be able to connect to the Reticulum DB.