### PR TITLE
Optimize public rooms queries

### DIFF
--- a/priv/repo/migrations/20220304230943_add_hubs_public_rooms_index.exs
+++ b/priv/repo/migrations/20220304230943_add_hubs_public_rooms_index.exs
@@ -1,0 +1,7 @@
+defmodule Ret.Repo.Migrations.AddHubsPublicRoomsIndex do
+  use Ecto.Migration
+
+  def change do
+    create(index(:hubs, [:allow_promotion]))
+  end
+end


### PR DESCRIPTION
Querying for public rooms can put a lot of load on the DB. This index helps with that considerably.

Here is the process I used for measuring the perf:

1. Use [Apache Bench](https://httpd.apache.org/docs/2.4/programs/ab.html) to measure baseline perf:
`ab -c 50 -n 500 'https://hubs.local:4000/api/v1/media/search?source=rooms&filter=public&cursor=0'`
3. Create 20,000 rooms:
`1..20000 |> Enum.each(fn _ -> Ret.Hub.create_new_room(%{"name" => "foo"}, true) end); `
4. Run benchmark again to measure perf after the migration adds the index.