### PR TITLE
Hub Account Deletion

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 [
   line_length: 120,
-  import_deps: [:phoenix],
+  import_deps: [:phoenix, :stream_data],
   inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/lib/ret.ex
+++ b/lib/ret.ex
@@ -1,12 +1,11 @@
 defmodule Ret do
   @moduledoc """
-  Ret keeps the contexts that define your domain
-  and business logic.
-
-  Contexts are also responsible for managing your data, regardless
-  if it comes from the database, an external API or others.
+  The boundary of the Ret context.
   """
-  alias Ret.{Account, Login, Repo}
+  alias Ret.{Account, Asset, Avatar, AvatarListing, Login, OwnedFile, Project, Repo, Scene, SceneListing, Storage}
+  import Canada, only: [can?: 2]
+  import Ret.Schema, only: [is_serial_id: 1]
+  require Ecto.Query
 
   def change_email_for_login(%{old_email: old_email, new_email: new_email}) do
     if not valid_email_address?(new_email) do
@@ -40,4 +39,185 @@ defmodule Ret do
   defp valid_email_address?(string) do
     string =~ ~r/\S+@\S+/
   end
+
+  @doc """
+  Obliterates the account with the given `account_id` and all its owned assets.
+
+  Returns `:ok` if successful, otherwise it returns `{:error, reason}`.
+
+  Error reasons are:
+
+  * `:forbidden` - the current user does not have sufficient authorization or
+    an account could not be found with the given `account_id`
+  * `:failed` - the account data was unable to be deleted for an unknown reason
+
+  """
+  @spec delete_account(Account.id(), Account.t()) :: :ok | {:error, :forbidden | :failed}
+  def delete_account(account_id, %Account{} = current_user) when is_serial_id(account_id) do
+    account_to_delete = Repo.get(Account, account_id)
+
+    cond do
+      !account_to_delete ->
+        {:error, :forbidden}
+
+      not can?(current_user, delete_account(account_to_delete)) ->
+        {:error, :forbidden}
+
+      true ->
+        reassignment = [set: [account_id: current_user.account_id]]
+
+        Ecto.Multi.new()
+        |> Ecto.Multi.delete_all(:delete_assets, asset_query(account_id))
+        |> Ecto.Multi.delete_all(:delete_projects, project_query(account_id))
+        |> delete_avatars_multi(account_id, reassignment)
+        |> delete_scenes_multi(account_id, reassignment)
+        |> delete_owned_files_multi(account_id)
+        |> Ecto.Multi.delete(:delete_account, account_to_delete)
+        |> Repo.transaction()
+        |> case do
+          {:ok, _} ->
+            :ok
+
+          {:error, _} ->
+            {:error, :failed}
+        end
+    end
+  end
+
+  @spec account_owned_file_query(Account.id()) :: Ecto.Query.t()
+  defp account_owned_file_query(account_id) when is_serial_id(account_id),
+    do: Ecto.Query.where(OwnedFile, account_id: ^account_id)
+
+  @spec asset_query(Account.id()) :: Ecto.Query.t()
+  defp asset_query(account_id) when is_serial_id(account_id),
+    do: Ecto.Query.where(Asset, account_id: ^account_id)
+
+  @spec avatar_owned_file_query(Account.id()) :: Ecto.Query.t()
+  defp avatar_owned_file_query(account_id) when is_serial_id(account_id),
+    do:
+      Ecto.Query.from(owned_file in OwnedFile,
+        join: avatar in Avatar,
+        on:
+          owned_file.owned_file_id == avatar.gltf_owned_file_id or
+            owned_file.owned_file_id == avatar.bin_owned_file_id or
+            owned_file.owned_file_id == avatar.thumbnail_owned_file_id or
+            owned_file.owned_file_id == avatar.base_map_owned_file_id or
+            owned_file.owned_file_id == avatar.emissive_map_owned_file_id or
+            owned_file.owned_file_id == avatar.normal_map_owned_file_id or
+            owned_file.owned_file_id == avatar.orm_map_owned_file_id,
+        where: avatar.account_id == ^account_id
+      )
+
+  @spec avatar_query(Account.id()) :: Ecto.Query.t()
+  defp avatar_query(account_id) when is_serial_id(account_id),
+    do: Ecto.Query.where(Avatar, account_id: ^account_id)
+
+  @spec delete_avatars_multi(Ecto.Multi.t(), Account.id(), Keyword.t()) :: Ecto.Multi.t()
+  defp delete_avatars_multi(%Ecto.Multi{} = multi, account_id, reassignment)
+       when is_serial_id(account_id) and is_list(reassignment),
+       do:
+         multi
+         |> Ecto.Multi.update_all(:reassign_avatar_owned_files, avatar_owned_file_query(account_id), reassignment)
+         |> Ecto.Multi.update_all(:reassign_listed_avatars, listed_avatar_query(account_id), reassignment)
+         |> Ecto.Multi.update_all(:reassign_parent_avatars, parent_avatar_query(account_id), reassignment)
+         |> ecto_multi_all(:avatar_owned_files, avatar_owned_file_query(account_id))
+         |> Ecto.Multi.delete_all(:delete_avatars, avatar_query(account_id))
+         |> Ecto.Multi.run(:delete_avatar_owned_files, &delete_owned_files(&2.avatar_owned_files, &1))
+
+  @spec delete_owned_files([OwnedFile.t()], module) :: {:ok, nil} | {:error, Ecto.Changeset.t(OwnedFile.t())}
+  defp delete_owned_files(owned_files, repo) when is_list(owned_files) and is_atom(repo) do
+    Enum.reduce_while(owned_files, {:ok, nil}, fn owned_file, acc ->
+      with {:ok, _} <- OwnedFile.set_inactive(owned_file),
+           Storage.rm_files_for_owned_file(owned_file),
+           {:ok, _} <- repo.delete(owned_file) do
+        {:cont, acc}
+      else
+        error ->
+          {:halt, error}
+      end
+    end)
+  end
+
+  @spec delete_owned_files_multi(Ecto.Multi.t(), Account.id()) :: Ecto.Multi.t()
+  defp delete_owned_files_multi(%Ecto.Multi{} = multi, account_id) when is_serial_id(account_id),
+    do:
+      multi
+      |> ecto_multi_all(:account_owned_files, account_owned_file_query(account_id))
+      |> Ecto.Multi.run(:delete_account_owned_files, &delete_owned_files(&2.account_owned_files, &1))
+
+  @spec delete_scenes_multi(Ecto.Multi.t(), Account.id(), Keyword.t()) :: Ecto.Multi.t()
+  defp delete_scenes_multi(%Ecto.Multi{} = multi, account_id, reassignment)
+       when is_serial_id(account_id) and is_list(reassignment),
+       do:
+         multi
+         |> Ecto.Multi.update_all(:reassign_scene_owned_files, scene_owned_file_query(account_id), reassignment)
+         |> Ecto.Multi.update_all(:reassign_listed_scenes, listed_scene_query(account_id), reassignment)
+         |> Ecto.Multi.update_all(:reassign_parent_scenes, parent_scene_query(account_id), reassignment)
+         |> ecto_multi_all(:scene_owned_files, scene_owned_file_query(account_id))
+         |> Ecto.Multi.delete_all(:delete_scenes, scene_query(account_id))
+         |> Ecto.Multi.run(:delete_scene_owned_files, &delete_owned_files(&2.scene_owned_files, &1))
+
+  # TODO: Replace calls with Ecto.Multi.all/3 after Ecto updgrade
+  @spec ecto_multi_all(Ecto.Multi.t(), atom, Ecto.Query.t()) :: Ecto.Multi.t()
+  defp ecto_multi_all(%Ecto.Multi{} = multi, name, %Ecto.Query{} = query) when is_atom(name) do
+    Ecto.Multi.run(multi, name, fn repo, _changes ->
+      {:ok, repo.all(query)}
+    end)
+  end
+
+  @spec listed_avatar_query(Account.id()) :: Ecto.Query.t()
+  defp listed_avatar_query(account_id) when is_serial_id(account_id),
+    do:
+      Ecto.Query.from(avatar in Avatar,
+        join: listing in AvatarListing,
+        on: avatar.avatar_id == listing.avatar_id,
+        where: avatar.account_id == ^account_id
+      )
+
+  @spec listed_scene_query(Account.id()) :: Ecto.Query.t()
+  defp listed_scene_query(account_id) when is_serial_id(account_id),
+    do:
+      Ecto.Query.from(scene in Scene,
+        join: listing in SceneListing,
+        on: scene.scene_id == listing.scene_id,
+        where: scene.account_id == ^account_id
+      )
+
+  @spec parent_avatar_query(Account.id()) :: Ecto.Query.t()
+  defp parent_avatar_query(account_id) when is_serial_id(account_id),
+    do:
+      Ecto.Query.from(parent_avatar in Avatar,
+        join: child_avatar in Avatar,
+        on: parent_avatar.avatar_id == child_avatar.parent_avatar_id,
+        where: parent_avatar.account_id == ^account_id
+      )
+
+  @spec parent_scene_query(Account.id()) :: Ecto.Query.t()
+  defp parent_scene_query(account_id) when is_serial_id(account_id),
+    do:
+      Ecto.Query.from(parent_scene in Scene,
+        join: child_scene in Scene,
+        on: parent_scene.scene_id == child_scene.parent_scene_id,
+        where: parent_scene.account_id == ^account_id
+      )
+
+  @spec project_query(Account.id()) :: Ecto.Query.t()
+  defp project_query(account_id) when is_serial_id(account_id),
+    do: Ecto.Query.where(Project, created_by_account_id: ^account_id)
+
+  @spec scene_owned_file_query(Account.id()) :: Ecto.Query.t()
+  defp scene_owned_file_query(account_id) when is_serial_id(account_id),
+    do:
+      Ecto.Query.from(owned_file in OwnedFile,
+        join: scene in Scene,
+        on:
+          owned_file.owned_file_id == scene.model_owned_file_id or
+            owned_file.owned_file_id == scene.screenshot_owned_file_id or
+            owned_file.owned_file_id == scene.scene_owned_file_id,
+        where: scene.account_id == ^account_id
+      )
+
+  @spec scene_query(Account.id()) :: Ecto.Query.t()
+  defp scene_query(account_id) when is_serial_id(account_id),
+    do: Ecto.Query.where(Scene, account_id: ^account_id)
 end

--- a/lib/ret/account.ex
+++ b/lib/ret/account.ex
@@ -6,12 +6,13 @@ defmodule Ret.Account do
 
   import Canada, only: [can?: 2]
 
+  @type id :: pos_integer
   @type t :: %__MODULE__{}
+
+  @account_preloads [:login, :identity]
 
   @schema_prefix "ret0"
   @primary_key {:account_id, :id, autogenerate: true}
-  @account_preloads [:login, :identity]
-
   schema "accounts" do
     field(:min_token_issued_at, :utc_datetime)
     field(:is_admin, :boolean)

--- a/lib/ret/asset.ex
+++ b/lib/ret/asset.ex
@@ -6,9 +6,10 @@ defmodule Ret.Asset do
   alias Ecto.{Multi}
   alias Ret.{Repo, Asset, ProjectAsset}
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:asset_id, :id, autogenerate: true}
-
   schema "assets" do
     field(:asset_sid, :string)
     field(:name, :string)

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -14,21 +14,13 @@ defmodule Ret.Avatar do
   alias Ret.{Avatar, AvatarListing, Repo, OwnedFile, Account, Sids, Storage}
   alias Ret.Avatar.{AvatarSlug}
 
