### PR TITLE
Extend asset ttl

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -22,6 +22,7 @@ defmodule Ret.MediaResolver do
   @sketchfab_rate_limit %{scale: 60_000, limit: 15}
   @poly_rate_limit %{scale: 60_000, limit: 1000}
   @max_await_for_rate_limit_s 120
+  @sketchfab_ttl_ms 1000 * 60 * 60 * 24 * 31
 
   @non_video_root_hosts [
     "sketchfab.com",
@@ -454,7 +455,7 @@ defmodule Ret.MediaResolver do
         _err -> [uri, nil]
       end
 
-    {:commit, uri |> resolved(meta)}
+    {:commit, resolved(uri, meta) |> Map.put(:ttl, @sketchfab_ttl_ms)}
   end
 
   defp resolve_sketchfab_model(model_id, api_key, version \\ 1) do

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -467,7 +467,7 @@ defmodule Ret.MediaResolver do
 
           res =
             "https://api.sketchfab.com/v3/models/#{model_id}/download"
-            |> retry_get_until_success([{"Authorization", "Token #{api_key}"}])
+            |> retry_get_until_success([{"Authorization", "Token #{api_key}"}], 15_000, 15_000)
 
           case res do
             :error ->

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -347,7 +347,7 @@ defmodule Ret.MediaSearch do
     with api_key when is_binary(api_key) <- resolver_config(:sketchfab_api_key) do
       res =
         "https://api.sketchfab.com/v3/search?#{query}"
-        |> retry_get_until_success([{"Authorization", "Token #{api_key}"}])
+        |> retry_get_until_success([{"Authorization", "Token #{api_key}"}], 15_000, 15_000)
 
       case res do
         :error ->


### PR DESCRIPTION
We suspect we are repeatedly downloading the same assets over and over again. This change caches the files as long as someone is still using them. We will measure the impact in this change in grafana:

![image](https://user-images.githubusercontent.com/4072106/109577595-b5ea6b00-7aaa-11eb-877e-c4122ba1fd23.png)

