### PR TITLE
API endpoints to add and remove room owners

### DIFF
--- a/lib/ret/api/rooms.ex
+++ b/lib/ret/api/rooms.ex
@@ -106,7 +106,7 @@ defmodule Ret.Api.Rooms do
   end
 
   def authed_update_owner(event, hub_sid, %Credentials{} = credentials, params) when event in ["add_owner", "remove_owner"] do
-    hub = Hub |> Repo.get_by(hub_sid: hub_sid)
+    hub = Hub |> Repo.get_by(hub_sid: hub_sid) |> Repo.preload([:hub_role_memberships, :hub_bindings])
     if is_nil(hub) do
       {:error, "Cannot find room with id: " <> hub_sid}
     else

--- a/lib/ret_web/resolvers/room_resolver.ex
+++ b/lib/ret_web/resolvers/room_resolver.ex
@@ -146,4 +146,29 @@ defmodule RetWeb.Resolvers.RoomResolver do
   def update_room(_parent, _args, _resolutions) do
     resolver_error(:unauthorized, "Unauthorized access")
   end
+
+  def add_owner(_parent, %{id: hub_sid} = args, %{
+        context: %{
+          credentials: %Credentials{} = credentials
+        }
+      }) do
+    Ret.Api.Rooms.authed_update_owner("add_owner", hub_sid, credentials, args)
+  end
+
+  def add_owner(_parent, _args, _resolutions) do
+    resolver_error(:unauthorized, "Unauthorized access")
+  end
+
+  def remove_owner(_parent, %{id: hub_sid} = args, %{
+      context: %{
+        credentials: %Credentials{} = credentials
+      }
+    }) do
+    Ret.Api.Rooms.authed_update_owner("remove_owner", hub_sid, credentials, args)
+  end
+
+  def remove_owner(_parent, _args, _resolutions) do
+    resolver_error(:unauthorized, "Unauthorized access")
+  end
+
 end

--- a/lib/ret_web/schema/room_types.ex
+++ b/lib/ret_web/schema/room_types.ex
@@ -237,10 +237,29 @@ defmodule RetWeb.Schema.RoomTypes do
       @desc "Arbitrary json data associated with this room"
       arg(:user_data, :json)
 
-      # TODO: add/remove owner
-
       resolve(&Resolvers.RoomResolver.update_room/3)
     end
+
+    @desc "Add an owner to the room specified by the given id"
+    field :add_owner, :room do
+      @desc "The id of the room"
+      arg(:id, non_null(:string))
+      @desc "The session id of the user to promote"
+      arg(:session_id, non_null(:string))
+
+      resolve(&Resolvers.RoomResolver.add_owner/3)
+    end
+
+    @desc "Remove an owner to the room specified by the given id"
+    field :remove_owner, :room do
+      @desc "The id of the room"
+      arg(:id, non_null(:string))
+      @desc "The session id of the user to demote"
+      arg(:session_id, non_null(:string))
+
+      resolve(&Resolvers.RoomResolver.remove_owner/3)
+    end
+
   end
 
   object :room_subscriptions do


### PR DESCRIPTION
These two functions are essential to support more sophisticated use cases, particularly those involving rooms that have been created via the API rather than by a **creator** user. Our use case specifically requires the ability to promote and demote users independent of the Hubs UI.

I have hacked out a minimal implementation based on how I _think_ reticulum works, but it is very much inferred from the other API calls and my shaky knowledge of Elixir so comments (including complete rewrites) are very welcome.