### PR TITLE
get_dialog-pod fixes for turkeymode

### DIFF
--- a/lib/ret/load_balancing/janus_load_status.ex
+++ b/lib/ret/load_balancing/janus_load_status.ex
@@ -44,7 +44,7 @@ defmodule Ret.JanusLoadStatus do
         |> Enum.map(fn {a, b, c, d} -> "#{a}.#{b}.#{c}.#{d}" end)
 
       for host <- hosts do
-        %{body: body} = HTTPoison.get!("http://#{host}:7000/meta", [], hackney: [:insecure])
+        %{body: body} = HTTPoison.get!("http://#{host}:7000/meta")
         body_json = body |> Poison.decode!()
 
         # The cache key we construct here is a set of meta data that will be parsed by the dialog ingress proxy (dip),

--- a/lib/ret/load_balancing/janus_load_status.ex
+++ b/lib/ret/load_balancing/janus_load_status.ex
@@ -44,7 +44,7 @@ defmodule Ret.JanusLoadStatus do
         |> Enum.map(fn {a, b, c, d} -> "#{a}.#{b}.#{c}.#{d}" end)
 
       for host <- hosts do
-        %{body: body} = HTTPoison.get!("https://#{host}:7000/meta", [], hackney: [:insecure])
+        %{body: body} = HTTPoison.get!("http://#{host}:7000/meta", [], hackney: [:insecure])
         body_json = body |> Poison.decode!()
 
         # The cache key we construct here is a set of meta data that will be parsed by the dialog ingress proxy (dip),


### PR DESCRIPTION
dialog's port 7000 in turkey arch is internal and only used to report local levels