### PR TITLE
Amend asset rewrite implementation 

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -13,14 +13,15 @@ config :ret, RetWeb.Endpoint,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-db_credentials = "admin"
+db_credentials = System.get_env("DB_CREDENTIALS") || "admin"
+db_host = System.get_env("DB_HOST") || "localhost"
 
 config :ret, Ret.Repo,
   adapter: Ecto.Adapters.Postgres,
   username: db_credentials,
   password: db_credentials,
   database: "ret_test",
-  hostname: "localhost",
+  hostname: db_host,
   template: "template0",
   pool_size: 10,
   pool: Ecto.Adapters.SQL.Sandbox
@@ -30,7 +31,7 @@ config :ret, Ret.SessionLockRepo,
   username: db_credentials,
   password: db_credentials,
   database: "ret_test",
-  hostname: "localhost",
+  hostname: db_host,
   template: "template0",
   pool_size: 10,
   pool: Ecto.Adapters.SQL.Sandbox
@@ -41,7 +42,7 @@ config :ret, Ret.Locking,
     username: db_credentials,
     password: db_credentials,
     database: "ret_test",
-    hostname: "localhost"
+    hostname: db_host
   ]
 
 config :ret, Ret.Guardian,

--- a/lib/ret/account.ex
+++ b/lib/ret/account.ex
@@ -6,6 +6,8 @@ defmodule Ret.Account do
 
   import Canada, only: [can?: 2]
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:account_id, :id, autogenerate: true}
   @account_preloads [:login, :identity]

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -5,6 +5,8 @@ defmodule Ret.Project do
 
   alias Ret.{Repo, Project, ProjectAsset, Scene, SceneListing, Storage, OwnedFile}
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:project_id, :id, autogenerate: true}
 

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -122,6 +122,8 @@ defmodule Ret.Project do
         |> Repo.update!()
 
         OwnedFile.set_inactive(old_project_owned_file)
+        Storage.rm_files_for_owned_file(old_project_owned_file)
+        Repo.delete(old_project_owned_file)
       end)
 
       :ok

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -216,6 +216,12 @@ defmodule Ret.Scene do
 
         OwnedFile.set_inactive(old_scene_owned_file)
         OwnedFile.set_inactive(old_model_owned_file)
+
+        Storage.delete_owned_file(old_scene_owned_file)
+        Storage.delete_owned_file(old_model_owned_file)
+
+        Repo.delete(old_scene_owned_file)
+        Repo.delete(old_model_owned_file)
       end)
 
       :ok

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -214,14 +214,11 @@ defmodule Ret.Scene do
         |> put_change(:model_owned_file_id, new_model_owned_file.owned_file_id)
         |> Repo.update!()
 
-        OwnedFile.set_inactive(old_scene_owned_file)
-        OwnedFile.set_inactive(old_model_owned_file)
-
-        Storage.rm_files_for_owned_file(old_scene_owned_file)
-        Storage.rm_files_for_owned_file(old_model_owned_file)
-
-        Repo.delete(old_scene_owned_file)
-        Repo.delete(old_model_owned_file)
+        for old_owned_file <- [old_scene_owned_file, old_model_owned_file] do
+          OwnedFile.set_inactive(old_owned_file)
+          Storage.rm_files_for_owned_file(old_owned_file)
+          Repo.delete(old_owned_file)
+        end
       end)
 
       :ok

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -14,6 +14,8 @@ defmodule Ret.Scene do
   alias Ret.{Repo, Scene, SceneListing, Project, Storage, OwnedFile, GLTFUtils}
   alias Ret.Scene.{SceneSlug}
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:scene_id, :id, autogenerate: true}
 

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -217,8 +217,8 @@ defmodule Ret.Scene do
         OwnedFile.set_inactive(old_scene_owned_file)
         OwnedFile.set_inactive(old_model_owned_file)
 
-        Storage.delete_owned_file(old_scene_owned_file)
-        Storage.delete_owned_file(old_model_owned_file)
+        Storage.rm_files_for_owned_file(old_scene_owned_file)
+        Storage.rm_files_for_owned_file(old_model_owned_file)
 
         Repo.delete(old_scene_owned_file)
         Repo.delete(old_model_owned_file)

