### PR TITLE
Portal/internal endpoints /v1/internal -> /api-internal/v1

### DIFF
--- a/config/turkey.exs
+++ b/config/turkey.exs
@@ -2,9 +2,7 @@ use Mix.Config
 
 import_config "prod.exs"
 
-config :peerage, log_results: true, via: Peerage.Via.Dns,
-  dns_name: "foo.bar",
-  app_name: "foo"
+config :peerage, log_results: true, via: Peerage.Via.Dns, dns_name: "foo.bar", app_name: "foo"
 
 config :sentry,
   environment_name: :turkey,

--- a/lib/ret_web/controllers/api-internal/v1/presence_controller.ex
+++ b/lib/ret_web/controllers/api-internal/v1/presence_controller.ex
@@ -1,4 +1,4 @@
-defmodule RetWeb.Api.V1.PresenceController do
+defmodule RetWeb.ApiInternal.V1.PresenceController do
   use RetWeb, :controller
 
   # Get presence count

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -197,7 +197,7 @@ defmodule RetWeb.Router do
       [:portal_header_auth, :secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: [])
     )
 
-    scope "/v1", as: :api_v1 do
+    scope "/v1", as: :api_internal_v1 do
       get("/presence", ApiInternal.V1.PresenceController, :show)
     end
   end

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -202,7 +202,7 @@ defmodule RetWeb.Router do
     pipe_through([:portal_header_auth, :secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: []))
 
     scope "/v1", as: :api_v1 do
-      get("/presence", ApiInternal.PresenceController, :show)
+      get("/presence", ApiInternal.V1.PresenceController, :show)
     end
   end
 

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -101,6 +101,7 @@ defmodule RetWeb.Router do
     forward("/", RetWeb.Plugs.ItaProxy)
   end
 
+
   scope "/api", RetWeb do
     pipe_through(
       [:secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: [])
@@ -127,9 +128,9 @@ defmodule RetWeb.Router do
       resources("/slack", Api.V1.SlackController, only: [:create])
     end
 
-    scope "/v1/internal", as: :api_v1 do
+    scope "/api-internal/v1", as: :api_v1 do
       pipe_through([:portal_header_auth])
-      get("/presence", Api.V1.PresenceController, :show)
+      get("/presence", ApiInternal.PresenceController, :show)
     end
 
     scope "/v1", as: :api_v1 do
@@ -195,6 +196,14 @@ defmodule RetWeb.Router do
 
     forward "/graphiql", Absinthe.Plug.GraphiQL, json_codec: Jason, schema: RetWeb.Schema
     forward "/", Absinthe.Plug, json_codec: Jason, schema: RetWeb.Schema
+  end
+
+  scope "/api-internal", RetWeb do
+    pipe_through([:portal_header_auth, :secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: []))
+
+    scope "/v1", as: :api_v1 do
+      get("/presence", ApiInternal.PresenceController, :show)
+    end
   end
 
   # Directly accessible APIs.

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -101,7 +101,6 @@ defmodule RetWeb.Router do
     forward("/", RetWeb.Plugs.ItaProxy)
   end
 
-
   scope "/api", RetWeb do
     pipe_through(
       [:secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: [])
@@ -199,7 +198,9 @@ defmodule RetWeb.Router do
   end
 
   scope "/api-internal", RetWeb do
-    pipe_through([:portal_header_auth, :secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: []))
+    pipe_through(
+      [:portal_header_auth, :secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: [])
+    )
 
     scope "/v1", as: :api_v1 do
       get("/presence", ApiInternal.V1.PresenceController, :show)

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -127,11 +127,6 @@ defmodule RetWeb.Router do
       resources("/slack", Api.V1.SlackController, only: [:create])
     end
 
-    scope "/api-internal/v1", as: :api_v1 do
-      pipe_through([:portal_header_auth])
-      get("/presence", ApiInternal.PresenceController, :show)
-    end
-
     scope "/v1", as: :api_v1 do
       pipe_through([:bot_header_auth])
       resources("/hub_bindings", Api.V1.HubBindingController, only: [:create])


### PR DESCRIPTION
To ensure the internal endpoints are private and secure, organize the endpoint under /api-internal/v1 and NOT /api/v1. 