### PR TITLE
Use POSIX output format with df

### DIFF
--- a/lib/ret/storage_used.ex
+++ b/lib/ret/storage_used.ex
@@ -24,7 +24,7 @@ defmodule Ret.StorageUsed do
       end
     else
       # Not TURKEY_MODE
-      case System.cmd("df", ["-k", storage_path]) do
+      case System.cmd("df", ["-kP", storage_path]) do
         {lines, 0} ->
           line = lines |> String.split("\n") |> Enum.at(1)
 


### PR DESCRIPTION
Fix a bug related to estimating disk use.

Explanation of the `-P` flag:

> This is like the default format except that the information about each filesystem is always printed on exactly one line; a mount device is never put on a line by itself. This means that if the mount device name is more than 20 characters long (e.g., for some network mounts), the columns are misaligned.
> 
> https://www.math.utah.edu/docs/info/fileutils_8.html

Without this flag, we fail to parse the output correctly with long device names. e.g.
```elixir
iex(1)> System.cmd("df", ["-k", "storage/dev"])
{"Filesystem           1K-blocks      Used Available Use% Mounted on\n/dev/mapper/MyVolGroup-root\n                      65478188  55206600   6899764  89% /code\n",
 0}
 ```
  Notice the trailing newline after `/dev/mapper/MyVolGroup-root\n` in the example above.
  
  The `-P` flag ensures the output is on one line:
 ```elixir
iex(2)> System.cmd("df", ["-kP", "storage/dev"])
{"Filesystem           1024-blocks    Used Available Capacity Mounted on\n/dev/mapper/MyVolGroup-root         65478188  55206600   6899764  89% /code\n",
 0}
 ```