--- a/lib/ret/storage.ex
+++ b/lib/ret/storage.ex
@@ -464,7 +464,8 @@ defmodule Ret.Storage do
     end
   end
 
-  def delete_owned_file(%OwnedFile{} = owned_file) do
+  @spec rm_files_for_owned_file(OwnedFile.t()) :: :ok
+  def rm_files_for_owned_file(%OwnedFile{} = owned_file) do
     [_, meta_file_path, blob_file_path] = paths_for_uuid(owned_file.owned_file_uuid, owned_file_path())
     File.rm!(meta_file_path)
     File.rm!(blob_file_path)
@@ -501,6 +502,7 @@ defmodule Ret.Storage do
     Ret.Crypto.encrypt_stream_to_file(source_stream, source_size, destination_path, key |> Ret.Crypto.hash())
   end
 
+  @spec paths_for_owned_file(OwnedFile.t()) :: [String.t(), ...]
   def paths_for_owned_file(%OwnedFile{} = owned_file) do
     paths_for_uuid(owned_file.owned_file_uuid, owned_file_path())
   end

--- a/lib/ret/storage.ex
+++ b/lib/ret/storage.ex
@@ -464,6 +464,12 @@ defmodule Ret.Storage do
     end
   end
 
+  def delete_owned_file(%OwnedFile{} = owned_file) do
+    [_, meta_file_path, blob_file_path] = paths_for_uuid(owned_file.owned_file_uuid, owned_file_path())
+    File.rm!(meta_file_path)
+    File.rm!(blob_file_path)
+  end
+
   def uri_for(id, content_type, token \\ nil) do
     file_host = Application.get_env(:ret, Ret.Storage)[:host] || RetWeb.Endpoint.url()
     ext = MIME.extensions(content_type) |> List.first()
@@ -493,6 +499,10 @@ defmodule Ret.Storage do
 
   defp encrypt_stream_to_file(source_stream, source_size, destination_path, key) do
     Ret.Crypto.encrypt_stream_to_file(source_stream, source_size, destination_path, key |> Ret.Crypto.hash())
+  end
+
+  def paths_for_owned_file(%OwnedFile{} = owned_file) do
+    paths_for_uuid(owned_file.owned_file_uuid, owned_file_path())
   end
 
   defp paths_for_uuid(uuid, subpath) do

--- a/test/ret/project_test.exs
+++ b/test/ret/project_test.exs
@@ -1,0 +1,75 @@
+defmodule Ret.ProjectTest do
+  use Ret.DataCase, async: true
+
+  alias Ret.{Account, DummyData, OwnedFile, Repo, Project, Storage}
+
+  import Ret.TestHelpers,
+    only: [create_account: 1, create_owned_file: 2, generate_temp_owned_file: 1]
+
+  @sample_domain "https://hubs.local"
+
+  describe "rewrite_domain_for_all/2" do
+    test "project is rewritten" do
+      old_domain_url = @sample_domain
+      new_domain_url = DummyData.domain_url()
+
+      for _ <- 1..2 do
+        DummyData.account_prefix()
+        |> create_account()
+        |> create_project_with_sample_owned_files()
+      end
+
+      Project.rewrite_domain_for_all(old_domain_url, new_domain_url)
+
+      for project <- projects() do
+        {:ok, _meta, stream} = Storage.fetch(project.project_owned_file)
+        file_contents = Enum.join(stream)
+        assert file_contents =~ new_domain_url
+        refute file_contents =~ old_domain_url
+      end
+    end
+
+    test "old assets are removed" do
+      project =
+        DummyData.account_prefix()
+        |> create_account()
+        |> create_project_with_sample_owned_files()
+
+      # We expect the project we created above to have two owned files,
+      # a project_owned_file and thumbnail_owned_file.
+      2 = Repo.aggregate(OwnedFile, :count)
+      Repo.get!(OwnedFile, project.project_owned_file_id)
+      Repo.get!(OwnedFile, project.thumbnail_owned_file_id)
+
+      [_path, old_meta_file_path, old_blob_file_path] = Storage.paths_for_owned_file(project.project_owned_file)
+      true = File.exists?(old_meta_file_path)
+      true = File.exists?(old_blob_file_path)
+
+      Project.rewrite_domain_for_all(@sample_domain, DummyData.domain_url())
+
+      refute File.exists?(old_meta_file_path)
+      refute File.exists?(old_blob_file_path)
+
+      # The database should still only contain three owned files, since the old ones would have been deleted.
+      assert 2 === Repo.aggregate(OwnedFile, :count)
+    end
+  end
+
+  @spec create_project_with_sample_owned_files(Account.t()) :: Project.t()
+  defp create_project_with_sample_owned_files(%Account{} = account) do
+    project_owned_file = create_owned_file(account, @sample_domain)
+    thumbnail_owned_file = generate_temp_owned_file(account)
+
+    %Project{}
+    |> Project.changeset(account, project_owned_file, thumbnail_owned_file, %{name: DummyData.project_name()})
+    |> Repo.insert!()
+    |> Repo.preload([:project_owned_file])
+  end
+
+  @spec projects :: [Project.t()]
+  defp projects,
+    do:
+      Project
+      |> Repo.all()
+      |> Repo.preload([:project_owned_file])
+end