-  @schema_prefix "ret0"
-  @primary_key {:avatar_id, :id, autogenerate: true}
+  @type t :: %__MODULE__{}
 
-  @image_columns [
-    :base_map_owned_file,
-    :emissive_map_owned_file,
-    :normal_map_owned_file,
-    :orm_map_owned_file
-  ]
-
+  @image_columns [:base_map_owned_file, :emissive_map_owned_file, :normal_map_owned_file, :orm_map_owned_file]
   @file_columns [:gltf_owned_file, :bin_owned_file, :thumbnail_owned_file] ++ @image_columns
 
-  def image_columns, do: @image_columns
-  def file_columns, do: @file_columns
-
+  @schema_prefix "ret0"
+  @primary_key {:avatar_id, :id, autogenerate: true}
   schema "avatars" do
     field(:avatar_sid, :string)
     field(:slug, AvatarSlug.Type)
@@ -65,6 +57,10 @@ defmodule Ret.Avatar do
 
     timestamps()
   end
+
+  def file_columns, do: @file_columns
+
+  def image_columns, do: @image_columns
 
   def load_parents(nil, _preload_fields), do: nil
 

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -13,9 +13,10 @@ defmodule Ret.AvatarListing do
   alias Ret.{AvatarListing, OwnedFile, Avatar, Account}
   alias AvatarListing.{AvatarListingSlug}
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:avatar_listing_id, :id, autogenerate: true}
-
   schema "avatar_listings" do
     field(:avatar_listing_sid, :string)
     field(:slug, AvatarListingSlug.Type)

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -862,6 +862,14 @@ defimpl Canada.Can, for: Ret.Account do
     false
   end
 
