### PR TITLE
Remove processing_status from sketchfab API query

### DIFF
--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -86,7 +86,7 @@ defmodule Ret.MediaSearch do
         count: @page_size,
         max_face_count: @max_face_count,
         max_filesizes: "gltf:#{@max_file_size_bytes}",
-        processing_status: :succeeded,
+        # processing_status: :succeeded, # Sketchfab API seems to have a bug that rejects processing_status
         cursor: cursor,
         q: q
       )
@@ -103,7 +103,7 @@ defmodule Ret.MediaSearch do
         count: @page_size,
         max_face_count: @max_face_count,
         max_filesizes: "gltf:#{@max_file_size_bytes}",
-        processing_status: :succeeded,
+        # processing_status: :succeeded,  # Sketchfab API seems to have a bug that rejects processing_status
         sort_by:
           if q == nil || q == "" do
             "-publishedAt"


### PR DESCRIPTION
It appears that the Sketchfab API introduced a bug where `processing_status` is no longer accepted. 

Details TBD, but this workaround at least gets most sketchfab searches working again.

More info here: https://discord.com/channels/691604175322087474/700374866720981093/820007295659409429