### PR TITLE
Add new whats-new API to query GitHub for merged pull requests

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -112,6 +112,8 @@ config :ret, Ret.DiscordClient,
   client_secret: "",
   bot_token: ""
 
+config :ret, RetWeb.Api.V1.WhatsNewController, token: ""
+
 # Allow any origin for API access in dev
 config :cors_plug, origin: ["*"]
 

--- a/habitat/config/config.toml
+++ b/habitat/config/config.toml
@@ -26,6 +26,11 @@ token = {{ toToml cfg.slack_controller.token }}
 {{ toToml cfg.twitter_client }}
 {{/if}}
 
+{{#if cfg.whats_new.token}}
+[ret."Elixir.RetWeb.Api.V1.WhatsNewController"]
+token = {{ toToml cfg.whats_new.token }}
+{{/if}}
+
 [ret."Elixir.RetWeb.Endpoint".https]
 port = {{ cfg.phx.port }}
 certfile = "{{ pkg.svc_files_path }}/ssl.pem"

--- a/lib/ret/application.ex
+++ b/lib/ret/application.ex
@@ -235,6 +235,19 @@ defmodule Ret.Application do
         ],
         id: :coturn_secret
       ),
+
+      # What's new cache
+      worker(
+        Cachex,
+        [
+          :whats_new,
+          [
+            expiration: expiration(default: :timer.minutes(1)),
+            fallback: fallback(default: &RetWeb.Api.V1.WhatsNewController.fetch_pull_requests/1)
+          ]
+        ],
+        id: :whats_new_cache
+      ),
       supervisor(TheEnd.Of.Phoenix, [[timeout: 10_000, endpoint: RetWeb.Endpoint]])
     ]
 

--- a/lib/ret_web/controllers/api/v1/whats_new_controller.ex
+++ b/lib/ret_web/controllers/api/v1/whats_new_controller.ex
@@ -1,0 +1,99 @@
+defmodule RetWeb.Api.V1.WhatsNewController do
+  use RetWeb, :controller
+
+  @endpoint "https://api.github.com/graphql"
+  @per_page 20
+  @paragraph_separator "\r\n\r\n"
+  @image_prefix "!["
+  @whats_new_label "whats new"
+
+  def show(conn, params) do
+    {_status, pull_requests} = Cachex.fetch(:whats_new, [params["source"], params["cursor"]])
+
+    last_pull_request = Enum.at(pull_requests, -1, %{})
+    has_more = Enum.count(pull_requests) === @per_page
+
+    conn
+    |> json(%{
+      pullRequests: Enum.map(pull_requests, &format_pull_request/1),
+      moreCursor: if(has_more, do: last_pull_request["cursor"], else: nil)
+    })
+  end
+
+  def fetch_pull_requests([source, cursor]) do
+    {:commit, fetch_pull_requests(source, cursor, module_config(:token))}
+  end
+
+  defp fetch_pull_requests(_source, _cursor, nil = _token),
+    do: []
+
+  defp fetch_pull_requests(_source, _cursor, "" = _token),
+    do: []
+
+  defp fetch_pull_requests("hubs" = _source, cursor, token),
+    do: fetch_pull_requests("mozilla", "hubs", cursor, token)
+
+  defp fetch_pull_requests("spoke" = _source, cursor, token),
+    do: fetch_pull_requests("mozilla", "spoke", cursor, token)
+
+  defp fetch_pull_requests(_source, _cursor, _token),
+    do: []
+
+  defp fetch_pull_requests(repo_owner, repo_name, cursor, token) do
+    query = "
+      query {
+        repository(owner: \"#{repo_owner}\", name: \"#{repo_name}\") {
+          pullRequests(
+            labels: [\"#{@whats_new_label}\"],
+            states: [MERGED],
+            first: #{@per_page},
+            orderBy: { field: CREATED_AT, direction: DESC },
+            #{if(cursor, do: "after: \"#{cursor}\"", else: "")}
+          ) {
+            edges {
+              node {
+                title
+                url
+                mergedAt
+                body
+              }
+              cursor
+            }
+          }
+        }
+      }
+    "
+
+    %{body: resp_body} =
+      Ret.HttpUtils.retry_post_until_success(
+        @endpoint,
+        %{query: query} |> Poison.encode!(),
+        headers: [{"authorization", "token #{token}"}]
+      )
+
+    resp_body |> Poison.decode() |> extract_pull_requests
+  end
+
+  defp extract_pull_requests({:ok, %{"data" => data}}), do: data["repository"]["pullRequests"]["edges"]
+  defp extract_pull_requests(_), do: []
+
+  defp format_pull_request(%{"node" => pull_request}) do
+    body = pull_request["body"]
+
+    paragraphs = String.split(body, @paragraph_separator)
+
+    para1 = Enum.at(paragraphs, 0)
+    para2 = Enum.at(paragraphs, 1)
+
+    formatted_body =
+      if para2 && String.contains?(para2, @image_prefix) do
+        Enum.join([para1, para2], @paragraph_separator)
+      else
+        para1
+      end
+
+    pull_request |> Map.put("body", formatted_body)
+  end
+
+  defp module_config(key), do: Application.get_env(:ret, __MODULE__)[key]
+end

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -115,6 +115,8 @@ defmodule RetWeb.Router do
 
       resources("/credentials/scopes", Api.V1.ScopesController, only: [:index])
       resources("/ret_notices", Api.V1.RetNoticeController, only: [:create])
+
+      get("/whats-new", Api.V1.WhatsNewController, :show)
     end
 
     scope "/v1", as: :api_v1 do


### PR DESCRIPTION
This replaces client code that previously used the Github API directly in the client code. This allows us to keep the github token safe, and affords us some caching. It also uses Github's GraphQL API instead of their REST API, which is a bit more efficient.

Goes with:
- https://github.com/mozilla/hubs/pull/5126
- https://github.com/mozilla/Spoke/pull/1221
- https://github.com/mozilla/hubs-ops/pull/155