+  def can?(
+        %Ret.Account{is_admin: true} = admin_account,
+        :delete_account,
+        %Ret.Account{is_admin: false} = account_to_delete
+      ) do
+    admin_account.account_id !== account_to_delete.account_id
+  end
+
   @owner_actions [:update_hub, :close_hub, :embed_hub, :kick_users, :mute_users, :amplify_audio]
   @object_actions [
     :spawn_and_move_media,

--- a/lib/ret/owned_file.ex
+++ b/lib/ret/owned_file.ex
@@ -4,9 +4,10 @@ defmodule Ret.OwnedFile do
   import Ecto.Changeset
   alias Ret.{Repo, OwnedFile, Account}
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:owned_file_id, :id, autogenerate: true}
-
   schema "owned_files" do
     field(:owned_file_uuid, :string)
     field(:key, :string)

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -9,7 +9,6 @@ defmodule Ret.Project do
 
   @schema_prefix "ret0"
   @primary_key {:project_id, :id, autogenerate: true}
-
   schema "projects" do
     field(:project_sid, :string)
     field(:name, :string)

--- a/lib/ret/project_asset.ex
+++ b/lib/ret/project_asset.ex
@@ -2,9 +2,10 @@ defmodule Ret.ProjectAsset do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:project_asset_id, :id, autogenerate: true}
-
   schema "project_assets" do
     belongs_to(:project, Ret.Project, references: :project_id)
     belongs_to(:asset, Ret.Asset, references: :asset_id)

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -18,18 +18,6 @@ defmodule Ret.Scene do
 
   @schema_prefix "ret0"
   @primary_key {:scene_id, :id, autogenerate: true}
-
-  @scene_preloads [
-    :parent_scene,
-    :parent_scene_listing,
-    :account,
-    :project,
-    :model_owned_file,
-    :screenshot_owned_file,
-    :scene_owned_file
-  ]
-  def scene_preloads, do: @scene_preloads
-
   schema "scenes" do
     field(:scene_sid, :string)
     field(:slug, SceneSlug.Type)
@@ -56,6 +44,17 @@ defmodule Ret.Scene do
 
     timestamps()
   end
+
+  def scene_preloads,
+    do: [
+      :parent_scene,
+      :parent_scene_listing,
+      :account,
+      :project,
+      :model_owned_file,
+      :screenshot_owned_file,
+      :scene_owned_file
+    ]
 
   def scene_or_scene_listing_by_sid(sid) do
     Scene |> Repo.get_by(scene_sid: sid) ||

--- a/lib/ret/scene_listing.ex
+++ b/lib/ret/scene_listing.ex
@@ -13,9 +13,10 @@ defmodule Ret.SceneListing do
   alias Ret.{Repo, SceneListing, Scene}
   alias Ret.SceneListing.{SceneListingSlug}
 
+  @type t :: %__MODULE__{}
+
   @schema_prefix "ret0"
   @primary_key {:scene_listing_id, :id, autogenerate: true}
-
   schema "scene_listings" do
     field(:scene_listing_sid, :string)
     field(:slug, SceneListingSlug.Type)

--- a/lib/ret/schema.ex
+++ b/lib/ret/schema.ex
@@ -1,0 +1,65 @@
+defmodule Ret.Schema do
+  @moduledoc """
+  Conveniences for working with Ecto schemas.
+  """
+
+  @spec is_struct(term) :: boolean
+  defguardp is_struct(term)
+            when is_map(term) and :erlang.is_map_key(:__struct__, term) and is_atom(:erlang.map_get(:__struct__, term))
+
+  @spec is_struct(term, module) :: boolean
+  defguardp is_struct(term, module)
+            when is_map(term) and
+                   is_atom(module) and
+                   :erlang.is_map_key(:__struct__, term) and
+                   :erlang.map_get(:__struct__, term) === module
+
+  @doc """
+  Determines if a `term` is an Ecto schema.
+
+  Returns `true` if the given `term` is an Ecto schema, otherwise it returns
+  `false`.
+
+  Allowed in guard clauses.
+
+  ## Examples
+
+      iex> Schema.is_schema(%Account{})
+      true
+
+      iex> Schema.is_schema(%Date{})
+      false
+
+      iex> Schema.is_schema(123)
+      false
+
+  """
+  @spec is_schema(term) :: boolean
+  defguard is_schema(term)
+           when is_struct(term) and
+                  :erlang.is_map_key(:__meta__, term) and
+                  is_struct(:erlang.map_get(:__meta__, term), Ecto.Schema.Metadata)
+
+  @doc """
+  Determines if a `term` is a serial ID.
+
+  Returns `true` if the given `term` is a serial ID, otherwise it returns
+  `false`.
+
+  Allowed in guard clauses.
+
+  ## Examples
+
+      iex> Schema.is_serial_id(10)
+      true
+
+      iex> Schema.is_serial_id("7ebc6052-5256-402b-8a8b-b33a5727068b")
+      false
+
+      iex> Schema.is_serial_id(0)
+      false
+
+  """
+  @spec is_serial_id(term) :: boolean
+  defguard is_serial_id(term) when is_integer(term) and term > 0
+end

