### PR TITLE
Respond with an error if twitter might be misconfigured

### DIFF
--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -566,8 +566,10 @@ defmodule RetWeb.HubChannel do
 
     case Guardian.Phoenix.Socket.current_resource(socket) do
       %Account{} = account ->
-        url = Ret.TwitterClient.get_oauth_url(hub.hub_sid, account.account_id)
-        {:reply, {:ok, %{oauth_url: url}}, socket}
+        case Ret.TwitterClient.get_oauth_url(hub.hub_sid, account.account_id) do
+          {:error, reason} -> {:reply, {:error, %{reason: reason}}, socket}
+          url -> {:reply, {:ok, %{oauth_url: url}}, socket}
+        end
 
       _ ->
         {:reply, :error, socket}


### PR DESCRIPTION
If twitter is misconfigured, either with a typo in the tokens configured, or a configuration error in the twitter developer console, it may result in API calls failing in reticulum. Previously, this would cause the hub_channel websocket to crash, and break the client in different ways (perhaps causing the game loop to stop). 
This PR adds error handling so that we forward the error to the client, instead of crashing entirely.

Goes with https://github.com/mozilla/hubs/pull/4997