### PR TITLE
Fix asset import helper

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Ret.Mixfile do
       {:statix, "~> 1.2"},
       {:quantum, "~> 2.2.7"},
       {:credo, "~> 1.1", only: [:dev, :test], runtime: false},
+      {:mox, "~> 1.0.1", only: [:dev, :test]},
       {:plug_attack, "~> 0.4"},
       {:ecto_enum, "~> 1.3"},
       {:the_end, git: "https://github.com/mozillareality/the_end.git", branch: "bug/phoenix-14"},

--- a/mix.lock
+++ b/mix.lock
@@ -51,6 +51,7 @@
   "mime": {:hex, :mime, "1.4.0", "5066f14944b470286146047d2f73518cf5cca82f8e4815cf35d196b58cf07c47", [:mix], [], "hexpm", "75fa42c4228ea9a23f70f123c74ba7cece6a03b1fd474fe13f6a7a85c6ea4ff6"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.0.2", "34900184cbbbc6b6ed616ed3a8ea9b791f9fd2088419352a6d3200525637f785", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "47ac558d8b06f684773972c6d04fcc15590abdb97aeb7666da19fcbfdc441a07"},
+  "mox": {:hex, :mox, "1.0.1", "b651bf0113265cda0ba3a827fcb691f848b683c373b77e7d7439910a8d754d6e", [:mix], [], "hexpm", "35bc0dea5499d18db4ef7fe4360067a59b06c74376eb6ab3bd67e6295b133469"},
   "mutex": {:hex, :mutex, "1.1.3", "d7e19f96fe19d6d97583bf12ca1ec182bbf14619b7568592cc461135de1c3b81", [:mix], [], "hexpm"},
   "oauther": {:hex, :oauther, "1.1.1", "7d8b16167bb587ecbcddd3f8792beb9ec3e7b65c1f8ebd86b8dd25318d535752", [:mix], [], "hexpm", "9374f4302045321874cccdc57eb975893643bd69c3b22bf1312dab5f06e5788e"},
   "observer_cli": {:hex, :observer_cli, "1.5.3", "d42e20054116c49d5242d3ff9e1913acccebe6015f449d6e312a5bc160e79a62", [:mix, :rebar3], [{:recon, "~>2.5.0", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "3d2de7a710b9bed4cfbdae0419d98b1985634bd8cc1f26ef9576c2eb9aa6b35e"},

--- a/test/ret/http_utils_test.exs
+++ b/test/ret/http_utils_test.exs
@@ -1,0 +1,21 @@
+defmodule Ret.HttpUtilsTest do
+  use ExUnit.Case
+
+  setup_all do
+    Mox.defmock(Ret.HttpMock, for: HTTPoison.Base)
+    Ret.TestHelpers.merge_module_config(:ret, Ret.HttpUtils, %{:http_client => Ret.HttpMock})
+
+    on_exit(fn ->
+      Ret.TestHelpers.merge_module_config(:ret, Ret.HttpUtils, %{:http_client => nil})
+    end)
+  end
+
+  test "fetch_content_type should attempt a request return the response content type" do
+    Ret.HttpMock
+    |> Mox.expect(:request, 1, fn _verb, _url, _body, _headers, _options ->
+      {:ok, %HTTPoison.Response{status_code: 200, headers: %{"content-type" => "foo/bar"}}}
+    end)
+
+    {:ok, "foo/bar"} = Ret.HttpUtils.fetch_content_type("http://foo.local/")
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -224,4 +224,9 @@ defmodule Ret.TestHelpers do
     |> Ret.Hub.changeset_for_creator_assignment(account, hub.creator_assignment_token)
     |> Ret.Repo.update!()
   end
+
+  def merge_module_config(app, key, configs) do
+    current_config = Application.get_env(app, key, %{})
+    Application.put_env(app, key, Map.merge(current_config, configs))
+  end
 end


### PR DESCRIPTION
A regression introduced in #531 broke the asset import feature in the admin panel. The function signature for `retry_head_then_get_until_success` was changed, but the call site in `fetch_content_type` was not changed accordingly.

This PR fixes `fetch_content_type` and also adds a test that uses the Mox library to exercise the function with a basic test.