--- a/test/ret/project_test.exs
+++ b/test/ret/project_test.exs
@@ -50,7 +50,6 @@ defmodule Ret.ProjectTest do
       refute File.exists?(old_meta_file_path)
       refute File.exists?(old_blob_file_path)
 
-      # The database should still only contain three owned files, since the old ones would have been deleted.
       assert 2 === Repo.aggregate(OwnedFile, :count)
     end
   end

--- a/test/ret/scene_test.exs
+++ b/test/ret/scene_test.exs
@@ -52,7 +52,6 @@ defmodule Ret.SceneTest do
       refute File.exists?(old_meta_file_path)
       refute File.exists?(old_blob_file_path)
 
-      # The database should still only contain three owned files, since the old ones would have been deleted
       assert 3 === Repo.aggregate(OwnedFile, :count)
     end
   end

--- a/test/ret/scene_test.exs
+++ b/test/ret/scene_test.exs
@@ -28,7 +28,25 @@ defmodule Ret.SceneTest do
       end
     end
 
-    test "old assets are removed"
+    test "old assets are removed" do
+      scene =
+        dummy_account_prefix()
+        |> create_account()
+        |> create_scene_with_sample_owned_files()
+
+      assert Repo.aggregate(OwnedFile, :count) === 3
+
+      [_path, old_meta_file_path, old_blob_file_path] = Storage.paths_for_owned_file(scene.scene_owned_file)
+      assert File.exists?(old_meta_file_path)
+      assert File.exists?(old_blob_file_path)
+
+      Scene.rewrite_domain_for_all(@sample_domain, dummy_domain_url())
+
+      refute File.exists?(old_meta_file_path)
+      refute File.exists?(old_blob_file_path)
+
+      assert Repo.aggregate(OwnedFile, :count) === 3
+    end
   end
 
   @spec create_scene_with_sample_owned_files(Account.t()) :: Scene.t()

