### PR TITLE
Update container scripts

### DIFF
--- a/bin/iex
+++ b/bin/iex
@@ -1,3 +1,3 @@
 #!/bin/bash
-basedir=$(dirname $0)
-docker-compose -f $basedir/../../../docker-compose.yml exec ${MIX_ENV:+--env MIX_ENV=$MIX_ENV} reticulum iex "$@"
+basedir=$(dirname "$0")/..
+docker-compose -f "$basedir/../../docker-compose.yml" exec ${MIX_ENV:+--env MIX_ENV=$MIX_ENV} reticulum iex "$@"

--- a/bin/iex
+++ b/bin/iex
@@ -1,3 +1,3 @@
 #!/bin/bash
 basedir=$(dirname $0)
-docker-compose -f $basedir/../../../docker-compose.yml exec reticulum iex "$@"
+docker-compose -f $basedir/../../../docker-compose.yml exec ${MIX_ENV:+--env MIX_ENV=$MIX_ENV} reticulum iex "$@"

--- a/bin/mix
+++ b/bin/mix
@@ -1,3 +1,3 @@
 #!/bin/bash
-basedir=$(dirname $0)
-docker-compose -f $basedir/../../../docker-compose.yml exec ${MIX_ENV:+--env MIX_ENV=$MIX_ENV} reticulum mix "$@"
+basedir=$(dirname "$0")/..
+docker-compose -f "$basedir/../../docker-compose.yml" exec ${MIX_ENV:+--env MIX_ENV=$MIX_ENV} reticulum mix "$@"

--- a/bin/mix
+++ b/bin/mix
@@ -1,3 +1,3 @@
 #!/bin/bash
 basedir=$(dirname $0)
-docker-compose -f $basedir/../../../docker-compose.yml exec reticulum mix "$@"
+docker-compose -f $basedir/../../../docker-compose.yml exec ${MIX_ENV:+--env MIX_ENV=$MIX_ENV} reticulum mix "$@"

--- a/bin/psql
+++ b/bin/psql
@@ -1,3 +1,3 @@
 #!/bin/bash
-basedir=$(dirname $0)
-docker-compose -f $basedir/../../../docker-compose.yml exec db psql postgres://postgres:postgres@db:5432/ret_dev
+basedir=$(dirname "$0")/..
+docker-compose -f "$basedir/../../docker-compose.yml" exec db psql postgres://postgres:postgres@db:5432/ret_dev


### PR DESCRIPTION
Why
---

I want to be able to run tasks under the test environment inside the container
as I would locally.  For instance $ `MIX_ENV=test mix ecto.reset` has the
desired effect, but $ `MIX_ENV=test bin/mix ecto.reset` does not.

When the path contains a space all of the scripts break.  This is because the
commands treat the path as multiple arguments.

What
----

* Update `bin/mix` and `bin/iex` to pass `$MIX_ENV` through to the container
* Quote paths