### PR TITLE
Scrub room name when it is closed

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -547,6 +547,9 @@ defmodule Ret.Hub do
   def changeset_for_entry_mode(%Hub{} = hub, entry_mode),
     do: hub |> cast(%{entry_mode: entry_mode}, [:entry_mode])
 
+  def changeset_for_scrubbed_room_data(hub),
+    do: hub |> cast(%{name: "closed", description: "room is closed"}, [:name, :description])
+
   def changeset_for_new_host(%Hub{} = hub, host), do: hub |> cast(%{host: host}, [:host])
 
   def changeset_for_creator_assignment(

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -547,8 +547,7 @@ defmodule Ret.Hub do
   def changeset_for_entry_mode(%Hub{} = hub, entry_mode),
     do: hub |> cast(%{entry_mode: entry_mode}, [:entry_mode])
 
-  def changeset_for_scrubbed_room_data(hub),
-    do: hub |> cast(%{name: "closed", description: "room is closed"}, [:name, :description])
+  def changeset_for_closed_room_name(hub), do: hub |> cast(%{name: "closed"}, [:name])
 
   def changeset_for_new_host(%Hub{} = hub, host), do: hub |> cast(%{host: host}, [:host])
 

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -714,6 +714,14 @@ defmodule RetWeb.HubChannel do
     end
   end
 
+  defp maybe_scrub_room_data(hub, entry_mode) do
+    if entry_mode == :deny do
+      Hub.changeset_for_scrubbed_room_data(hub)
+    else
+      hub
+    end
+  end
+
   defp handle_entry_mode_change(socket, entry_mode) do
     hub = socket |> hub_for_socket
     account = Guardian.Phoenix.Socket.current_resource(socket)
@@ -721,6 +729,7 @@ defmodule RetWeb.HubChannel do
     if account |> can?(close_hub(hub)) do
       hub
       |> Hub.changeset_for_entry_mode(entry_mode)
+      |> maybe_scrub_room_data(entry_mode)
       |> Repo.update!()
       |> Repo.preload(Hub.hub_preloads())
       |> broadcast_hub_refresh!(socket, ["entry_mode"])

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -716,7 +716,7 @@ defmodule RetWeb.HubChannel do
 
   defp maybe_scrub_room_data(hub, entry_mode) do
     if entry_mode == :deny do
-      Hub.changeset_for_scrubbed_room_data(hub)
+      Hub.changeset_for_closed_room_name(hub)
     else
       hub
     end

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -84,6 +84,7 @@ defmodule RetWeb.Api.V1.HubController do
     Hub
     |> Repo.get_by(hub_sid: hub_sid)
     |> Hub.changeset_for_entry_mode(:deny)
+    |> Hub.changeset_for_scrubbed_room_data()
     |> Repo.update!()
 
     conn |> send_resp(200, "OK")

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -84,7 +84,7 @@ defmodule RetWeb.Api.V1.HubController do
     Hub
     |> Repo.get_by(hub_sid: hub_sid)
     |> Hub.changeset_for_entry_mode(:deny)
-    |> Hub.changeset_for_scrubbed_room_data()
+    |> Hub.changeset_for_closed_room_name()
     |> Repo.update!()
 
     conn |> send_resp(200, "OK")

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -41,19 +41,19 @@ defmodule Ret.HubTest do
   end
 
   test "should deny entry for closed hub, allow entry for re-opened hub", %{scene: scene} do
-    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub", description: "Test"}) |> Repo.insert()
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
     hub = hub |> Repo.preload([:hub_bindings])
 
     %{join_hub: true} = hub |> Hub.perms_for_account(nil)
 
     hub = hub
           |> Hub.changeset_for_entry_mode(:deny)
-          |> Hub.changeset_for_scrubbed_room_data()
+          |> Hub.changeset_for_closed_room_name()
           |> Repo.update!()
 
     %{join_hub: false} = hub |> Hub.perms_for_account(nil)
 
-    %{name: "closed", description: "room is closed"} = hub
+    %{name: "closed"} = hub
 
     hub = hub |> Hub.changeset_for_entry_mode(:allow) |> Repo.update!()
 

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -41,14 +41,19 @@ defmodule Ret.HubTest do
   end
 
   test "should deny entry for closed hub, allow entry for re-opened hub", %{scene: scene} do
-    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
+    {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub", description: "Test"}) |> Repo.insert()
     hub = hub |> Repo.preload([:hub_bindings])
 
     %{join_hub: true} = hub |> Hub.perms_for_account(nil)
 
-    hub = hub |> Hub.changeset_for_entry_mode(:deny) |> Repo.update!()
+    hub = hub
+          |> Hub.changeset_for_entry_mode(:deny)
+          |> Hub.changeset_for_scrubbed_room_data()
+          |> Repo.update!()
 
     %{join_hub: false} = hub |> Hub.perms_for_account(nil)
+
+    %{name: "closed", description: "room is closed"} = hub
 
     hub = hub |> Hub.changeset_for_entry_mode(:allow) |> Repo.update!()
 

--- a/test/ret_web/controllers/api/media_search_controller_test.exs
+++ b/test/ret_web/controllers/api/media_search_controller_test.exs
@@ -206,7 +206,10 @@ defmodule RetWeb.MediaSearchControllerTest do
     assert length(Enum.filter(entries, fn e -> e["id"] == private_hub_2.hub_sid end)) == 1
 
     # Close the first hub
-    private_hub |> Hub.changeset_for_entry_mode(:deny) |> Repo.update!()
+    private_hub
+    |> Hub.changeset_for_entry_mode(:deny)
+    |> Hub.changeset_for_scrubbed_room_data()
+    |> Repo.update!()
 
     resp =
       conn

--- a/test/ret_web/controllers/api/media_search_controller_test.exs
+++ b/test/ret_web/controllers/api/media_search_controller_test.exs
@@ -208,7 +208,7 @@ defmodule RetWeb.MediaSearchControllerTest do
     # Close the first hub
     private_hub
     |> Hub.changeset_for_entry_mode(:deny)
-    |> Hub.changeset_for_scrubbed_room_data()
+    |> Hub.changeset_for_closed_room_name()
     |> Repo.update!()
 
     resp =


### PR DESCRIPTION
This PR makes it so that when a room is closed, we scrub the room name so that user-submitted data does not appear in the page title. 