### PR TITLE
Add failing test for discord integration bug

### DIFF
--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -35,7 +35,9 @@ defmodule Ret.HttpUtils do
       end
 
     retry with: exponential_backoff() |> randomize |> cap(cap_ms) |> expiry(expiry_ms) do
-      case HTTPoison.request(verb, url, body, headers,
+      http_client = module_config(:http_client) || HTTPoison
+
+      case http_client.request(verb, url, body, headers,
              follow_redirect: true,
              timeout: cap_ms,
              recv_timeout: cap_ms,

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Ret.Mixfile do
       {:statix, "~> 1.2"},
       {:quantum, "~> 2.2.7"},
       {:credo, "~> 1.1", only: [:dev, :test], runtime: false},
+      {:mox, "~> 1.0.1", only: [:dev, :test]},
       {:plug_attack, "~> 0.4"},
       {:ecto_enum, "~> 1.3"},
       {:the_end, git: "https://github.com/mozillareality/the_end.git", branch: "bug/phoenix-14"},

--- a/mix.lock
+++ b/mix.lock
@@ -51,6 +51,7 @@
   "mime": {:hex, :mime, "1.4.0", "5066f14944b470286146047d2f73518cf5cca82f8e4815cf35d196b58cf07c47", [:mix], [], "hexpm", "75fa42c4228ea9a23f70f123c74ba7cece6a03b1fd474fe13f6a7a85c6ea4ff6"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "47ac558d8b06f684773972c6d04fcc15590abdb97aeb7666da19fcbfdc441a07"},
+  "mox": {:hex, :mox, "1.0.1", "b651bf0113265cda0ba3a827fcb691f848b683c373b77e7d7439910a8d754d6e", [:mix], [], "hexpm", "35bc0dea5499d18db4ef7fe4360067a59b06c74376eb6ab3bd67e6295b133469"},
   "mutex": {:hex, :mutex, "1.1.3", "d7e19f96fe19d6d97583bf12ca1ec182bbf14619b7568592cc461135de1c3b81", [:mix], [], "hexpm"},
   "oauther": {:hex, :oauther, "1.1.1", "7d8b16167bb587ecbcddd3f8792beb9ec3e7b65c1f8ebd86b8dd25318d535752", [:mix], [], "hexpm", "9374f4302045321874cccdc57eb975893643bd69c3b22bf1312dab5f06e5788e"},
   "observer_cli": {:hex, :observer_cli, "1.5.3", "d42e20054116c49d5242d3ff9e1913acccebe6015f449d6e312a5bc160e79a62", [:mix, :rebar3], [{:recon, "~>2.5.0", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "3d2de7a710b9bed4cfbdae0419d98b1985634bd8cc1f26ef9576c2eb9aa6b35e"},


### PR DESCRIPTION
This is a failing test for #531. I've put this in its own PR since I'm a bit unsure of the testing technique I've used here, since it introduces and uses a mocking library in order to test our usage of the external HTTPoison library, in the context of Discord API calls. The mocking mechanism also requires some fairly complex setup, since it needs to operate across Erlang process boundaries. I'm also unsure if we do want to write a test around this particular bug, since this code is unlikely to break in this particular way.