### PR TITLE
Reduce log spam

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -75,6 +75,9 @@ config :logger, :console, format: "[$level] $message\n"
 # in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20
 
+# Disable phoenix logging
+config :phoenix, :logger, false
+
 env_db_host = "#{System.get_env("DB_HOST")}"
 
 # Configure your database
@@ -84,7 +87,8 @@ config :ret, Ret.Repo,
   database: "ret_dev",
   hostname: if(env_db_host == "", do: "localhost", else: env_db_host),
   template: "template0",
-  pool_size: 10
+  pool_size: 10,
+  log: false
 
 config :ret, Ret.SessionLockRepo,
   username: "postgres",

--- a/lib/ret_web.ex
+++ b/lib/ret_web.ex
@@ -55,7 +55,7 @@ defmodule RetWeb do
 
   def channel do
     quote do
-      use Phoenix.Channel
+      use Phoenix.Channel, log_join: false, log_handle_in: false
       import RetWeb.Gettext
     end
   end

--- a/lib/ret_web/endpoint.ex
+++ b/lib/ret_web/endpoint.ex
@@ -3,7 +3,7 @@ defmodule RetWeb.Endpoint do
   use Sentry.Phoenix.Endpoint
   use Absinthe.Phoenix.Endpoint
 
-  socket("/socket", RetWeb.SessionSocket, websocket: [check_origin: {RetWeb.Endpoint, :allowed_origin?, []}])
+  socket("/socket", RetWeb.SessionSocket, websocket: [log: false, check_origin: {RetWeb.Endpoint, :allowed_origin?, []}])
 
   def get_cors_origins, do: Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")
   def get_cors_origin_urls, do: get_cors_origins() |> Enum.filter(&(&1 != "*")) |> Enum.map(&URI.parse/1)
@@ -25,7 +25,7 @@ defmodule RetWeb.Endpoint do
   end
 
   plug(Plug.RequestId)
-  plug(Plug.Logger)
+  # plug(Plug.Logger)
 
   plug(Plug.MethodOverride)
 


### PR DESCRIPTION
It is difficult to do println debugging in development when so much logging is enabled. This PR disables a bunch of stuff that writes to the console during an iex session. There may be a smarter way to do this. I didn't think these logs were particularly important for debugging problems in production but if they are I'll look for alternative solutions. 