### PR TITLE
Increase CachedFile timeout

### DIFF
--- a/lib/ret/cached_file.ex
+++ b/lib/ret/cached_file.ex
@@ -77,9 +77,9 @@ defmodule Ret.CachedFile do
   def vacuum do
     Ret.Locking.exec_if_lockable(:cached_file_vacuum, fn ->
       # Underlying files will be removed by storage vacuum
-      one_day_ago = Timex.now() |> Timex.shift(days: -1)
+      two_days_ago = Timex.now() |> Timex.shift(days: -2)
 
-      from(f in CachedFile, where: f.inserted_at() < ^one_day_ago)
+      from(f in CachedFile, where: f.inserted_at() < ^two_days_ago)
       |> Repo.delete_all()
     end)
   end


### PR DESCRIPTION
We suspect we may be repeatedly downloading the same assets over and over again as their `CachedFile` records expire. This change extends the lifetime of these records to two days instead of one. We will measure the impact in this change in grafana. This will allow us to (roughly) estimate how many new source URLs are introduced each day and how many are re-requested:
![image](https://user-images.githubusercontent.com/4072106/110344118-0c433680-7fe2-11eb-8b17-dcd209d6a7ca.png)

More work is being done to allow the lifetime of `CachedFiles` to be extended until they are no longer used. This change is meant as a quick diagnostic that will be useful in the meantime. 
