### PR TITLE
Account Deletion: Restrict account deletion

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -854,7 +854,11 @@ defimpl Canada.Can, for: Ret.Account do
     false
   end
 
-  def can?(%Ret.Account{is_admin: true} = admin_account, :delete_account, %Ret.Account{} = account_to_delete) do
+  def can?(
+        %Ret.Account{is_admin: true} = admin_account,
+        :delete_account,
+        %Ret.Account{is_admin: false} = account_to_delete
+      ) do
     admin_account.account_id !== account_to_delete.account_id
   end
 

--- a/test/ret_test.exs
+++ b/test/ret_test.exs
@@ -435,6 +435,38 @@ defmodule RetTest do
       assert 0 === count(OwnedFile, target_account)
       refute owned_files_exist?(owned_files)
     end
+
+    test "only admin accounts can delete accounts" do
+      test_account = create_account("test")
+      target_account = create_account("target")
+
+      1 = count(Account, target_account)
+
+      assert {:error, :forbidden} = Ret.delete_account(test_account, target_account)
+
+      1 = count(Account, target_account)
+    end
+
+    test "cannot delete admin account" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      {:ok, admin_account: other_account} = create_admin_account("other")
+
+      1 = count(Account, other_account)
+
+      assert {:error, :forbidden} = Ret.delete_account(admin_account, other_account)
+
+      1 = count(Account, other_account)
+    end
+
+    test "cannot delete own account" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+
+      1 = count(Account, admin_account)
+
+      assert {:error, :forbidden} = Ret.delete_account(admin_account, admin_account)
+
+      1 = count(Account, admin_account)
+    end
   end
 
   defp create_scene_listing(%Scene{} = scene) do


### PR DESCRIPTION
Builds on #626. Amends the Canada permission to prevent admin accounts from being deleted. Also adds tests to verify restrictions on account deletion.