### PR TITLE
Account Deletion

### DIFF
--- a/lib/ret.ex
+++ b/lib/ret.ex
@@ -1,9 +1,158 @@
 defmodule Ret do
-  @moduledoc """
-  Ret keeps the contexts that define your domain
-  and business logic.
+  import Canada, only: [can?: 2]
+  import Ecto.Query
+  alias Ret.{Account, Asset, Avatar, AvatarListing, OwnedFile, Project, Repo, Scene, SceneListing, Storage}
 
-  Contexts are also responsible for managing your data, regardless
-  if it comes from the database, an external API or others.
-  """
+  def get_account_by_id(account_id) do
+    Repo.get(Account, account_id)
+  end
+
+  @asset_file_columns [:asset_owned_file, :thumbnail_owned_file]
+  @project_file_columns [:project_owned_file, :thumbnail_owned_file]
+  @scene_file_columns [:scene_owned_file, :screenshot_owned_file, :model_owned_file]
+  def delete_account(%Account{} = acting_account, %Account{} = account_to_delete) do
+    if can?(acting_account, delete_account(account_to_delete)) do
+      reassign_avatar_listings(account_to_delete, acting_account)
+      reassign_parent_avatars(account_to_delete, acting_account)
+      reassign_scene_listings(account_to_delete, acting_account)
+
+      delete_entities_with_owned_files(
+        from(avatar in Avatar, where: avatar.account_id == ^account_to_delete.account_id),
+        Avatar.file_columns()
+      )
+
+      delete_entities_with_owned_files(
+        from(asset in Asset, where: asset.account_id == ^account_to_delete.account_id),
+        @asset_file_columns
+      )
+
+      project_query = from(project in Project, where: project.created_by_account_id == ^account_to_delete.account_id)
+      scene_query = from(scene in Scene, where: scene.account_id == ^account_to_delete.account_id)
+
+      project_and_scene_owned_files =
+        collect_owned_files(project_query, @project_file_columns) ++
+          collect_owned_files(scene_query, @scene_file_columns)
+
+      Repo.delete_all(project_query)
+      Repo.delete_all(scene_query)
+
+      delete_owned_files(project_and_scene_owned_files)
+
+      delete_owned_files(Repo.all(from(o in OwnedFile, where: o.account_id == ^account_to_delete.account_id)))
+
+      case Repo.delete(account_to_delete) do
+        {:ok, _} -> :ok
+        {:error, _} -> {:error, :failed}
+      end
+    else
+      {:error, :forbidden}
+    end
+  end
+
+  defp collect_owned_files(query, file_columns) when is_list(file_columns) do
+    entities = Repo.all(query) |> Repo.preload(file_columns)
+    Enum.flat_map(entities, fn entity -> entity_owned_files(entity, file_columns) end)
+  end
+
+  defp delete_entities_with_owned_files(query, file_columns) when is_list(file_columns) do
+    entities = Repo.all(query) |> Repo.preload(file_columns)
+    entity_owned_files = Enum.flat_map(entities, fn entity -> entity_owned_files(entity, file_columns) end)
+    Repo.delete_all(query)
+    delete_owned_files(entity_owned_files)
+  end
+
+  defp entity_owned_files(entity, file_columns) do
+    for column <- file_columns,
+        owned_file = Map.fetch!(entity, column),
+        do: owned_file
+  end
+
+  defp delete_owned_files(owned_files) when is_list(owned_files) do
+    uniq_owned_files = owned_files |> Enum.uniq_by(fn owned_file -> owned_file.owned_file_id end)
+
+    for owned_file <- uniq_owned_files do
+      OwnedFile.set_inactive(owned_file)
+      Storage.rm_files_for_owned_file(owned_file)
+      Repo.delete(owned_file)
+    end
+  end
+
+  defp reassign_avatar_listings(%Account{} = old_account, %Account{} = new_account) do
+    reassign_owned_files_for_avatars_or_listings(AvatarListing, old_account, new_account)
+
+    Repo.update_all(
+      from(av in Avatar,
+        join: al in AvatarListing,
+        on: av.avatar_id == al.avatar_id,
+        where: av.account_id == ^old_account.account_id
+      ),
+      set: [account_id: new_account.account_id]
+    )
+
+    Repo.update_all(
+      from(al in AvatarListing, where: al.account_id == ^old_account.account_id),
+      set: [account_id: new_account.account_id]
+    )
+  end
+
+  defp reassign_parent_avatars(%Account{} = old_account, %Account{} = new_account) do
+    reassign_owned_files_for_avatars_or_listings(Avatar, old_account, new_account)
+
+    Repo.update_all(
+      from(a1 in Avatar,
+        join: a2 in Avatar,
+        on: a1.avatar_id == a2.parent_avatar_id,
+        where: a1.account_id == ^old_account.account_id
+      ),
+      set: [account_id: new_account.account_id]
+    )
+  end
+
+  defp reassign_owned_files_for_avatars_or_listings(schema, %Account{} = old_account, %Account{} = new_account)
+       when schema in [Avatar, AvatarListing] do
+    Repo.update_all(
+      from(o in OwnedFile,
+        join: avatar_or_listing in ^schema,
+        on:
+          o.owned_file_id == avatar_or_listing.gltf_owned_file_id or
+            o.owned_file_id == avatar_or_listing.bin_owned_file_id or
+            o.owned_file_id == avatar_or_listing.thumbnail_owned_file_id or
+            o.owned_file_id == avatar_or_listing.base_map_owned_file_id or
+            o.owned_file_id == avatar_or_listing.emissive_map_owned_file_id or
+            o.owned_file_id == avatar_or_listing.normal_map_owned_file_id or
+            o.owned_file_id == avatar_or_listing.orm_map_owned_file_id,
+        where: o.account_id == ^old_account.account_id
+      ),
+      set: [account_id: new_account.account_id]
+    )
+  end
+
+  defp reassign_scene_listings(%Account{} = old_account, %Account{} = new_account) do
+    reassign_owned_files_for_scene_listings(old_account, new_account)
+
+    Repo.update_all(
+      from(sc in Scene,
+        join: sl in SceneListing,
+        on: sc.scene_id == sl.scene_id,
+        where: sc.account_id == ^old_account.account_id
+      ),
+      set: [account_id: new_account.account_id]
+    )
+  end
+
+  defp reassign_owned_files_for_scene_listings(%Account{} = old_account, %Account{} = new_account) do
+    Repo.update_all(
+      from(o in OwnedFile,
+        join: sl in SceneListing,
+        join: sc in Scene,
+        on:
+          (o.owned_file_id == sl.model_owned_file_id or
+             o.owned_file_id == sl.screenshot_owned_file_id or
+             o.owned_file_id == sl.scene_owned_file_id) and
+            sl.scene_id == sc.scene_id,
+        where: sc.account_id == ^old_account.account_id
+      ),
+      set: [account_id: new_account.account_id]
+    )
+  end
 end

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -862,6 +862,14 @@ defimpl Canada.Can, for: Ret.Account do
     false
   end
 