--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -26,6 +26,28 @@ defmodule RetWeb.Api.V1.AccountController do
     exec_api_create(conn, params, @record_schema, &process_account_create_record/2)
   end
 
+  def delete(conn, %{"id" => id}) do
+    id
+    |> String.to_integer()
+    |> Ret.delete_account(Guardian.Plug.current_resource(conn))
+    |> case do
+      :ok ->
+        json(conn, %{status: "ok"})
+
+      {:error, :forbidden} ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{error: "forbidden"})
+        |> halt()
+
+      {:error, :failed} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> json(%{error: "error"})
+        |> halt()
+    end
+  end
+
   def update(conn, params) do
     exec_api_create(conn, params, @record_schema, &process_account_update_record/2)
   end

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -168,7 +168,7 @@ defmodule RetWeb.Router do
     scope "/v1", as: :api_v1 do
       pipe_through([:admin_required])
       resources("/app_configs", Api.V1.AppConfigController, only: [:index, :create])
-      resources("/accounts", Api.V1.AccountController, only: [:create])
+      resources("/accounts", Api.V1.AccountController, only: [:create, :delete])
       patch("/accounts", Api.V1.AccountController, :update)
       resources("/accounts/search", Api.V1.AccountSearchController, only: [:create])
     end

--- a/mix.exs
+++ b/mix.exs
@@ -91,7 +91,8 @@ defmodule Ret.Mixfile do
       {:ex_rated, "~> 1.3.3"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:ex_json_schema, "~> 0.7.3"},
