### PR TITLE
Fix non-mods unable to chat in bound rooms

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -900,7 +900,7 @@ defimpl Canada.Can, for: Ret.Account do
 
   # Bound hubs - Moderator actions
   def can?(%Ret.Account{} = account, action, %Ret.Hub{hub_bindings: hub_bindings})
-      when hub_bindings |> length > 0 and action in [:kick_users, :mute_users, :amplify_audio, :voice_chat, :text_chat] do
+      when hub_bindings |> length > 0 and action in [:kick_users, :mute_users, :amplify_audio] do
     hub_bindings |> Enum.any?(&(account |> Ret.HubBinding.can_moderate_users?(&1)))
   end
 


### PR DESCRIPTION
Currently in Discord bound rooms only moderators can text/voice chat, regardless of the room permission setting. This clause will always match when checking for voice/text chat permission and only checks if a user is a moderator. We want this check to fall through to the next clause where moderators are always allowed, and normal users are checked against the room permission.

Testing this locally is pretty tricky so I haven't actually tested this fix...