### PR TITLE
Add support for setting themes as a json string in app_configs.

### DIFF
--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -458,7 +458,7 @@ defmodule RetWeb.PageController do
         Map.put(config, "themes", themes_map)
 
       _ ->
-        config = Map.put(config, "themes", "[]")
+        config = Map.put(config, "themes", [])
         Map.put(config, "themes_failed_to_load", true)
     end
   end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -486,7 +486,7 @@ defmodule RetWeb.PageController do
 
       _ ->
         category = Map.put(category, "themes", [])
-        category = Map.put(category, "failed_to_load", true)
+        category = Map.put(category, "error", "Failed to parse custom theme JSON.")
         Map.put(config, "theme", category)
     end
   end

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -469,10 +469,9 @@ defmodule RetWeb.PageController do
   # The themes array must be decoded from a string and re-encoded
   # so that it can be successfully parsed by the client.
   defp escape_themes(%{"theme" => %{"themes" => string} = category} = config) do
-    case Poison.decode(string) do
-      {:ok, array} ->
-        Map.put(config, "theme", Map.put(category, "themes", array))
-
+    try do
+      Map.put(config, "theme", Map.put(category, "themes", Poison.decode!(string)))
+    rescue
       _ ->
         category = Map.put(category, "themes", [])
         category = Map.put(category, "failed_to_load", true)

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -470,8 +470,8 @@ defmodule RetWeb.PageController do
   # so that it can be successfully parsed by the client.
   defp escape_themes(%{"theme" => %{"themes" => string} = category} = config) do
     case Poison.decode(string) do
-      {:ok, map} ->
-        Map.put(config, "theme", Map.put(category, "themes", map))
+      {:ok, array} ->
+        Map.put(config, "theme", Map.put(category, "themes", array))
 
       _ ->
         category = Map.put(category, "themes", [])

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -452,8 +452,23 @@ defmodule RetWeb.PageController do
     Ret.AppConfig.get_config(!!module_config(:skip_cache)) |> generate_config("APP_CONFIG")
   end
 
+  defp escape_themes(%{"themes" => themes_string} = config) do
+    case Poison.decode(themes_string) do
+      {:ok, themes_map} ->
+        Map.put(config, "themes", themes_map)
+
+      _ ->
+        config = Map.put(config, "themes", "[]")
+        Map.put(config, "themes_failed_to_load", true)
+    end
+  end
+
+  defp escape_themes(config) do
+    config
+  end
+
   defp generate_config(config, name) do
-    config_json = config |> Poison.encode!()
+    config_json = config |> escape_themes() |> Poison.encode!()
     config_script = "window.#{name} = JSON.parse('#{config_json |> String.replace("'", "\\'")}')"
     {config, config_script}
   end


### PR DESCRIPTION
The simplest way to support custom themes for the new UI was to allow users to paste a JSON blob describing an array of themes into the admin panel. In order for this to be parsed correctly by the client, we need to parse the JSON blob into an elixir map in the backend, then re-encode it into the json blob sent to the client.

Client changes are in this PR https://github.com/mozilla/hubs/pull/4109 

The shortcoming of this approach is that it does not do this for all future json configs. I was not sure how to achieve that. Instead, it looks specifically for themes. In order to add more json parameters to the admin panel, we will need to update this code.