-      {:observer_cli, "~> 1.5"}
+      {:observer_cli, "~> 1.5"},
+      {:stream_data, "~> 0.5", github: "whatyouhide/stream_data", ref: "c7ef8ef", only: [:dev, :test]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -83,6 +83,7 @@
   "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "statix": {:hex, :statix, "1.4.0", "c822abd1e60e62828e8460e932515d0717aa3c089b44cc3f795d43b94570b3a8", [:mix], [], "hexpm", "507373cc80925a9b6856cb14ba17f6125552434314f6613c907d295a09d1a375"},
+  "stream_data": {:git, "https://github.com/whatyouhide/stream_data.git", "c7ef8ef9c1fe78e6f404272c7129c4eac83db53c", [ref: "c7ef8ef"]},
   "telemetry": {:hex, :telemetry, "0.4.2", "2808c992455e08d6177322f14d3bdb6b625fbcfd233a73505870d8738a2f4599", [:rebar3], [], "hexpm", "2d1419bd9dda6a206d7b5852179511722e2b18812310d304620c7bd92a13fcef"},
   "temp": {:hex, :temp, "0.4.7", "2c78482cc2294020a4bc0c95950b907ff386523367d4e63308a252feffbea9f2", [:mix], [], "hexpm", "6af19e7d6a85a427478be1021574d1ae2a1e1b90882586f06bde76c63cd03e0d"},
   "the_end": {:git, "https://github.com/mozillareality/the_end.git", "978ce97bec3ec754182fa72e24a82eab935a5853", [branch: "bug/phoenix-14"]},

--- a/priv/repo/migrations/20220820164826_delete_orphaned_data_from_tables_missing_references.exs
+++ b/priv/repo/migrations/20220820164826_delete_orphaned_data_from_tables_missing_references.exs
@@ -1,0 +1,29 @@
+defmodule Ret.Repo.Migrations.DeleteOrphanedDataFromTablesMissingReferences do
+  @moduledoc """
+  This migration prepares the database for the migration that immediately follows it.
+  Here we delete orphaned data, where an administrator might have manually, and partially
+  deleted records that were referenced by these tables. The following migration adds
+  those references to ensure constraints going forward.
+  """
+  use Ecto.Migration
+
+  def up do
+    for {table, column, foreign_table} <- [
+          {:hub_bindings, :hub_id, :hubs},
+          {:hub_invites, :hub_id, :hubs},
+          {:oauth_providers, :account_id, :accounts},
+          {:web_push_subscriptions, :hub_id, :hubs}
+        ] do
+      execute("""
+      DELETE FROM #{table}
+      WHERE NOT EXISTS
+        (SELECT *
+           FROM "#{foreign_table}"
+          WHERE "#{table}"."#{column}" = "#{foreign_table}"."#{column}")
+      """)
+    end
+  end
+
+  def down do
+  end
+end

--- a/priv/repo/migrations/20220915094102_add_foreign_references_and_delete_behaviors_to_tables.exs
+++ b/priv/repo/migrations/20220915094102_add_foreign_references_and_delete_behaviors_to_tables.exs
@@ -1,0 +1,57 @@
+defmodule Ret.Repo.Migrations.AddForeignReferencesAndDeleteBehaviorToTables do
+  use Ecto.Migration
+
+  @missing_reference [
+    {:hub_bindings, :hub_id, :hubs},
+    {:hub_invites, :hub_id, :hubs},
+    {:oauth_providers, :account_id, :accounts},
+    {:web_push_subscriptions, :hub_id, :hubs}
+  ]
+
+  @missing_on_delete_action [
+    {:account_favorites, :account_id, :accounts, :account_id},
+    {:account_favorites, :hub_id, :hubs, :hub_id},
+    {:api_credentials, :account_id, :accounts, :account_id},
+    {:hub_role_memberships, :account_id, :accounts, :account_id},
+    {:hub_role_memberships, :hub_id, :hubs, :hub_id},
+    {:hubs, :created_by_account_id, :accounts, :account_id},
+    {:hubs, :scene_id, :scenes, :scene_id},
+    {:room_objects, :account_id, :accounts, :account_id},
+    {:room_objects, :hub_id, :hubs, :hub_id},
+    {:scenes, :parent_scene_id, :scenes, :scene_id}
+  ]
+
+  def up do
+    for {table, column, foreign_table} <- @missing_reference do
+      alter table(table) do
+        modify(column, references(foreign_table, column: column, on_delete: :delete_all))
+      end
+    end
+
+    for {table, column, foreign_table, foreign_column} <- @missing_on_delete_action do
+      drop_foreign_constraint(table, column)
+
+      alter table(table) do
+        modify(column, references(foreign_table, column: foreign_column, on_delete: :delete_all))
+      end
+    end
+  end
+
+  def down do
+    for {table, column, _foreign_table} <- @missing_reference do
+      drop_foreign_constraint(table, column)
+    end
+
+    for {table, column, foreign_table, foreign_column} <- @missing_on_delete_action do
+      drop_foreign_constraint(table, column)
+
+      alter table(table) do
+        modify(column, references(foreign_table, column: foreign_column, on_delete: :nothing))
+      end
+    end
+  end
+
+  @spec drop_foreign_constraint(String.t(), String.t()) :: :ok
+  defp drop_foreign_constraint(table, column) when is_atom(table) and is_atom(column),
+    do: execute("ALTER TABLE #{table} DROP CONSTRAINT #{table}_#{column}_fkey")
+end

--- a/test/ret/schema_test.exs
+++ b/test/ret/schema_test.exs
@@ -1,0 +1,56 @@
+defmodule Ret.SchemaTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ret.{DummySchema, DummyStruct, Schema}
+  require Ret.Schema
+
+  describe "is_schema/1" do
+    test "with an Ecto schema" do
+      assert true === Schema.is_schema(%DummySchema{})
+    end
+
+    test "with a non-schema struct" do
+      assert false === Schema.is_schema(%DummyStruct{})
+    end
+
+    property "with a non-struct map" do
+      check all map <-
+                  string(:printable, max_length: 3)
+                  |> map(&String.to_atom/1)
+                  |> map_of(nil) do
+        assert false === Schema.is_schema(map)
+      end
+    end
+
+    property "with a non-map value" do
+      check all non_map <- filter(term(), &(not is_map(&1))) do
+        assert false === Schema.is_schema(non_map)
+      end
+    end
+  end
+
+  describe "is_serial_id/1" do
+    property "with a positive integer" do
+      check all pos_integer <- positive_integer() do
+        assert true === Schema.is_serial_id(pos_integer)
+      end
+    end
+
+    test "with zero" do
+      assert false === Schema.is_serial_id(0)
+    end
+
+    property "with a negative integer" do
+      check all neg_integer <- map(positive_integer(), &(-&1)) do
+        assert false === Schema.is_serial_id(neg_integer)
+      end
+    end
+
+    property "with a non-integer value" do
+      check all non_integer <- filter(term(), &(not is_integer(&1))) do
+        assert false === Schema.is_serial_id(non_integer)
+      end
+    end
+  end
+end

--- a/test/ret_test.exs
+++ b/test/ret_test.exs
@@ -1,0 +1,682 @@
+defmodule RetTest do
+  use Ret.DataCase
+
+  import Ret.Schema, only: [is_schema: 1]
+  import Ret.TestHelpers, only: [create_admin_account: 1, create_account: 1, generate_temp_owned_file: 1]
+
+  alias Ret.{
+    Account,
+    AccountFavorite,
+    Api,
+    Asset,
+    Avatar,
+    AvatarListing,
+    Hub,
+    HubBinding,
+    HubInvite,
+    HubRoleMembership,
+    Identity,
+    Login,
+    OAuthProvider,
+    OwnedFile,
+    Project,
+    ProjectAsset,
+    Repo,
+    RoomObject,
+    Scene,
+    SceneListing,
+    Sids,
+    Storage,
+    WebPushSubscription
+  }
+
+  describe "delete_account/2" do
+    setup do
+      {:ok, admin_account: current_user} = create_admin_account("current user")
+      %{account_to_delete: create_account("account to delete"), current_user: current_user}
+    end
+
+    test "deletes account", %{account_to_delete: account_to_delete, current_user: current_user} do
+      %Account{} = repo_reload(account_to_delete)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(account_to_delete)
+    end
+
+    test "deletes account owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+      owned_file = generate_temp_owned_file(account_to_delete)
+
+      %OwnedFile{} = repo_reload(owned_file)
+      true = file_on_disk?(owned_file)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(owned_file)
+      refute file_on_disk?(owned_file)
+    end
+
+    test "deletes account favorites", %{account_to_delete: account_to_delete, current_user: current_user} do
+      own_hub = create_hub(account_to_delete)
+      member_hub = create_hub()
+      favorite1 = Repo.insert!(%AccountFavorite{account: account_to_delete, hub: own_hub})
+      favorite2 = Repo.insert!(%AccountFavorite{account: account_to_delete, hub: member_hub})
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(favorite1)
+      refute repo_reload(favorite2)
+    end
+
+    test "deletes API credentials", %{account_to_delete: account_to_delete, current_user: current_user} do
+      Api.TokenUtils.gen_token_for_account(account_to_delete)
+      credentials = Repo.get_by(Api.Credentials, account_id: account_to_delete.account_id)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(credentials)
+    end
+
+    test "deletes assets", %{account_to_delete: account_to_delete, current_user: current_user} do
+      asset = create_asset(account_to_delete)
+
+      %Asset{} = repo_reload(asset)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(asset)
+    end
+
+    test "deletes asset owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+      asset = create_asset(account_to_delete)
+      owned_files = owned_files(asset, [:asset_owned_file, :thumbnail_owned_file])
+
+      for owned_file <- owned_files do
+        %OwnedFile{} = repo_reload(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        refute repo_reload(owned_file)
+        refute file_on_disk?(owned_file)
+      end
+    end
+
+    test "deletes avatars", %{account_to_delete: account_to_delete, current_user: current_user} do
+      avatar = create_avatar(account_to_delete)
+
+      %Avatar{} = repo_reload(avatar)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(avatar)
+    end
+
+    test "deletes avatar owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+      avatar = create_avatar(account_to_delete)
+      owned_files = avatar_owned_files(avatar)
+
+      for owned_file <- owned_files do
+        %OwnedFile{} = repo_reload(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        refute repo_reload(owned_file)
+        refute file_on_disk?(owned_file)
+      end
+    end
+
+    test "reassigns parent avatars to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+      account_to_delete_id = account_to_delete.account_id
+      avatar = create_avatar(account_to_delete)
+      create_child_avatar(avatar)
+
+      %Avatar{account_id: ^account_to_delete_id} = repo_reload(avatar)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert avatar = repo_reload(avatar)
+      assert current_user.account_id === avatar.account_id
+    end
+
+    test "reassigns owned files of parent avatar to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
+      account_to_delete_id = account_to_delete.account_id
+      avatar = create_avatar(account_to_delete)
+      owned_files = avatar_owned_files(avatar)
+      create_child_avatar(avatar)
+
+      for owned_file <- owned_files do
+        ^account_to_delete_id = reload_account_id(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        assert current_user.account_id === reload_account_id(owned_file)
+        assert file_on_disk?(owned_file)
+      end
+    end
+
+    test "reassigns listed avatars to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+      account_to_delete_id = account_to_delete.account_id
+      avatar = create_avatar(account_to_delete)
+      create_avatar_listing(avatar)
+
+      %Avatar{account_id: ^account_to_delete_id} = repo_reload(avatar)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert avatar = repo_reload(avatar)
+      assert current_user.account_id === avatar.account_id
+    end
+
+    test "reassigns owned files of listed avatar to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
+      account_to_delete_id = account_to_delete.account_id
+      avatar = create_avatar(account_to_delete)
+      owned_files = avatar_owned_files(avatar)
+      create_avatar_listing(avatar)
+
+      for owned_file <- owned_files do
+        ^account_to_delete_id = reload_account_id(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        assert current_user.account_id === reload_account_id(owned_file)
+        assert file_on_disk?(owned_file)
+      end
+    end
+
+    test "deletes hubs", %{account_to_delete: account_to_delete, current_user: current_user} do
+      hub = create_hub(account_to_delete)
+
+      %Hub{} = repo_reload(hub)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(hub)
+    end
+
+    test "deletes hub account favorites", %{account_to_delete: account_to_delete, current_user: current_user} do
+      hub = create_hub(account_to_delete)
+      other_account = create_account("other account")
+      favorite = Repo.insert!(%AccountFavorite{account: other_account, hub: hub})
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(favorite)
+    end
+
+    test "deletes hub bindings", %{account_to_delete: account_to_delete, current_user: current_user} do
+      hub = create_hub(account_to_delete)
+
+      binding =
+        Repo.insert!(%HubBinding{
+          channel_id: "fake channel id",
+          community_id: "fake community id",
+          hub: hub,
+          type: :discord
+        })
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(binding)
+    end
+
+    test "deletes hub invites", %{account_to_delete: account_to_delete, current_user: current_user} do
+      hub = create_hub(account_to_delete)
+      invite = Repo.insert!(%HubInvite{hub: hub, hub_invite_sid: "dummy sid"})
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(invite)
+    end
+
+    test "deletes hub hub-role memberships", %{account_to_delete: account_to_delete, current_user: current_user} do
+      hub = create_hub(account_to_delete)
+      other_account = create_account("other account")
+      membership = Repo.insert!(%HubRoleMembership{account: other_account, hub: hub})
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(membership)
+    end
+
+    test "deletes hub room objects", %{account_to_delete: account_to_delete, current_user: current_user} do
+      hub = create_hub(account_to_delete)
+      other_account = create_account("other account")
+      object = create_room_object(hub, other_account)
+
+      %RoomObject{} = repo_reload(object)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(object)
+    end
+
+    test "deletes hub web push subscriptions", %{account_to_delete: account_to_delete, current_user: current_user} do
+      hub = create_hub(account_to_delete)
+
+      subscription =
+        Repo.insert!(%WebPushSubscription{auth: "fake auth", endpoint: "fake endpoint", hub: hub, p256dh: "fake key"})
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(subscription)
+    end
+
+    test "deletes hub-role memberships", %{account_to_delete: account_to_delete, current_user: current_user} do
+      own_hub = create_hub(account_to_delete)
+      member_hub = create_hub()
+      membership1 = Repo.insert!(%HubRoleMembership{account: account_to_delete, hub: own_hub})
+      membership2 = Repo.insert!(%HubRoleMembership{account: account_to_delete, hub: member_hub})
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(membership1)
+      refute repo_reload(membership2)
+    end
+
+    test "deletes identity", %{account_to_delete: account_to_delete, current_user: current_user} do
+      %{identity: identity} = Account.set_identity!(account_to_delete, "test identity")
+
+      %Identity{} = repo_reload(identity)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(identity)
+    end
+
+    test "deletes login", %{account_to_delete: account_to_delete, current_user: current_user} do
+      login = Repo.get_by(Login, account_id: account_to_delete.account_id)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(login)
+    end
+
+    test "deletes OAuth providers", %{account_to_delete: account_to_delete, current_user: current_user} do
+      provider =
+        Repo.insert!(%OAuthProvider{
+          account: account_to_delete,
+          provider_account_id: "fake id",
+          source: :discord
+        })
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(provider)
+    end
+
+    test "deletes projects", %{account_to_delete: account_to_delete, current_user: current_user} do
+      project = create_project(account_to_delete)
+
+      %Project{} = repo_reload(project)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(project)
+    end
+
+    test "deletes project owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+      project = create_project(account_to_delete)
+      owned_files = owned_files(project, [:project_owned_file, :thumbnail_owned_file])
+
+      for owned_file <- owned_files do
+        %OwnedFile{} = repo_reload(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        refute repo_reload(owned_file)
+        refute file_on_disk?(owned_file)
+      end
+    end
+
+    test "deletes project assets", %{account_to_delete: account_to_delete, current_user: current_user} do
+      %{project_id: project_id} = create_project(account_to_delete)
+      %{asset_id: asset_id} = create_asset(account_to_delete)
+      project_asset = Repo.insert!(%ProjectAsset{asset_id: asset_id, project_id: project_id})
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(project_asset)
+    end
+
+    test "deletes room objects", %{account_to_delete: account_to_delete, current_user: current_user} do
+      own_hub = create_hub(account_to_delete)
+      member_hub = create_hub()
+      object1 = create_room_object(own_hub, account_to_delete)
+      object2 = create_room_object(member_hub, account_to_delete)
+
+      %RoomObject{} = repo_reload(object1)
+      %RoomObject{} = repo_reload(object2)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(object1)
+      refute repo_reload(object2)
+    end
+
+    test "deletes scenes", %{account_to_delete: account_to_delete, current_user: current_user} do
+      scene = create_scene(account_to_delete)
+
+      %Scene{} = repo_reload(scene)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      refute repo_reload(scene)
+    end
+
+    test "deletes scene owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+      scene = create_scene(account_to_delete)
+      owned_files = scene_owned_files(scene)
+
+      for owned_file <- owned_files do
+        %OwnedFile{} = repo_reload(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        refute repo_reload(owned_file)
+        refute file_on_disk?(owned_file)
+      end
+    end
+
+    test "rassigns parent scenes to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+      account_to_delete_id = account_to_delete.account_id
+      scene = create_scene(account_to_delete)
+      create_child_scene(scene)
+
+      %Scene{account_id: ^account_to_delete_id} = repo_reload(scene)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert scene = repo_reload(scene)
+      assert current_user.account_id === scene.account_id
+    end
+
+    test "reassigns owned files of parent scene to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
+      account_to_delete_id = account_to_delete.account_id
+      scene = create_scene(account_to_delete)
+      owned_files = scene_owned_files(scene)
+      create_child_scene(scene)
+
+      for owned_file <- owned_files do
+        ^account_to_delete_id = reload_account_id(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        assert current_user.account_id === reload_account_id(owned_file)
+        assert file_on_disk?(owned_file)
+      end
+    end
+
+    test "reassigns listed scenes to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+      account_to_delete_id = account_to_delete.account_id
+      scene = create_scene(account_to_delete)
+      create_scene_listing(scene)
+
+      %Scene{account_id: ^account_to_delete_id} = repo_reload(scene)
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert scene = repo_reload(scene)
+      assert current_user.account_id === scene.account_id
+    end
+
+    test "reassigns owned files of listed scene to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
+      account_to_delete_id = account_to_delete.account_id
+      scene = create_scene(account_to_delete)
+      owned_files = scene_owned_files(scene)
+      create_scene_listing(scene)
+
+      for owned_file <- owned_files do
+        ^account_to_delete_id = reload_account_id(owned_file)
+        true = file_on_disk?(owned_file)
+      end
+
+      assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
+
+      for owned_file <- owned_files do
+        assert current_user.account_id === reload_account_id(owned_file)
+        assert file_on_disk?(owned_file)
+      end
+    end
+
+    test "with a non-admin user", %{account_to_delete: account_to_delete} do
+      current_user = create_account("non-admin")
+
+      assert {:error, :forbidden} === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert repo_reload(account_to_delete)
+    end
+
+    test "with an admin account to delete", %{current_user: current_user} do
+      {:ok, admin_account: account_to_delete} = create_admin_account("admin account")
+
+      assert {:error, :forbidden} === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert repo_reload(account_to_delete)
+    end
+
+    test "with the user’s own account to delete" do
+      {:ok, admin_account: account} = create_admin_account("own account")
+
+      assert {:error, :forbidden} === Ret.delete_account(account.account_id, account)
+      assert repo_reload(account)
+    end
+  end
+
+  defp avatar_owned_files(%Avatar{} = avatar) do
+    owned_files(avatar, [
+      :base_map_owned_file,
+      :bin_owned_file,
+      :emissive_map_owned_file,
+      :gltf_owned_file,
+      :normal_map_owned_file,
+      :orm_map_owned_file,
+      :thumbnail_owned_file
+    ])
+  end
+
+  @spec create_asset(Account.t()) :: Asset.t()
+  defp create_asset(%Account{} = account) do
+    [asset_owned_file, thumbnail_owned_file] =
+      account
+      |> temp_owned_files()
+      |> Enum.take(2)
+
+    Repo.insert!(%Asset{
+      account_id: account.account_id,
+      asset_owned_file: asset_owned_file,
+      asset_sid: "fake-asset-sid-#{Sids.generate_sid()}",
+      name: "fake asset",
+      thumbnail_owned_file: thumbnail_owned_file,
+      type: :image
+    })
+  end
+
+  @spec create_avatar(Account.t()) :: Avatar.t()
+  defp create_avatar(%Account{} = account) do
+    [
+      gltf_owned_file,
+      bin_owned_file,
+      thumbnail_owned_file,
+      base_map_owned_file,
+      emissive_map_owned_file,
+      normal_map_owned_file,
+      orm_map_owned_file
+    ] =
+      account
+      |> temp_owned_files()
+      |> Enum.take(7)
+
+    Repo.insert!(%Avatar{
+      account_id: account.account_id,
+      avatar_sid: Integer.to_string(account.account_id),
+      base_map_owned_file: base_map_owned_file,
+      bin_owned_file: bin_owned_file,
+      emissive_map_owned_file: emissive_map_owned_file,
+      gltf_owned_file: gltf_owned_file,
+      name: "fake avatar",
+      normal_map_owned_file: normal_map_owned_file,
+      orm_map_owned_file: orm_map_owned_file,
+      slug: "fake-avatar-slug",
+      thumbnail_owned_file: thumbnail_owned_file
+    })
+  end
+
+  @spec create_avatar_listing(Avatar.t()) :: AvatarListing.t()
+  defp create_avatar_listing(%Avatar{} = avatar),
+    do:
+      Repo.insert!(%AvatarListing{
+        avatar_id: avatar.avatar_id,
+        avatar_listing_sid: "fake-avatar-listing-sid",
+        base_map_owned_file: avatar.base_map_owned_file,
+        bin_owned_file: avatar.bin_owned_file,
+        emissive_map_owned_file: avatar.emissive_map_owned_file,
+        gltf_owned_file: avatar.gltf_owned_file,
+        name: "fake avatar listing",
+        normal_map_owned_file: avatar.normal_map_owned_file,
+        orm_map_owned_file: avatar.orm_map_owned_file,
+        slug: "fake-avatar-listing-slug",
+        thumbnail_owned_file: avatar.thumbnail_owned_file
+      })
+
+  @spec create_child_avatar(Avatar.t()) :: Avatar.t()
+  defp create_child_avatar(%Avatar{} = avatar) do
+    account = create_account("other account")
+
+    Repo.insert!(%Avatar{
+      account_id: account.account_id,
+      avatar_sid: "fake-child-avatar-sid",
+      name: "fake child avatar",
+      parent_avatar_id: avatar.avatar_id,
+      slug: "fake-child-avatar-slug"
+    })
+  end
+
+  @spec create_child_scene(Scene.t()) :: Scene.t()
+  defp create_child_scene(%Scene{} = scene) do
+    account = create_account("other account")
+
+    [screenshot_owned_file, model_owned_file] =
+      account
+      |> temp_owned_files()
+      |> Enum.take(2)
+
+    Repo.insert!(%Scene{
+      account_id: account.account_id,
+      scene_sid: "fake-child-scene-sid",
+      model_owned_file_id: model_owned_file.owned_file_id,
+      name: "fake child scene",
+      parent_scene_id: scene.scene_id,
+      screenshot_owned_file_id: screenshot_owned_file.owned_file_id,
+      slug: "fake-child-scene-slug"
+    })
+  end
+
+  @spec create_hub :: Hub.t()
+  defp create_hub,
+    do:
+      "hub owner"
+      |> create_account()
+      |> create_hub()
+
+  @spec create_hub(Account.t()) :: Hub.t()
+  defp create_hub(%Account{} = account),
+    do:
+      Repo.insert!(%Hub{created_by_account: account, name: "test hub", scene: create_scene(account), slug: "dummy-slug"})
+
+  @spec create_project(Account.t()) :: Project.t()
+  defp create_project(%Account{} = account) do
+    [project_owned_file, thumbnail_owned_file] =
+      account
+      |> temp_owned_files()
+      |> Enum.take(2)
+
+    Repo.insert!(%Project{
+      created_by_account_id: account.account_id,
+      name: "fake project",
+      project_owned_file: project_owned_file,
+      thumbnail_owned_file: thumbnail_owned_file
+    })
+  end
+
+  @spec create_room_object(Hub.t(), Account.t()) :: RoomObject.t()
+  defp create_room_object(%Hub{} = hub, %Account{} = account),
+    do: Repo.insert!(%RoomObject{account: account, gltf_node: "fake node", hub: hub, object_id: "fake id"})
+
+  @spec create_scene(Account.t()) :: Scene.t()
+  defp create_scene(%Account{} = account) do
+    [scene_owned_file, screenshot_owned_file, model_owned_file] =
+      account
+      |> temp_owned_files()
+      |> Enum.take(3)
+
+    {:ok, scene} =
+      Repo.insert(%Scene{
+        account_id: account.account_id,
+        model_owned_file: model_owned_file,
+        name: "fake scene",
+        scene_owned_file: scene_owned_file,
+        screenshot_owned_file: screenshot_owned_file,
+        slug: "fake-scene-slug"
+      })
+
+    account
+    |> create_project()
+    |> Ecto.Changeset.change(scene_id: scene.scene_id)
+    |> Repo.update!()
+
+    scene
+  end
+
+  @spec create_scene_listing(Scene.t()) :: SceneListing.t()
+  defp create_scene_listing(%Scene{} = scene),
+    do:
+      Repo.insert!(%SceneListing{
+        model_owned_file: scene.model_owned_file,
+        name: "fake scene listing",
+        scene_id: scene.scene_id,
+        scene_owned_file: scene.scene_owned_file,
+        screenshot_owned_file: scene.screenshot_owned_file,
+        slug: "fake-scene-listing-slug"
+      })
+
+  @spec file_on_disk?(OwnedFile.t()) :: boolean
+  defp file_on_disk?(%OwnedFile{} = owned_file) do
+    [_base_path, meta_file_path, blob_file_path] = Storage.paths_for_owned_file(owned_file)
+    File.exists?(meta_file_path) and File.exists?(blob_file_path)
+  end
+
+  @spec owned_files(Ecto.Schema.schema(), [atom]) :: [OwnedFile.t()]
+  defp owned_files(schema, assocs) when is_schema(schema) and is_list(assocs) do
+    for assoc <- assocs do
+      Map.fetch!(schema, assoc)
+    end
+  end
+
+  # TODO: Replace calls with Repo.reload/1 after Ecto updgrade
+  @spec repo_reload(schema) :: schema when schema: Ecto.Schema.schema()
+  defp repo_reload(schema) when is_schema(schema) do
+    [primary_key] = schema.__struct__.__schema__(:primary_key)
+    Repo.get(schema.__struct__, Map.fetch!(schema, primary_key))
+  end
+
+  @spec reload_account_id(Ecto.Schema.schema()) :: Account.id()
+  defp reload_account_id(schema) when is_schema(schema),
+    do:
+      schema
+      |> repo_reload()
+      |> Map.fetch!(:account_id)
+
+  @spec scene_owned_files(Scene.t()) :: [OwnedFile.t()]
+  defp scene_owned_files(%Scene{} = scene),
+    do: owned_files(scene, [:model_owned_file, :screenshot_owned_file, :scene_owned_file])
+
+  @spec temp_owned_files(Account.t()) :: Enumerable.t(OwnedFile.t())
+  defp temp_owned_files(%Account{} = account),
+    do: Stream.repeatedly(fn -> generate_temp_owned_file(account) end)
+end

--- a/test/support/dummy_schema.ex
+++ b/test/support/dummy_schema.ex
@@ -1,0 +1,6 @@
+defmodule Ret.DummySchema do
+  use Ecto.Schema
+
+  schema "" do
+  end
+end

--- a/test/support/dummy_struct.ex
+++ b/test/support/dummy_struct.ex
@@ -1,0 +1,3 @@
+defmodule Ret.DummyStruct do
+  defstruct []
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -54,8 +54,8 @@ defmodule Ret.TestHelpers do
     {:ok, account: create_account("test"), account2: create_account("test2")}
   end
 
-  def create_admin_account(_) do
-    {:ok, admin_account: create_account("test", true)}
+  def create_admin_account(prefix) do
+    {:ok, admin_account: create_account(prefix, true)}
   end
 
   def create_owned_file(%{account: account}) do


### PR DESCRIPTION
Why
---
When a user asks for their account to be deleted
I need to be able to wipe out all their owned data
So I can honor their right to be forgotten.

What
----
* Add DELETE action to account route
* Add `delete_account/2` to `Ret`
* Create data migration to delete orphaned data
* Create schema migration to update references
* Add `stream_data` dev dependency