### PR TITLE
Add media-src CSP

### DIFF
--- a/lib/ret_web/plugs/add_csp.ex
+++ b/lib/ret_web/plugs/add_csp.ex
@@ -67,6 +67,10 @@ defmodule RetWeb.Plugs.AddCSP do
         "'self'",
         storage_url
       ],
+      "media-src" => [
+        "'self'",
+        storage_url
+      ],
       "style-src" => [
         "'self'",
         "'unsafe-inline'"


### PR DESCRIPTION
This change allows Hubs Client to play recorded camera video in a new tab by clicking "Open Link" on the object menu.

See https://github.com/mozilla/hubs/issues/5576