### PR TITLE
Add fonts.gstattic.com to connect-src for Troika

### DIFF
--- a/lib/ret_web/plugs/add_csp.ex
+++ b/lib/ret_web/plugs/add_csp.ex
@@ -182,6 +182,7 @@ defmodule RetWeb.Plugs.AddCSP do
         "https://dpdb.webvr.rocks",
         "https://www.google-analytics.com",
         "https://www.youtube.com",
+        "https://fonts.gstatic.com",
         assets_url,
         cors_proxy_url,
         custom_rules[:connect_src],


### PR DESCRIPTION
Troika text loads fonts using fetch not directly as a CSS font so this needs to be in our connect-src as well (it was previously already in our font-src for use in CSS)