### PR TITLE
TurkeyDockerfile + coreutils

### DIFF
--- a/TurkeyDockerfile
+++ b/TurkeyDockerfile
@@ -14,6 +14,6 @@ run mkdir -p /storage && chmod 777 /storage
 workdir ret
 copy --from=builder /_build/turkey/rel/ret/ .
 copy --from=certr /certs .
-RUN apk update && apk add --no-cache bash openssl-dev openssl jq libstdc++
+RUN apk update && apk add --no-cache bash openssl-dev openssl jq libstdc++ coreutils
 copy scripts/docker/run.sh /run.sh
 cmd bash /run.sh


### PR DESCRIPTION
lib/ret/storage_used.ex expects "gnu/posix version of" df's output
alpine's default df is a busybox implementation (https://boxmatrix.info/wiki/Property:df), it adds an extra /n for long filesystem names in it's output, causing storage_used to throw on https://github.com/mozilla/reticulum/blob/dbe92397502380491548242b4828cd7546b07904/lib/ret/storage_used.ex#L12-L14