### PR TITLE
Let clients tell the ret channel they changed hub

### DIFF
--- a/lib/ret_web/channels/ret_channel.ex
+++ b/lib/ret_web/channels/ret_channel.ex
@@ -24,6 +24,11 @@ defmodule RetWeb.RetChannel do
     socket |> handle_join(hub_id)
   end
 
+  def handle_in("change_hub", %{"hub_id" => hub_id}, socket) do
+    {:ok, _} = Presence.update(socket, socket.assigns.session_id, %{hub_id: hub_id})
+    {:noreply, socket}
+  end
+
   def handle_in("refresh_perms_token", _params, socket) do
     account = Guardian.Phoenix.Socket.current_resource(socket)
 


### PR DESCRIPTION
This PR adds a `"change_hub"` event handler to the `"ret"` channel, which we use in https://github.com/mozilla/hubs/pull/4347/commits/6f0506fdcd29a655bbbc98cd76e66ae276cb2dcb (https://github.com/mozilla/hubs/pull/4347)