### PR TITLE
Add cross-origin headers required for SABs

### DIFF
--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -4,12 +4,20 @@ defmodule RetWeb.Router do
   use Sentry.Plug
 
   pipeline :secure_headers do
-    plug(:put_secure_browser_headers)
+    plug(:put_secure_browser_headers, %{
+      "cross-origin-opener-policy" => "same-origin",
+      "cross-origin-resource-policy" => "require-corp"
+    })
+
     plug(RetWeb.Plugs.AddCSP)
   end
 
   pipeline :strict_secure_headers do
-    plug(:put_secure_browser_headers)
+    plug(:put_secure_browser_headers, %{
+      "cross-origin-opener-policy" => "same-origin",
+      "cross-origin-resource-policy" => "require-corp"
+    })
+
     plug(RetWeb.Plugs.AddCSP, strict: true)
   end
 


### PR DESCRIPTION
Adds the required headers to load Hubs in a secure context to access **SharedArrayBuffers** and high resolution timers. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements. This also increases security in general, but will make it more difficult to communicate with iframed hubs clients if that becomes necessary in the future.

Reticulum compliment to https://github.com/mozilla/hubs/pull/4252