--- a/test/ret/scene_test.exs
+++ b/test/ret/scene_test.exs
@@ -1,0 +1,71 @@
+defmodule Ret.SceneTest do
+  use Ret.DataCase, async: true
+
+  alias Ret.{Account, OwnedFile, Repo, Scene, Storage}
+  import Ret.TestHelpers, only: [create_account: 1, generate_temp_file: 1, generate_temp_owned_file: 1]
+
+  @sample_domain "https://hubs.local"
+
+  describe "rewrite_domain_for_all/2" do
+    test "scene is rewritten" do
+      old_domain_url = @sample_domain
+      new_domain_url = dummy_domain_url()
+
+      for _ <- 1..2 do
+        dummy_account_prefix()
+        |> create_account()
+        |> create_scene_with_sample_owned_files()
+      end
+
+      Scene.rewrite_domain_for_all(old_domain_url, new_domain_url)
+
+      for scene <- scenes(),
+          owned_file <- [scene.model_owned_file, scene.scene_owned_file] do
+        {:ok, _meta, stream} = Storage.fetch(owned_file)
+        file_contents = Enum.join(stream)
+        assert file_contents =~ new_domain_url
+        refute file_contents =~ old_domain_url
+      end
+    end
+
+    test "old assets are removed"
+  end
+
+  @spec create_scene_with_sample_owned_files(Account.t()) :: Scene.t()
+  defp create_scene_with_sample_owned_files(%Account{} = account) do
+    model_owned_file = create_owned_file(account, File.read!("test/fixtures/test.glb"))
+    screenshot_owned_file = generate_temp_owned_file(account)
+    scene_owned_file = create_owned_file(account, @sample_domain)
+
+    %Scene{}
+    |> Scene.changeset(account, model_owned_file, screenshot_owned_file, scene_owned_file, %{name: dummy_scene_name()})
+    |> Repo.insert!()
+  end
+
+  @spec create_owned_file(Account.t(), String.t()) :: OwnedFile.t()
+  defp create_owned_file(%Account{} = account, file_contents) when is_binary(file_contents) do
+    file_path = generate_temp_file(file_contents)
+    {:ok, uuid} = Storage.store(%Plug.Upload{path: file_path}, "text/plain", "secret")
+    {:ok, owned_file} = Storage.promote(uuid, "secret", nil, account)
+    owned_file
+  end
+
+  @spec dummy_account_prefix :: String.t()
+  defp dummy_account_prefix,
+    do: "test-user-account-prefix-account-user"
+
+  @spec dummy_domain_url :: String.t()
+  defp dummy_domain_url,
+    do: "http://example.com"
+
+  @spec dummy_scene_name :: String.t()
+  defp dummy_scene_name,
+    do: "some name"
+
+  @spec scenes :: [Scene.t()]
+  defp scenes,
+    do:
+      Scene
+      |> Repo.all()
+      |> Repo.preload([:model_owned_file, :scene_owned_file])
+end

--- a/test/ret/scene_test.exs
+++ b/test/ret/scene_test.exs
@@ -34,18 +34,24 @@ defmodule Ret.SceneTest do
         |> create_account()
         |> create_scene_with_sample_owned_files()
 
-      assert Repo.aggregate(OwnedFile, :count) === 3
+      # We expect the scene we created above to have three owned files,
+      # a model_owned_file, screenshot_owned_file, and scene_owned_file
+      3 = Repo.aggregate(OwnedFile, :count)
+      Repo.get!(OwnedFile, scene.scene_owned_file_id)
+      Repo.get!(OwnedFile, scene.screenshot_owned_file_id)
+      Repo.get!(OwnedFile, scene.model_owned_file_id)
 
       [_path, old_meta_file_path, old_blob_file_path] = Storage.paths_for_owned_file(scene.scene_owned_file)
-      assert File.exists?(old_meta_file_path)
-      assert File.exists?(old_blob_file_path)
+      true = File.exists?(old_meta_file_path)
+      true = File.exists?(old_blob_file_path)
 
       Scene.rewrite_domain_for_all(@sample_domain, dummy_domain_url())
 
       refute File.exists?(old_meta_file_path)
       refute File.exists?(old_blob_file_path)
 
-      assert Repo.aggregate(OwnedFile, :count) === 3
+      # The database should still only contain three owned files, since the old ones would have been deleted
+      assert 3 === Repo.aggregate(OwnedFile, :count)
     end
   end
 

--- a/test/ret/scene_test.exs
+++ b/test/ret/scene_test.exs
@@ -1,18 +1,20 @@
 defmodule Ret.SceneTest do
   use Ret.DataCase, async: true
 
-  alias Ret.{Account, OwnedFile, Repo, Scene, Storage}
-  import Ret.TestHelpers, only: [create_account: 1, generate_temp_file: 1, generate_temp_owned_file: 1]
+  alias Ret.{Account, DummyData, OwnedFile, Repo, Scene, Storage}
+
+  import Ret.TestHelpers,
+    only: [create_account: 1, create_owned_file: 2, generate_temp_owned_file: 1]
 
   @sample_domain "https://hubs.local"
 
   describe "rewrite_domain_for_all/2" do
     test "scene is rewritten" do
       old_domain_url = @sample_domain
