### PR TITLE
Add amplify_audio permission

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -878,6 +878,7 @@ defmodule Ret.Hub do
       embed_hub: account |> can?(embed_hub(hub)),
       kick_users: account |> can?(kick_users(hub)),
       mute_users: account |> can?(mute_users(hub)),
+      amplify_audio: account |> can?(amplify_audio(hub)),
       spawn_camera: account |> can?(spawn_camera(hub)),
       spawn_drawing: account |> can?(spawn_drawing(hub)),
       spawn_and_move_media: account |> can?(spawn_and_move_media(hub)),
@@ -927,7 +928,7 @@ defimpl Canada.Can, for: Ret.Account do
     false
   end
 
-  @owner_actions [:update_hub, :close_hub, :embed_hub, :kick_users, :mute_users]
+  @owner_actions [:update_hub, :close_hub, :embed_hub, :kick_users, :mute_users, :amplify_audio]
   @object_actions [:spawn_and_move_media, :spawn_camera, :spawn_drawing, :pin_objects, :spawn_emoji, :fly]
   @creator_actions [:update_roles]
 
@@ -956,7 +957,7 @@ defimpl Canada.Can, for: Ret.Account do
 
   # Bound hubs - Moderator actions
   def can?(%Ret.Account{} = account, action, %Ret.Hub{hub_bindings: hub_bindings})
-      when hub_bindings |> length > 0 and action in [:kick_users, :mute_users] do
+      when hub_bindings |> length > 0 and action in [:kick_users, :mute_users, :amplify_audio] do
     hub_bindings |> Enum.any?(&(account |> Ret.HubBinding.can_moderate_users?(&1)))
   end
 
@@ -1025,7 +1026,7 @@ defimpl Canada.Can, for: Ret.OAuthProvider do
   alias Ret.{AppConfig, Hub}
 
   @object_actions [:spawn_and_move_media, :spawn_camera, :spawn_drawing, :pin_objects, :spawn_emoji, :fly]
-  @special_actions [:update_hub, :update_roles, :close_hub, :embed_hub, :kick_users, :mute_users]
+  @special_actions [:update_hub, :update_roles, :close_hub, :embed_hub, :kick_users, :mute_users, :amplify_audio]
 
   # Always deny access to non-enterable hubs
   def can?(%Ret.OAuthProvider{}, :join_hub, %Ret.Hub{entry_mode: :deny}), do: false

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -28,7 +28,7 @@ defmodule Ret.HubTest do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
     hub = hub |> Repo.preload([:hub_bindings, :hub_role_memberships])
 
-    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false} =
+    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false, amplify_audio: false} =
       hub |> Hub.perms_for_account(Ret.Account.account_for_email("non-creator@mozilla.com"))
   end
 
@@ -36,7 +36,8 @@ defmodule Ret.HubTest do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
     hub = hub |> Repo.preload([:hub_bindings])
 
-    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false} = hub |> Hub.perms_for_account(nil)
+    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false, amplify_audio: false} =
+      hub |> Hub.perms_for_account(nil)
   end
 
   test "should deny entry for closed hub, allow entry for re-opened hub", %{scene: scene} do
@@ -63,7 +64,8 @@ defmodule Ret.HubTest do
 
     hub = hub |> Repo.preload([:hub_bindings, :hub_role_memberships])
 
-    %{join_hub: true, update_hub: true, close_hub: true, mute_users: true} = hub |> Hub.perms_for_account(account)
+    %{join_hub: true, update_hub: true, close_hub: true, mute_users: true, amplify_audio: true} =
+      hub |> Hub.perms_for_account(account)
   end
 
   test "should have creator assignment token if no account assigned", %{scene: scene} do


### PR DESCRIPTION
This is for usage with "zone audio source" components and any other "presenter" audio features we might add. Still not sure about the name. Originally had `broadcast_audio` but that seems like it might be confused with sending any audio at all. Also considered `present_audio` but that also felt a bit weird.. so I landed on `amplify_audio`. Open to suggestions.

For starters just mirroring the same permission model as `mute_user`. Creators and owners are allowed to do it in unbound rooms, and in bound rooms its tied to `HubBinding.can_moderate_users` which is slightly weird, but we don't really have finer granularity right now.

Don't have an easy way to test room binding locally so I will just test that part in staging. Since I am using the same exact semantics as `mute_user` I think it should work fine.

This is all quite easy to tweak in the future.