### PR TITLE
Fix Discord integration

### DIFF
--- a/lib/ret/discord_client.ex
+++ b/lib/ret/discord_client.ex
@@ -31,7 +31,7 @@ defmodule Ret.DiscordClient do
     }
 
     "#{@discord_api_base}/oauth2/token"
-    |> Ret.HttpUtils.retry_post_until_success(body, [{"content-type", "application/x-www-form-urlencoded"}])
+    |> Ret.HttpUtils.retry_post_until_success(body, headers: [{"content-type", "application/x-www-form-urlencoded"}])
     |> Map.get(:body)
     |> Poison.decode!()
     |> Map.get("access_token")
@@ -39,7 +39,7 @@ defmodule Ret.DiscordClient do
 
   def fetch_user_info(access_token) do
     "#{@discord_api_base}/users/@me"
-    |> Ret.HttpUtils.retry_get_until_success([{"authorization", "Bearer #{access_token}"}])
+    |> Ret.HttpUtils.retry_get_until_success(headers: [{"authorization", "Bearer #{access_token}"}])
     |> Map.get(:body)
     |> Poison.decode!()
   end
@@ -84,7 +84,7 @@ defmodule Ret.DiscordClient do
 
   def api_request(path) do
     "#{@discord_api_base}#{path}"
-    |> Ret.HttpUtils.retry_get_until_success([{"authorization", "Bot #{module_config(:bot_token)}"}])
+    |> Ret.HttpUtils.retry_get_until_success(headers: [{"authorization", "Bot #{module_config(:bot_token)}"}])
     |> Map.get(:body)
     |> Poison.decode!()
   end

--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -2,16 +2,16 @@ defmodule Ret.HttpUtils do
   use Retry
 
   def retry_head_until_success(url, options \\ []),
-    do: retry_until_success(:head, url, options)
+    do: retry_until_success(:head, url, "", options)
 
   def retry_get_until_success(url, options \\ []),
-    do: retry_until_success(:get, url, options)
+    do: retry_until_success(:get, url, "", options)
 
   def retry_post_until_success(url, body, options \\ []),
-    do: retry_until_success(:post, url, Keyword.merge(options, body: body))
+    do: retry_until_success(:post, url, body, options)
 
   def retry_put_until_success(url, body, options \\ []),
-    do: retry_until_success(:put, url, Keyword.merge(options, body: body))
+    do: retry_until_success(:put, url, body, options)
 
   def retry_head_then_get_until_success(url, options \\ []) do
     case url |> retry_head_until_success(options) do
@@ -23,9 +23,8 @@ defmodule Ret.HttpUtils do
     end
   end
 
-  defp retry_until_success(verb, url, options) do
+  defp retry_until_success(verb, url, body, options) do
     default_options = [
-      body: "",
       headers: [],
       cap_ms: 5_000,
       expiry_ms: 10_000,
@@ -50,7 +49,7 @@ defmodule Ret.HttpUtils do
       end
 
     retry with: exponential_backoff() |> randomize |> cap(options[:cap_ms]) |> expiry(options[:expiry_ms]) do
-      case HTTPoison.request(verb, url, options[:body], headers,
+      case HTTPoison.request(verb, url, body, headers,
              follow_redirect: true,
              timeout: options[:cap_ms],
              recv_timeout: options[:cap_ms],

--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -28,13 +28,13 @@ defmodule Ret.HttpUtils do
       headers: [],
       cap_ms: 5_000,
       expiry_ms: 10_000,
-      append_browser_ua: false
+      append_browser_user_agent: false
     ]
 
     options = Keyword.merge(default_options, options)
 
     headers =
-      if options[:append_browser_ua] do
+      if options[:append_browser_user_agent] do
         options[:headers] ++
           [{"User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0"}]
       else

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -319,7 +319,7 @@ defmodule Ret.MediaResolver do
 
     case uri
          |> URI.to_string()
-         |> retry_head_then_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_ua: true) do
+         |> retry_head_then_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_user_agent: true) do
       :error ->
         :error
 
@@ -376,7 +376,7 @@ defmodule Ret.MediaResolver do
   defp opengraph_result_for_uri(uri) do
     case uri
          |> URI.to_string()
-         |> retry_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_ua: true) do
+         |> retry_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_user_agent: true) do
       :error ->
         :error
 

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -317,7 +317,9 @@ defmodule Ret.MediaResolver do
     # Crawl og tags for hubs rooms + scenes
     is_local_url = host === RetWeb.Endpoint.host()
 
-    case uri |> URI.to_string() |> retry_head_then_get_until_success([{"Range", "bytes=0-32768"}]) do
+    case uri
+         |> URI.to_string()
+         |> retry_head_then_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_ua: true) do
       :error ->
         :error
 
@@ -372,7 +374,9 @@ defmodule Ret.MediaResolver do
   end
 
   defp opengraph_result_for_uri(uri) do
-    case uri |> URI.to_string() |> retry_get_until_success([{"Range", "bytes=0-32768"}]) do
+    case uri
+         |> URI.to_string()
+         |> retry_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_ua: true) do
       :error ->
         :error
 
@@ -414,7 +418,7 @@ defmodule Ret.MediaResolver do
 
   defp get_sketchfab_model_zip_url(%{model_id: model_id, api_key: api_key}) do
     case "https://api.sketchfab.com/v3/models/#{model_id}/download"
-         |> retry_get_until_success([{"Authorization", "Token #{api_key}"}], 15_000, 15_000) do
+         |> retry_get_until_success(headers: [{"Authorization", "Token #{api_key}"}], cap_ms: 15_000, expiry_ms: 15_000) do
       :error ->
         {:error, "Failed to get sketchfab metadata"}
 