-      new_domain_url = dummy_domain_url()
+      new_domain_url = DummyData.domain_url()
 
       for _ <- 1..2 do
-        dummy_account_prefix()
+        DummyData.account_prefix()
         |> create_account()
         |> create_scene_with_sample_owned_files()
       end
@@ -30,7 +32,7 @@ defmodule Ret.SceneTest do
 
     test "old assets are removed" do
       scene =
-        dummy_account_prefix()
+        DummyData.account_prefix()
         |> create_account()
         |> create_scene_with_sample_owned_files()
 
@@ -45,7 +47,7 @@ defmodule Ret.SceneTest do
       true = File.exists?(old_meta_file_path)
       true = File.exists?(old_blob_file_path)
 
-      Scene.rewrite_domain_for_all(@sample_domain, dummy_domain_url())
+      Scene.rewrite_domain_for_all(@sample_domain, DummyData.domain_url())
 
       refute File.exists?(old_meta_file_path)
       refute File.exists?(old_blob_file_path)
@@ -62,29 +64,11 @@ defmodule Ret.SceneTest do
     scene_owned_file = create_owned_file(account, @sample_domain)
 
     %Scene{}
-    |> Scene.changeset(account, model_owned_file, screenshot_owned_file, scene_owned_file, %{name: dummy_scene_name()})
+    |> Scene.changeset(account, model_owned_file, screenshot_owned_file, scene_owned_file, %{
+      name: DummyData.scene_name()
+    })
     |> Repo.insert!()
   end
-
-  @spec create_owned_file(Account.t(), String.t()) :: OwnedFile.t()
-  defp create_owned_file(%Account{} = account, file_contents) when is_binary(file_contents) do
-    file_path = generate_temp_file(file_contents)
-    {:ok, uuid} = Storage.store(%Plug.Upload{path: file_path}, "text/plain", "secret")
-    {:ok, owned_file} = Storage.promote(uuid, "secret", nil, account)
-    owned_file
-  end
-
-  @spec dummy_account_prefix :: String.t()
-  defp dummy_account_prefix,
-    do: "test-user-account-prefix-account-user"
-
-  @spec dummy_domain_url :: String.t()
-  defp dummy_domain_url,
-    do: "http://example.com"
-
-  @spec dummy_scene_name :: String.t()
-  defp dummy_scene_name,
-    do: "some name"
 
   @spec scenes :: [Scene.t()]
   defp scenes,

--- a/test/support/dummy_data.ex
+++ b/test/support/dummy_data.ex
@@ -1,0 +1,17 @@
+defmodule Ret.DummyData do
+  @spec account_prefix :: String.t()
+  def account_prefix,
+    do: "test-user-account-prefix-account-user"
+
+  @spec domain_url :: String.t()
+  def domain_url,
+    do: "http://example.com"
+
+  @spec project_name :: String.t()
+  def project_name,
+    do: "some project name"
+
+  @spec scene_name :: String.t()
+  def scene_name,
+    do: "some scene name"
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -62,6 +62,14 @@ defmodule Ret.TestHelpers do
     {:ok, owned_file: generate_temp_owned_file(account)}
   end
 
+  @spec create_owned_file(Account.t(), String.t()) :: OwnedFile.t()
+  def create_owned_file(%Account{} = account, file_contents) when is_binary(file_contents) do
+    file_path = generate_temp_file(file_contents)
+    {:ok, uuid} = Storage.store(%Plug.Upload{path: file_path}, "text/plain", "secret")
+    {:ok, owned_file} = Storage.promote(uuid, "secret", nil, account)
+    owned_file
+  end
+
   def create_scene(%Account{} = account) do
     {:ok, scene: scene} = create_scene(%{account: account, owned_file: generate_temp_owned_file(account)})
     scene


### PR DESCRIPTION
Amend the asset rewrite implementations so that they immediately delete old assets, instead of waiting for them to be demoted and vacuumed.
Also adds tests to cover existing assets rewrite code, and verify the deletion of old assets.