### PR TITLE
Prepare for local orchestration

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,5 @@
+bin/
+====
+These scripts allow you to run common commands inside the
+[Hubs Compose](https://github.com/mozilla/hubs-compose) Reticulum container
+from your own shell

--- a/bin/iex
+++ b/bin/iex
@@ -1,0 +1,3 @@
+#!/bin/bash
+basedir=$(dirname $0)
+docker-compose -f $basedir/../../../docker-compose.yml exec reticulum iex $*

--- a/bin/mix
+++ b/bin/mix
@@ -1,0 +1,3 @@
+#!/bin/bash
+basedir=$(dirname $0)
+docker-compose -f $basedir/../../../docker-compose.yml exec reticulum mix $*

--- a/bin/psql
+++ b/bin/psql
@@ -1,0 +1,3 @@
+#!/bin/bash
+basedir=$(dirname $0)
+docker-compose -f $basedir/../../../docker-compose.yml exec db psql postgres://postgres:postgres@db:5432/ret_dev

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,6 +8,8 @@ use Mix.Config
 # General application configuration
 config :ret, ecto_repos: [Ret.Repo, Ret.SessionLockRepo]
 
+config :ret, RetWeb.Plugs.PostgrestProxy, hostname: System.get_env("POSTGREST_INTERNAL_HOSTNAME") || "localhost"
+
 config :phoenix, :format_encoders, "json-api": Jason
 config :phoenix, :json_library, Jason
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,8 +10,6 @@ link_host = "hubs-link.local"
 # To run reticulum across a LAN for local testing, uncomment and change the line below to the LAN IP
 # host = cors_proxy_host = "192.168.1.27"
 
-dev_janus_host = "dev-janus.reticulum.io"
-
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #
@@ -124,10 +122,14 @@ config :ret,
   upload_encryption_key: "a8dedeb57adafa7821027d546f016efef5a501bd",
   bot_access_key: ""
 
+hubs_admin_internal_hostname = System.get_env("HUBS_ADMIN_INTERNAL_HOSTNAME") || host
+hubs_client_internal_hostname = System.get_env("HUBS_CLIENT_INTERNAL_HOSTNAME") || host
+spoke_internal_hostname = System.get_env("SPOKE_INTERNAL_HOSTNAME") || host
+
 config :ret, Ret.PageOriginWarmer,
-  hubs_page_origin: "https://#{host}:8080",
-  admin_page_origin: "https://#{host}:8989",
-  spoke_page_origin: "https://#{host}:9090",
+  admin_page_origin: "https://#{hubs_admin_internal_hostname}:8989",
+  hubs_page_origin: "https://#{hubs_client_internal_hostname}:8080",
+  spoke_page_origin: "https://#{spoke_internal_hostname}:9090",
   insecure_ssl: true
 
 config :ret, Ret.HttpUtils, insecure_ssl: true
@@ -202,7 +204,10 @@ config :sentry,
 
 config :ret, Ret.Habitat, ip: "127.0.0.1", http_port: 9631
 
-config :ret, Ret.JanusLoadStatus, default_janus_host: dev_janus_host, janus_port: 443
+dialog_hostname = System.get_env("DIALOG_HOSTNAME") || "dev-janus.reticulum.io"
+dialog_port = String.to_integer(System.get_env("DIALOG_PORT") || "443")
+
+config :ret, Ret.JanusLoadStatus, default_janus_host: dialog_hostname, janus_port: dialog_port
 
 config :ret, Ret.RoomAssigner, balancer_weights: [{600, 1}, {300, 50}, {0, 500}]
 

--- a/lib/ret_web/plugs/proxies.ex
+++ b/lib/ret_web/plugs/proxies.ex
@@ -1,6 +1,20 @@
 defmodule RetWeb.Plugs.PostgrestProxy do
   use Plug.Builder
-  plug ReverseProxyPlug, upstream: "http://localhost:3000"
+
+  plug :call
+
+  @spec call(Plug.Conn.t(), []) :: Plug.Conn.t()
+  def call(conn, []) do
+    opts = ReverseProxyPlug.init(upstream: "http://#{hostname()}:3000")
+    ReverseProxyPlug.call(conn, opts)
+  end
+
+  @spec hostname :: String.t()
+  defp hostname,
+    do:
+      :ret
+      |> Application.fetch_env!(__MODULE__)
+      |> Keyword.fetch!(:hostname)
 end
 
 defmodule RetWeb.Plugs.ItaProxy do


### PR DESCRIPTION
Why
---
Content administration screens cannot load and the following error messages appear in the browser when Hubs is orchestrated with Docker Compose:
* Missing file index.html. Please try again.
* Missing file admin.html. Please try again.

Reticulum is run against an external Dialog instance.  I want to be able to tweak, and thus run against, a local instance.

I want to be able to easily run common commands inside the orchestrated container from my own shell.

What
----
* Allow hostnames for the following to be supplied by OS vars:
    + hubs client
    + hubs admin
    + postgREST
    + spoke
    + dialog
* Add `bin/iex`, `bin/mix`, and `bin/psql`