@@ -493,7 +497,7 @@ defmodule Ret.MediaResolver do
     with headers when is_list(headers) <- get_imgur_headers() do
       image_data =
         imgur_api_url
-        |> retry_get_until_success(headers)
+        |> retry_get_until_success(headers: headers)
         |> Map.get(:body)
         |> Poison.decode!()
         |> Kernel.get_in(["data", "images"])

--- a/lib/ret/media_search.ex
+++ b/lib/ret/media_search.ex
@@ -272,7 +272,8 @@ defmodule Ret.MediaSearch do
           offset: cursor || 0
         )
 
-      res = "https://api.twitch.tv/helix/streams?#{query}" |> retry_get_until_success([{"Client-ID", client_id}])
+      res =
+        "https://api.twitch.tv/helix/streams?#{query}" |> retry_get_until_success(headers: [{"Client-ID", client_id}])
 
       case res do
         :error ->
@@ -308,9 +309,9 @@ defmodule Ret.MediaSearch do
       res =
         retry_get_until_success(
           "https://api.sketchfab.com/v3/search?#{query}",
-          [{"Authorization", "Token #{api_key}"}],
-          15_000,
-          15_000
+          headers: [{"Authorization", "Token #{api_key}"}],
+          cap_ms: 15_000,
+          expiry_ms: 15_000
         )
 
       case res do
@@ -343,7 +344,7 @@ defmodule Ret.MediaSearch do
 
       res =
         "https://westus.api.cognitive.microsoft.com/bing/v7.0/videos/trending?#{query}"
-        |> retry_get_until_success([{"Ocp-Apim-Subscription-Key", api_key}])
+        |> retry_get_until_success(headers: [{"Ocp-Apim-Subscription-Key", api_key}])
 
       case res do
         :error ->
@@ -390,7 +391,7 @@ defmodule Ret.MediaSearch do
 
       res =
         "https://westus.api.cognitive.microsoft.com/bing/v7.0/#{type}/search?#{query}"
-        |> retry_get_until_success([{"Ocp-Apim-Subscription-Key", api_key}])
+        |> retry_get_until_success(headers: [{"Ocp-Apim-Subscription-Key", api_key}])
 
       case res do
         :error ->

--- a/lib/ret/slack_client.ex
+++ b/lib/ret/slack_client.ex
@@ -27,7 +27,7 @@ defmodule Ret.SlackClient do
 
     %{"authed_user" => authed_user} =
       "#{@slack_api_base}/api/oauth.v2.access"
-      |> Ret.HttpUtils.retry_post_until_success(body, [{"content-type", "application/x-www-form-urlencoded"}])
+      |> Ret.HttpUtils.retry_post_until_success(body, headers: [{"content-type", "application/x-www-form-urlencoded"}])
       |> Map.get(:body)
       |> Poison.decode!()
 
@@ -114,7 +114,7 @@ defmodule Ret.SlackClient do
 
   def api_request(path) do
     "#{@slack_api_base}#{path}"
-    |> Ret.HttpUtils.retry_get_until_success([{"authorization", "Bearer #{module_config(:bot_token)}"}])
+    |> Ret.HttpUtils.retry_get_until_success(headers: [{"authorization", "Bearer #{module_config(:bot_token)}"}])
     |> Map.get(:body)
     |> Poison.decode!()
   end

--- a/lib/ret/speelycaptor.ex
+++ b/lib/ret/speelycaptor.ex
@@ -21,7 +21,7 @@ defmodule Ret.Speelycaptor do
   def convert(_path, _content_type), do: nil
 
   defp upload_and_convert_mp4(endpoint, upload_url, path, key) do
-    case retry_put_until_success(upload_url, {:file, path}, [], 30_000, 120_000) do
+    case retry_put_until_success(upload_url, {:file, path}, cap_ms: 30_000, expiry_ms: 120_000) do
       %HTTPoison.Response{} ->
         query = %{
           key: key,
@@ -30,9 +30,8 @@ defmodule Ret.Speelycaptor do
 
         case retry_get_until_success(
                "#{endpoint}/convert?#{URI.encode_query(query)}",
-               [],
-               30_000,
-               120_000
+               cap_ms: 30_000,
+               expiry_ms: 120_000
              ) do
           %HTTPoison.Response{body: body} ->
             url = body |> Poison.decode!() |> Map.get("url")

--- a/lib/ret/twitter_client.ex
+++ b/lib/ret/twitter_client.ex
@@ -133,9 +133,9 @@ defmodule Ret.TwitterClient do
       retry_post_until_success(
         url,
         encoded_params,
-        [{"content-type", "application/x-www-form-urlencoded"}],
-        cap_ms,
-        expiry_ms
+        headers: [{"content-type", "application/x-www-form-urlencoded"}],
+        cap_ms: cap_ms,
+        expiry_ms: expiry_ms
       )
       |> Map.get(:body)
       |> to_string


### PR DESCRIPTION
In #452 we added a browser user-agent header to all requests made through all the functions in our HttpUtils module. That change is now breaking Discord integration, since it seems Discord now rejects API requests that include a user-agent header.

This PR removes the user-agent header from all requests by default, unless it is enabled with the new `append_browser_ua` parameter. Incidentally, the functions in HttpUtils have also been changed to use a keyword-list for their optional parameters, to avoid having to worry about positional arguments.

As far as I can tell, only the screenshot and opengraph code paths require a user-agent header enabled, so I've had all the other calls omit the header by default.