### PR TITLE
Removed max_filesizes query param due to sketchfab bug

### DIFF
--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -90,6 +90,7 @@ defmodule Ret.MediaSearch do
         cursor: cursor,
         q: q
       )
+
     sketchfab_search(query)
   end
 

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -28,7 +28,7 @@ defmodule Ret.MediaSearch do
   @scene_page_size 23
   @max_face_count 60000
   @max_collection_face_count 200_000
-  @max_file_size_bytes 20 * 1024 * 1024
+  # @max_file_size_bytes 20 * 1024 * 1024 # see sketchfab bug about max_filesizes params broken
   @max_collection_file_size_bytes 100 * 1024 * 1024
 
   def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: "featured", q: query}) do
@@ -103,7 +103,7 @@ defmodule Ret.MediaSearch do
         count: @page_size,
         max_face_count: @max_face_count,
         # max_filesizes: "gltf:#{@max_file_size_bytes}",
-        # processing_status: :succeeded,  # Sketchfab API seems to have a bug that rejects processing_status
+        # processing_status: :succeeded, # Sketchfab API seems to have a bug that rejects processing_status
         sort_by:
           if q == nil || q == "" do
             "-publishedAt"

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -28,8 +28,9 @@ defmodule Ret.MediaSearch do
   @scene_page_size 23
   @max_face_count 60000
   @max_collection_face_count 200_000
-  # @max_file_size_bytes 20 * 1024 * 1024 # see sketchfab bug about max_filesizes params broken
-  @max_collection_file_size_bytes 100 * 1024 * 1024
+  # see sketchfab bug about max_filesizes params broken
+  # @max_file_size_bytes 20 * 1024 * 1024 
+  # @max_collection_file_size_bytes 100 * 1024 * 1024
 
   def search(%Ret.MediaSearchQuery{source: "scene_listings", cursor: cursor, filter: "featured", q: query}) do
     scene_listing_search(cursor, query, "featured", asc: :order)
@@ -90,7 +91,6 @@ defmodule Ret.MediaSearch do
         cursor: cursor,
         q: q
       )
-
     sketchfab_search(query)
   end
 

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -91,6 +91,7 @@ defmodule Ret.MediaSearch do
         cursor: cursor,
         q: q
       )
+
     sketchfab_search(query)
   end
 

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -85,12 +85,11 @@ defmodule Ret.MediaSearch do
         downloadable: true,
         count: @page_size,
         max_face_count: @max_face_count,
-        max_filesizes: "gltf:#{@max_file_size_bytes}",
+        # max_filesizes: "gltf:#{@max_file_size_bytes}", # Sketchfab API has bug that disregards selected category if query has max_filesizes defined. Issue: https://forum.sketchfab.com/t/bug-model-search-api-using-max-filesizes-causes-query-to-ignore-categories/40247
         # processing_status: :succeeded, # Sketchfab API seems to have a bug that rejects processing_status
         cursor: cursor,
         q: q
       )
-
     sketchfab_search(query)
   end
 
@@ -102,7 +101,7 @@ defmodule Ret.MediaSearch do
         staffpicked: true,
         count: @page_size,
         max_face_count: @max_face_count,
-        max_filesizes: "gltf:#{@max_file_size_bytes}",
+        # max_filesizes: "gltf:#{@max_file_size_bytes}",
         # processing_status: :succeeded,  # Sketchfab API seems to have a bug that rejects processing_status
         sort_by:
           if q == nil || q == "" do
@@ -124,7 +123,7 @@ defmodule Ret.MediaSearch do
         downloadable: true,
         count: @page_size,
         max_face_count: @max_collection_face_count,
-        max_filesizes: "gltf:#{@max_collection_file_size_bytes}",
+        # max_filesizes: "gltf:#{@max_collection_file_size_bytes}",
         processing_status: :succeeded,
         sort_by:
           if q == nil || q == "" do
@@ -155,7 +154,7 @@ defmodule Ret.MediaSearch do
           downloadable: true,
           count: @page_size,
           max_face_count: @max_face_count,
-          max_filesizes: "gltf:#{@max_file_size_bytes}",
+          # max_filesizes: "gltf:#{@max_file_size_bytes}", 
           processing_status: :succeeded,
           cursor: cursor,
           categories: filter,


### PR DESCRIPTION
Sketchfab Issue opened: https://forum.sketchfab.com/t/bug-model-search-api-using-max-filesizes-causes-query-to-ignore-categories/40247