### PR TITLE
Properly handle join attempt to non-existent hubs

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -66,7 +66,12 @@ defmodule RetWeb.HubChannel do
         _ -> nil
       end
 
-    hub_requires_oauth = hub.hub_bindings |> Enum.empty?() |> Kernel.not()
+    hub_requires_oauth =
+      case hub do
+        nil -> false
+        _ -> hub.hub_bindings |> Enum.empty?() |> Kernel.not()
+      end
+
     bot_access_key = Application.get_env(:ret, :bot_access_key)
     has_valid_bot_access_key = !!(bot_access_key && params["bot_access_key"] == bot_access_key)
 
@@ -903,7 +908,7 @@ defmodule RetWeb.HubChannel do
   defp join_with_hub(nil, _account, _socket, _context, _params) do
     Statix.increment("ret.channels.hub.joins.not_found")
 
-    {:error, %{message: "No such Hub"}}
+    {:error, %{message: "No such Hub", reason: "not_found"}}
   end
 
   defp join_with_hub(%Hub{entry_mode: :deny}, _account, _socket, _context, _params) do

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -59,6 +59,11 @@ defmodule RetWeb.HubChannel do
     )
   end
 
+  defp perform_join(_socket, nil, _context, _params) do
+    Statix.increment("ret.channels.hub.joins.not_found")
+    {:error, %{message: "No such Hub", reason: "not_found"}}
+  end
+
   defp perform_join(socket, hub, context, params) do
     account =
       case Ret.Guardian.resource_from_token(params["auth_token"]) do
@@ -66,11 +71,7 @@ defmodule RetWeb.HubChannel do
         _ -> nil
       end
 
-    hub_requires_oauth =
-      case hub do
-        nil -> false
-        _ -> hub.hub_bindings |> Enum.empty?() |> Kernel.not()
-      end
+    hub_requires_oauth = hub.hub_bindings |> Enum.empty?() |> Kernel.not()
 
     bot_access_key = Application.get_env(:ret, :bot_access_key)
     has_valid_bot_access_key = !!(bot_access_key && params["bot_access_key"] == bot_access_key)
@@ -903,12 +904,6 @@ defmodule RetWeb.HubChannel do
       })
 
     assigns |> Map.put(:profile, overriden)
-  end
-
-  defp join_with_hub(nil, _account, _socket, _context, _params) do
-    Statix.increment("ret.channels.hub.joins.not_found")
-
-    {:error, %{message: "No such Hub", reason: "not_found"}}
   end
 
   defp join_with_hub(%Hub{entry_mode: :deny}, _account, _socket, _context, _params) do


### PR DESCRIPTION
This was particularly a problem with the Discord Bot, where it was attempting to connect to hub channels with hub ids that were either entered incorrectly by the user, or for hubs that had subsequently been deleted from the database. Previously we would error out trying to access `hubs_bindings` of `nil`. This PR changes accounts for a `nil` hub and allows the code to fall through to the corresponding `join_with_hub` overload.
The Discord Bot will look for the `"not_found"` reason and stop attempting to reconnect to this missing hub id with the changes in https://github.com/MozillaReality/hubs-discord-bot/pull/117