### PR TITLE
Add database indexes for the session_stats tables

### DIFF
--- a/priv/repo/migrations/20210416191647_add_session_stats_index.exs
+++ b/priv/repo/migrations/20210416191647_add_session_stats_index.exs
@@ -1,0 +1,22 @@
+defmodule Ret.Repo.Migrations.AddSessionStatsIndex do
+  use Ecto.Migration
+
+  @max_year 2030
+
+  def up do
+    for year <- 2018..@max_year,
+        month <- 0..11 do
+      execute("
+        create index session_stats_y#{year}_m#{month + 1}_session_id 
+          on ret0.session_stats_y#{year}_m#{month + 1} (session_id)
+      ")
+    end
+  end
+
+  def down do
+    for year <- 2018..@max_year,
+        month <- 0..11 do
+      execute("drop index session_stats_y#{year}_m#{month + 1}_session_id")
+    end
+  end
+end


### PR DESCRIPTION
The session_stats table appears to be one of the main bottlenecks for server performance due to the large number of sessions we now handle. The table was created with this in mind, where we partitioned the table in to monthly date ranges, however even this partitioning is not sufficient to mitigate the performance impact it has. This impact is particularly prevalent when we experience a flood of activity, such as when the Hubs Discord Bot needs to reestablish connections for all its bridged rooms.

The majority of the work behind this PR went into testing the performance characteristics of this table. I did so using a number of utility functions to populate a large number of records and test the performance various operations with and without the index. Importantly, while the index does have an impact on the upper limit of performance, it significantly speeds up update and query operations by about 10x, going from ~5.5 instructions per second (ips) for row updates on a fully loaded partition vs 56 ips on an indexed partition. This is compared to 77 ips on an empty, un-indexed partition.

The utility functions I used are in this gist. They were implemented as mix tasks, which can be run with `mix session_stats` followed by one of the commands implemented in the gist. Some of the functions use the [Benchee library](https://github.com/bencheeorg/benchee) to benchmark the performance of those operations. https://gist.github.com/brianpeiris/e2bd4935497ddf60393a8549d17a0402