+  def can?(
+        %Ret.Account{is_admin: true} = admin_account,
+        :delete_account,
+        %Ret.Account{is_admin: false} = account_to_delete
+      ) do
+    admin_account.account_id !== account_to_delete.account_id
+  end
+
   @owner_actions [:update_hub, :close_hub, :embed_hub, :kick_users, :mute_users, :amplify_audio]
   @object_actions [
     :spawn_and_move_media,

--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -30,6 +30,17 @@ defmodule RetWeb.Api.V1.AccountController do
     exec_api_create(conn, params, @record_schema, &process_account_update_record/2)
   end
 
+  def delete(conn, params) do
+    current_account = Guardian.Plug.current_resource(conn)
+    account_to_delete = Ret.get_account_by_id(params["id"])
+
+    case Ret.delete_account(current_account, account_to_delete) do
+      :ok -> conn |> put_status(:ok) |> json(%{status: "ok"})
+      {:error, :forbidden} -> conn |> put_status(:forbidden) |> json(%{error: "forbidden"}) |> halt()
+      {:error, _} -> conn |> put_status(:internal_server_error) |> json(%{error: "error"}) |> halt()
+    end
+  end
+
   defp process_account_update_record(%{"email" => email} = params, source) do
     if !Account.exists_for_email?(email) do
       {:error, [{:RECORD_DOES_NOT_EXIST, "Account with email does not exist.", source}]}

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -168,7 +168,7 @@ defmodule RetWeb.Router do
     scope "/v1", as: :api_v1 do
       pipe_through([:admin_required])
       resources("/app_configs", Api.V1.AppConfigController, only: [:index, :create])
-      resources("/accounts", Api.V1.AccountController, only: [:create])
+      resources("/accounts", Api.V1.AccountController, only: [:create, :delete])
       patch("/accounts", Api.V1.AccountController, :update)
       resources("/accounts/search", Api.V1.AccountSearchController, only: [:create])
     end

--- a/priv/repo/migrations/20220820164826_delete_orphaned_data_from_tables_missing_references.exs
+++ b/priv/repo/migrations/20220820164826_delete_orphaned_data_from_tables_missing_references.exs
@@ -1,0 +1,35 @@
+defmodule Ret.Repo.Migrations.DeleteOrphanedDataFromTablesMissingReferences do
+  @moduledoc """
+  This migration prepares the database for the migration that immediately follows it.
+  Here we delete orphaned data, where an administrator might have manually, and partially
+  deleted records that were referenced by these tables. The following migration adds
+  those references to ensure constraints going forward.
+  """
+  use Ecto.Migration
+
+  @missing_references [
+    # table, primary_key, foreign_table, column
+    {:hub_bindings, :hub_binding_id, :hubs, :hub_id},
+    {:hub_invites, :hub_invite_id, :hubs, :hub_id},
+    {:oauth_providers, :oauth_provider_id, :accounts, :account_id},
+    {:web_push_subscriptions, :web_push_subscription_id, :hubs, :hub_id}
+  ]
+
+  def up do
+    for {table, primary_key, foreign_table, column} <- @missing_references do
+      execute("
+        delete from #{table}
+        using #{table} as tt
+        left join #{foreign_table} as ft
+        on tt.#{column} = ft.#{column}
+        where
+          #{table}.#{primary_key} = tt.#{primary_key} and
+          ft.#{column} is null
+      ")
+    end
+  end
+
+  def down do
+    # Can't un-delete data!
+  end
+end

--- a/priv/repo/migrations/20220915094102_add_foreign_references_and_delete_behaviors_to_tables.exs
+++ b/priv/repo/migrations/20220915094102_add_foreign_references_and_delete_behaviors_to_tables.exs
@@ -1,0 +1,57 @@
+defmodule Ret.Repo.Migrations.AddForeignReferencesAndDeleteBehaviorToTables do
+  use Ecto.Migration
+
+  @missing_references [
+    # table, foreign_table, column, on_delete_action
+    {:hub_bindings, :hubs, :hub_id, :delete_all},
+    {:hub_invites, :hubs, :hub_id, :delete_all},
+    {:oauth_providers, :accounts, :account_id, :delete_all},
+    {:web_push_subscriptions, :hubs, :hub_id, :delete_all}
+  ]
+
+  @missing_on_delete_action [
+    # table, column, foreign_table, foreign_column, on_delete_action
+    {:account_favorites, :account_id, :accounts, :account_id, :delete_all},
+    {:account_favorites, :hub_id, :hubs, :hub_id, :delete_all},
+    {:api_credentials, :account_id, :accounts, :account_id, :delete_all},
+    {:hub_role_memberships, :account_id, :accounts, :account_id, :delete_all},
+    {:hub_role_memberships, :hub_id, :hubs, :hub_id, :delete_all},
+    {:hubs, :created_by_account_id, :accounts, :account_id, :delete_all},
+    {:projects, :parent_scene_id, :scenes, :scene_id, :nilify_all},
+    {:room_objects, :account_id, :accounts, :account_id, :delete_all},
+    {:room_objects, :hub_id, :hubs, :hub_id, :delete_all},
+    {:scenes, :parent_scene_id, :scenes, :scene_id, :nilify_all}
+  ]
+
+  def up do
+    for {table, foreign_table, column, on_delete_action} <- @missing_references do
+      add_foreign_reference(table, column, foreign_table, column, on_delete: on_delete_action)
+    end
+
+    for {table, column, foreign_table, foreign_column, on_delete_action} <- @missing_on_delete_action do
+      execute_drop_foreign_constraint(table, column)
+      add_foreign_reference(table, column, foreign_table, foreign_column, on_delete: on_delete_action)
+    end
+  end
+
+  def down do
+    for {table, _foreign_table, column, _on_delete_action} <- @missing_references do
+      execute_drop_foreign_constraint(table, column)
+    end
+
+    for {table, column, foreign_table, foreign_column, _on_delete_action} <- @missing_on_delete_action do
+      execute_drop_foreign_constraint(table, column)
+      add_foreign_reference(table, column, foreign_table, foreign_column, on_delete: :nothing)
+    end
+  end
+
+  defp execute_drop_foreign_constraint(table, column) do
+    execute("alter table #{table} drop constraint #{table}_#{column}_fkey")
+  end
+
+  defp add_foreign_reference(table, column, foreign_table, foreign_column, on_delete: on_delete_action) do
+    alter table(table) do
+      modify(column, references(foreign_table, column: foreign_column, on_delete: on_delete_action))
+    end
+  end
+end

--- a/test/ret_test.exs
+++ b/test/ret_test.exs
@@ -1,0 +1,646 @@
+defmodule RetTest do
+  use Ret.DataCase
+  import Ecto.Query, only: [from: 2]
+  import Ret.TestHelpers, only: [create_admin_account: 1, create_account: 1, generate_temp_owned_file: 1]
+
+  alias Ret.{
+    Account,
+    AccountFavorite,
+    Api,
+    Asset,
+    Avatar,
+    AvatarListing,
+    Hub,
+    HubBinding,
+    HubInvite,
+    HubRoleMembership,
+    Identity,
+    Login,
+    OAuthProvider,
+    OwnedFile,
+    Project,
+    ProjectAsset,
+    Repo,
+    RoomObject,
+    Scene,
+    SceneListing,
+    Sids,
+    Storage,
+    WebPushSubscription
+  }
+
+  describe "account deletion" do
+    test "deletes account, login, identity, oauthproviders, and api_credentials" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      test_account = create_account("test")
+
+      Account.set_identity!(test_account, "test identity")
+
+      Repo.insert(%OAuthProvider{
+        source: :discord,
+        account: test_account,
+        provider_account_id: "discord-test-user"
+      })
+
+      Api.TokenUtils.gen_token_for_account(test_account)
+
+      %Account{} = Ret.get_account_by_id(test_account.account_id)
+      1 = count(Login, test_account)
+      1 = count(Identity, test_account)
+      1 = count(OAuthProvider, test_account)
+      1 = count(Api.Credentials, test_account)
+
+      assert :ok = Ret.delete_account(admin_account, test_account)
+
+      assert nil === Ret.get_account_by_id(test_account.account_id)
+      assert 0 === count(Login, test_account)
+      assert 0 === count(Identity, test_account)
+      assert 0 === count(OAuthProvider, test_account)
+      assert 0 === count(Api.Credentials, test_account)
+    end
+
+    test "deletes hub and associated entities" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      test_account = create_account("test")
+      test_hub_member_account = create_account("test_member")
+
+      {:ok, hub} =
+        Repo.insert(%Hub{
+          name: "test hub",
+          slug: "fake test slug",
+          created_by_account: test_account
+        })
+
+      Repo.insert(%HubBinding{
+        hub: hub,
+        type: :discord,
+        community_id: "fake-community-id",
+        channel_id: "fake-channel-id"
+      })
+
+      Repo.insert(%AccountFavorite{
+        hub: hub,
+        account: test_account
+      })
+
+      Repo.insert(%HubInvite{
+        hub: hub,
+        hub_invite_sid: "fake-invite-sid"
+      })
+
+      Repo.insert(%HubRoleMembership{
+        hub: hub,
+        account: test_hub_member_account
+      })
+
+      Repo.insert(%RoomObject{
+        hub: hub,
+        account: test_account,
+        object_id: "fake object id",
+        gltf_node: "fake gltf node"
+      })
+
+      Repo.insert(%WebPushSubscription{
+        hub: hub,
+        endpoint: "fake-endpoint",
+        p256dh: "fake-key",
+        auth: "fake-auth-key"
+      })
+
+      1 = count(Hub, test_account)
+      1 = count(AccountFavorite, hub)
+      1 = count(HubBinding, hub)
+      1 = count(HubInvite, hub)
+      1 = count(HubRoleMembership, hub)
+      1 = count(RoomObject, hub)
+      1 = count(WebPushSubscription, hub)
+
+      assert :ok = Ret.delete_account(admin_account, test_account)
+
+      assert 0 === count(Hub, test_account)
+      assert 0 === count(AccountFavorite, hub)
+      assert 0 === count(HubBinding, hub)
+      assert 0 === count(HubInvite, hub)
+      assert 0 === count(HubRoleMembership, hub)
+      assert 0 === count(RoomObject, hub)
+      assert 0 === count(WebPushSubscription, hub)
+    end
+
+    test "deletes entities associated with an account, even when they belong to a hub owned by another account" do
+      {:ok, admin_account: admin_account} = create_admin_account("test_admin")
+      hub_owner = create_account("test_owner")
+      hub_user = create_account("test_user")
+
+      {:ok, hub} =
+        Repo.insert(%Hub{
+          name: "test hub",
+          slug: "fake test slug",
+          created_by_account: hub_owner
+        })
+
+      Repo.insert(%AccountFavorite{
+        hub: hub,
+        account: hub_user
+      })
+
+      Repo.insert(%HubRoleMembership{
+        hub: hub,
+        account: hub_user
+      })
+
+      Repo.insert(%RoomObject{
+        hub: hub,
+        account: hub_user,
+        object_id: "fake object id",
+        gltf_node: "fake gltf node"
+      })
+
+      1 = count(Hub, hub_owner)
+      1 = count(AccountFavorite, hub)
+      1 = count(HubRoleMembership, hub)
+      1 = count(RoomObject, hub)
+
+      assert :ok = Ret.delete_account(admin_account, hub_user)
+
+      assert 1 === count(Hub, hub_owner)
+      assert 0 === count(AccountFavorite, hub)
+      assert 0 === count(HubRoleMembership, hub)
+      assert 0 === count(RoomObject, hub)
+    end
+
+    test "deletes entities associated with hub, even when they belong to a hub owned by another account" do
+      {:ok, admin_account: admin_account} = create_admin_account("test_admin")
+      hub_owner = create_account("test_owner")
+      hub_user = create_account("test_user")
+
+      {:ok, hub} =
+        Repo.insert(%Hub{
+          name: "test hub",
+          slug: "fake test slug",
+          created_by_account: hub_owner
+        })
+
+      Repo.insert(%AccountFavorite{
+        hub: hub,
+        account: hub_user
+      })
+
+      Repo.insert(%HubRoleMembership{
+        hub: hub,
+        account: hub_user
+      })
+
+      Repo.insert(%RoomObject{
+        hub: hub,
+        account: hub_user,
+        object_id: "fake object id",
+        gltf_node: "fake gltf node"
+      })
+
+      1 = count(AccountFavorite, hub_user)
+      1 = count(HubRoleMembership, hub_user)
+      1 = count(RoomObject, hub_user)
+
+      assert :ok = Ret.delete_account(admin_account, hub_owner)
+
+      assert 0 === count(AccountFavorite, hub_user)
+      assert 0 === count(HubRoleMembership, hub_user)
+      assert 0 === count(RoomObject, hub_user)
+    end
+
+    test "deletes account's avatars" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      test_account = create_account("test")
+
+      [_avatar, avatar_owned_files] = create_avatar(test_account)
+
+      1 = count(Avatar, test_account)
+      7 = count(OwnedFile, test_account)
+      true = owned_files_exist?(avatar_owned_files)
+
+      assert :ok = Ret.delete_account(admin_account, test_account)
+
+      assert 0 === count(Avatar, test_account)
+      assert 0 === count(OwnedFile, test_account)
+      refute owned_files_exist?(avatar_owned_files)
+    end
+
+    test "listed avatars are reassigned to admin account" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+
+      [avatar, avatar_owned_files] = create_avatar(target_account)
+      create_avatar_listing(avatar)
+
+      1 = count(Avatar, target_account)
+      7 = count(OwnedFile, target_account)
+
+      0 = count(Avatar, admin_account)
+      0 = count(OwnedFile, admin_account)
+      1 = count(AvatarListing)
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+
+      assert 0 === count(Avatar, target_account)
+      assert 0 === count(OwnedFile, target_account)
+
+      assert 1 === count(Avatar, admin_account)
+      assert 7 === count(OwnedFile, admin_account)
+      assert 1 === count(AvatarListing)
+
+      assert owned_files_exist?(avatar_owned_files)
+    end
+
+    test "parent avatars are reassigned to admin account" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+      other_account = create_account("other")
+
+      [avatar, avatar_owned_files] = create_avatar(target_account)
+      create_child_avatar(avatar, other_account)
+
+      1 = count(Avatar, target_account)
+      7 = count(OwnedFile, target_account)
+
+      1 = count(Avatar, other_account)
+      0 = count(OwnedFile, other_account)
+
+      0 = count(Avatar, admin_account)
+      0 = count(OwnedFile, admin_account)
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+
+      assert 0 === count(Avatar, target_account)
+      assert 0 === count(OwnedFile, target_account)
+
+      assert 1 === count(Avatar, other_account)
+      assert 0 === count(OwnedFile, other_account)
+
+      assert 1 === count(Avatar, admin_account)
+      assert 7 === count(OwnedFile, admin_account)
+
+      assert owned_files_exist?(avatar_owned_files)
+    end
+
+    test "deletes projects and assets" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+
+      project = create_project(target_account)
+      create_project_asset(project, create_asset(target_account))
+      create_asset(target_account)
+
+      1 = count(Project, target_account)
+      1 = count(ProjectAsset, project)
+      2 = count(Asset, target_account)
+      6 = count(OwnedFile, target_account)
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+
+      assert 0 === count(Project, target_account)
+      assert 0 === count(ProjectAsset, project)
+      assert 0 === count(Asset, target_account)
+      assert 0 === count(OwnedFile, target_account)
+    end
+
+    test "deletes scenes" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+
+      project = create_project(target_account)
+      create_scene(project, target_account)
+
+      1 = count(Project, target_account)
+      1 = count(Scene, target_account)
+      5 = count(OwnedFile, target_account)
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+
+      assert 0 === count(Project, target_account)
+      assert 0 === count(Scene, target_account)
+      assert 0 === count(OwnedFile, target_account)
+    end
+
+    test "deletes scene with a project that shares files" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+
+      [
+        json_owned_file,
+        image_owned_file,
+        model_owned_file
+      ] = generate_temp_owned_files(3, target_account)
+
+      {:ok, project} =
+        Repo.insert(%Project{
+          created_by_account_id: target_account.account_id,
+          name: "fake project",
+          project_owned_file: json_owned_file,
+          thumbnail_owned_file: image_owned_file
+        })
+
+      {:ok, scene} =
+        Repo.insert(%Scene{
+          account_id: target_account.account_id,
+          name: "fake scene",
+          slug: "fake-scene-slug",
+          scene_owned_file: json_owned_file,
+          screenshot_owned_file: image_owned_file,
+          model_owned_file: model_owned_file
+        })
+
+      project |> Ecto.Changeset.change(scene_id: scene.scene_id) |> Repo.update!()
+
+      1 = count(Project, target_account)
+      1 = count(Scene, target_account)
+      3 = count(OwnedFile, target_account)
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+
+      assert 0 === count(Project, target_account)
+      assert 0 === count(Scene, target_account)
+      assert 0 === count(OwnedFile, target_account)
+    end
+
+    test "deletes parent scenes" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+      other_account = create_account("other")
+
+      project = create_project(target_account)
+      scene = create_scene(project, target_account)
+
+      other_project =
+        other_account
+        |> create_project()
+        |> Ecto.Changeset.change(parent_scene_id: scene.scene_id)
+        |> Repo.update!()
+
+      other_project
+      |> create_scene(other_account)
+      |> Ecto.Changeset.change(parent_scene_id: scene.scene_id)
+      |> Repo.update!()
+
+      1 = count(Project, target_account)
+      1 = count(Scene, target_account)
+      1 = count(Project, other_account)
+      1 = count(Scene, other_account)
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+
+      assert 0 === count(Project, target_account)
+      assert 0 === count(Scene, target_account)
+      assert 1 === count(Project, other_account)
+      assert 1 === count(Scene, other_account)
+    end
+
+    test "listed scenes are reassigned to admin account" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+
+      project = create_project(target_account)
+      scene = create_scene(project, target_account)
+      scene_listing = create_scene_listing(scene)
+
+      1 = count(Project, target_account)
+      1 = count(Scene, target_account)
+
+      5 = count(OwnedFile, target_account)
+      true = target_account.account_id === scene.account_id
+      true = scene.scene_id === scene_listing.scene_id
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+      updated_scene = Repo.get!(Scene, scene.scene_id)
+      updated_scene_listing = Repo.get!(SceneListing, scene_listing.scene_listing_id)
+
+      assert 0 === count(Project, target_account)
+      assert 0 === count(Scene, target_account)
+
+      assert 3 === count(OwnedFile, admin_account)
+      assert admin_account.account_id === updated_scene.account_id
+      assert scene.scene_id === updated_scene_listing.scene_id
+    end
+
+    test "deletes owned files" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      target_account = create_account("target")
+
+      owned_files = generate_temp_owned_files(3, target_account)
+
+      3 = count(OwnedFile, target_account)
+      true = owned_files_exist?(owned_files)
+
+      assert :ok = Ret.delete_account(admin_account, target_account)
+
+      assert 0 === count(OwnedFile, target_account)
+      refute owned_files_exist?(owned_files)
+    end
+
+    test "only admin accounts can delete accounts" do
+      test_account = create_account("test")
+      target_account = create_account("target")
+
+      1 = count(Account, target_account)
+
+      assert {:error, :forbidden} = Ret.delete_account(test_account, target_account)
+
+      assert 1 === count(Account, target_account)
+    end
+
+    test "cannot delete admin account" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+      {:ok, admin_account: other_account} = create_admin_account("other")
+
+      1 = count(Account, other_account)
+
+      assert {:error, :forbidden} = Ret.delete_account(admin_account, other_account)
+
+      assert 1 === count(Account, other_account)
+    end
+
+    test "cannot delete own account" do
+      {:ok, admin_account: admin_account} = create_admin_account("admin")
+
+      1 = count(Account, admin_account)
+
+      assert {:error, :forbidden} = Ret.delete_account(admin_account, admin_account)
+
+      assert 1 === count(Account, admin_account)
+    end
+  end
+
+  defp create_scene_listing(%Scene{} = scene) do
+    {:ok, scene_listing} =
+      Repo.insert(%SceneListing{
+        scene_id: scene.scene_id,
+        name: "fake scene listing",
+        slug: "fake-scene-listing-slug",
+        scene_owned_file: scene.scene_owned_file,
+        screenshot_owned_file: scene.screenshot_owned_file,
+        model_owned_file: scene.model_owned_file
+      })
+
+    scene_listing
+  end
+
+  defp create_scene(%Project{} = project, %Account{} = account) do
+    scene_owned_files = generate_temp_owned_files(3, account)
+
+    [scene_owned_file, screenshot_owned_file, model_owned_file] = scene_owned_files
+
+    {:ok, scene} =
+      Repo.insert(%Scene{
+        account_id: account.account_id,
+        name: "fake scene",
+        slug: "fake-scene-slug",
+        scene_owned_file: scene_owned_file,
+        screenshot_owned_file: screenshot_owned_file,
+        model_owned_file: model_owned_file
+      })
+
+    project |> Ecto.Changeset.change(scene_id: scene.scene_id) |> Repo.update!()
+
+    scene
+  end
+
+  defp create_project(%Account{} = account) do
+    project_owned_files = generate_temp_owned_files(2, account)
+
+    [project_owned_file, thumbnail_owned_file] = project_owned_files
+
+    {:ok, project} =
+      Repo.insert(%Project{
+        created_by_account_id: account.account_id,
+        name: "fake project",
+        project_owned_file: project_owned_file,
+        thumbnail_owned_file: thumbnail_owned_file
+      })
+
+    project
+  end
+
+  defp create_asset(%Account{} = account) do
+    asset_owned_files = generate_temp_owned_files(2, account)
+
+    [asset_owned_file, thumbnail_owned_file] = asset_owned_files
+
+    {:ok, asset} =
+      Repo.insert(%Asset{
+        account_id: account.account_id,
+        name: "fake asset",
+        asset_sid: "fake-asset-sid-#{Sids.generate_sid()}",
+        type: :image,
+        asset_owned_file: asset_owned_file,
+        thumbnail_owned_file: thumbnail_owned_file
+      })
+
+    asset
+  end
+
+  defp create_project_asset(%Project{} = project, %Asset{} = asset) do
+    Repo.insert(%ProjectAsset{
+      project_id: project.project_id,
+      asset_id: asset.asset_id
+    })
+  end
+
+  defp create_avatar(%Account{} = account) do
+    avatar_owned_files = generate_temp_owned_files(7, account)
+
+    [
+      gltf_owned_file,
+      bin_owned_file,
+      thumbnail_owned_file,
+      base_map_owned_file,
+      emissive_map_owned_file,
+      normal_map_owned_file,
+      orm_map_owned_file
+    ] = avatar_owned_files
+
+    {:ok, avatar} =
+      Repo.insert(%Avatar{
+        account_id: account.account_id,
+        name: "fake avatar",
+        slug: "fake-avatar-slug",
+        avatar_sid: "fake-avatar-sid",
+        gltf_owned_file: gltf_owned_file,
+        bin_owned_file: bin_owned_file,
+        thumbnail_owned_file: thumbnail_owned_file,
+        base_map_owned_file: base_map_owned_file,
+        emissive_map_owned_file: emissive_map_owned_file,
+        normal_map_owned_file: normal_map_owned_file,
+        orm_map_owned_file: orm_map_owned_file
+      })
+
+    [avatar, avatar_owned_files]
+  end
+
+  defp create_avatar_listing(%Avatar{} = avatar) do
+    Repo.insert(%AvatarListing{
+      avatar_id: avatar.avatar_id,
+      name: "fake avatar listing",
+      slug: "fake-avatar-listing-slug",
+      avatar_listing_sid: "fake-avatar-listing-sid",
+      gltf_owned_file: avatar.gltf_owned_file,
+      bin_owned_file: avatar.bin_owned_file,
+      thumbnail_owned_file: avatar.thumbnail_owned_file,
+      base_map_owned_file: avatar.base_map_owned_file,
+      emissive_map_owned_file: avatar.emissive_map_owned_file,
+      normal_map_owned_file: avatar.normal_map_owned_file,
+      orm_map_owned_file: avatar.orm_map_owned_file
+    })
+  end
+
+  defp create_child_avatar(%Avatar{} = avatar, %Account{} = account) do
+    Repo.insert(%Avatar{
+      account_id: account.account_id,
+      parent_avatar_id: avatar.avatar_id,
+      name: "fake child avatar",
+      slug: "fake-child-avatar-slug",
+      avatar_sid: "fake-child-avatar-sid"
+    })
+  end
+
+  defp owned_files_exist?(owned_files) when is_list(owned_files) do
+    Enum.all?(owned_files, fn owned_file ->
+      [_base_path, meta_file_path, blob_file_path] = Storage.paths_for_owned_file(owned_file)
+      File.exists?(meta_file_path) and File.exists?(blob_file_path)
+    end)
+  end
+
+  defp generate_temp_owned_files(num_files, %Account{} = account) when is_integer(num_files) do
+    Stream.repeatedly(fn -> generate_temp_owned_file(account) end) |> Enum.take(num_files)
+  end
+
+  defp count(queryable, %Account{} = account) when queryable in [Hub, Project] do
+    Ret.Repo.aggregate(
+      from(record in queryable, where: record.created_by_account_id == ^account.account_id),
+      :count
+    )
+  end
+
+  defp count(queryable, %Account{} = account) do
+    Ret.Repo.aggregate(
+      from(record in queryable, where: record.account_id == ^account.account_id),
+      :count
+    )
+  end
+
+  defp count(queryable, %Hub{} = hub) do
+    Ret.Repo.aggregate(
+      from(record in queryable, where: record.hub_id == ^hub.hub_id),
+      :count
+    )
+  end
+
+  defp count(queryable, %Project{} = project) do
+    Ret.Repo.aggregate(
+      from(record in queryable, where: record.project_id == ^project.project_id),
+      :count
+    )
+  end
+
+  defp count(queryable) do
+    Ret.Repo.aggregate(queryable, :count)
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -54,8 +54,8 @@ defmodule Ret.TestHelpers do
     {:ok, account: create_account("test"), account2: create_account("test2")}
   end
 
-  def create_admin_account(_) do
-    {:ok, admin_account: create_account("test", true)}
+  def create_admin_account(prefix) do
+    {:ok, admin_account: create_account(prefix, true)}
   end
 
   def create_owned_file(%{account: account}) do


### PR DESCRIPTION
This amends the account deletion migration to ensure that handles cases where existing databases do not match the new constraints that we're adding. It will delete orphaned data when data was manually deleted in the database. For example, if a hub had a hub_invite, and then the hub was deleted while the hub_invite remained, the migration will delete hub_invites that no longer have hubs associated with them. It does this for all tables and columns where we are adding foreign key reference.