### PR TITLE
Standardize formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
-  import_deps: [:phoenix, :stream_data],
+  import_deps: [:ecto, :phoenix, :stream_data],
   inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
-  import_deps: [:absinthe, :ecto, :ecto_sql, :phoenix, :stream_data],
+  import_deps: [:absinthe, :distillery, :ecto, :ecto_sql, :phoenix, :stream_data],
   inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,4 @@
 [
-  line_length: 120,
   import_deps: [:phoenix, :stream_data],
   inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
-  import_deps: [:ecto, :phoenix, :stream_data],
+  import_deps: [:ecto, :ecto_sql, :phoenix, :stream_data],
   inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
-  import_deps: [:ecto, :ecto_sql, :phoenix, :stream_data],
+  import_deps: [:absinthe, :ecto, :ecto_sql, :phoenix, :stream_data],
   inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,8 @@ use Mix.Config
 config :ret,
   ecto_repos: [Ret.Repo, Ret.SessionLockRepo]
 
-config :ret, RetWeb.Plugs.PostgrestProxy, hostname: System.get_env("POSTGREST_INTERNAL_HOSTNAME") || "localhost"
+config :ret, RetWeb.Plugs.PostgrestProxy,
+  hostname: System.get_env("POSTGREST_INTERNAL_HOSTNAME") || "localhost"
 
 config :phoenix, :format_encoders, "json-api": Jason
 config :phoenix, :json_library, Jason

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -145,7 +145,8 @@ config :ret, Ret.MediaResolver,
   ytdl_host: nil,
   photomnemonic_endpoint: "https://uvnsm9nzhe.execute-api.us-west-1.amazonaws.com/public"
 
-config :ret, Ret.Speelycaptor, speelycaptor_endpoint: "https://1dhaogh2hd.execute-api.us-west-1.amazonaws.com/public"
+config :ret, Ret.Speelycaptor,
+  speelycaptor_endpoint: "https://1dhaogh2hd.execute-api.us-west-1.amazonaws.com/public"
 
 config :ret, Ret.Storage,
   host: "https://#{host}:4000",
@@ -154,14 +155,16 @@ config :ret, Ret.Storage,
 
 asset_hosts =
   "https://localhost:4000 https://localhost:8080 " <>
-    "https://#{host}:4000 https://#{host}:8080 https://#{host}:3000 https://#{host}:8989 https://#{host}:9090 https://#{
-      cors_proxy_host
-    }:4000 " <>
+    "https://#{host}:4000 https://#{host}:8080 https://#{host}:3000 https://#{host}:8989 https://#{
+      host
+    }:9090 https://#{cors_proxy_host}:4000 " <>
     "https://assets-prod.reticulum.io https://asset-bundles-dev.reticulum.io https://asset-bundles-prod.reticulum.io"
 
 websocket_hosts =
   "https://localhost:4000 https://localhost:8080 wss://localhost:4000 " <>
-    "https://#{host}:4000 https://#{host}:8080 wss://#{host}:4000 wss://#{host}:8080 wss://#{host}:8989 wss://#{host}:9090 " <>
+    "https://#{host}:4000 https://#{host}:8080 wss://#{host}:4000 wss://#{host}:8080 wss://#{host}:8989 wss://#{
+      host
+    }:9090 " <>
     "wss://#{host}:4000 wss://#{host}:8080 https://#{host}:8080 https://hubs.local:8080 wss://hubs.local:8080"
 
 config :ret, RetWeb.Plugs.AddCSP,
@@ -178,7 +181,8 @@ config :ret, Ret.Mailer, adapter: Bamboo.LocalAdapter
 
 config :ret, RetWeb.Email, from: "info@hubs-mail.com"
 
-config :ret, Ret.PermsToken, perms_key: (System.get_env("PERMS_KEY") || "") |> String.replace("\\n", "\n")
+config :ret, Ret.PermsToken,
+  perms_key: (System.get_env("PERMS_KEY") || "") |> String.replace("\\n", "\n")
 
 config :ret, Ret.OAuthToken, oauth_token_key: ""
 
@@ -190,7 +194,8 @@ config :ret, Ret.Guardian,
 
 config :web_push_encryption, :vapid_details,
   subject: "mailto:admin@mozilla.com",
-  public_key: "BAb03820kHYuqIvtP6QuCKZRshvv_zp5eDtqkuwCUAxASBZMQbFZXzv8kjYOuLGF16A3k8qYnIN10_4asB-Aw7w",
+  public_key:
+    "BAb03820kHYuqIvtP6QuCKZRshvv_zp5eDtqkuwCUAxASBZMQbFZXzv8kjYOuLGF16A3k8qYnIN10_4asB-Aw7w",
   # This config value is for local development only.
   private_key: "w76tXh1d3RBdVQ5eINevXRwW6Ow6uRcBa8tBDOXfmxM"
 

--- a/lib/ret.ex
+++ b/lib/ret.ex
@@ -17,8 +17,8 @@ defmodule Ret do
   }
 
   import Canada, only: [can?: 2]
+  import Ecto.Query, only: [from: 2]
   import Ret.Schema, only: [is_serial_id: 1]
-  require Ecto.Query
 
   def change_email_for_login(%{old_email: old_email, new_email: new_email}) do
     if not valid_email_address?(new_email) do
@@ -98,32 +98,34 @@ defmodule Ret do
   end
 
   @spec account_owned_file_query(Account.id()) :: Ecto.Query.t()
-  defp account_owned_file_query(account_id) when is_serial_id(account_id),
-    do: Ecto.Query.where(OwnedFile, account_id: ^account_id)
+  defp account_owned_file_query(account_id) when is_serial_id(account_id) do
+    from OwnedFile, where: [account_id: ^account_id]
+  end
 
   @spec asset_query(Account.id()) :: Ecto.Query.t()
-  defp asset_query(account_id) when is_serial_id(account_id),
-    do: Ecto.Query.where(Asset, account_id: ^account_id)
+  defp asset_query(account_id) when is_serial_id(account_id) do
+    from Asset, where: [account_id: ^account_id]
+  end
 
   @spec avatar_owned_file_query(Account.id()) :: Ecto.Query.t()
-  defp avatar_owned_file_query(account_id) when is_serial_id(account_id),
-    do:
-      Ecto.Query.from(owned_file in OwnedFile,
-        join: avatar in Avatar,
-        on:
-          owned_file.owned_file_id == avatar.gltf_owned_file_id or
-            owned_file.owned_file_id == avatar.bin_owned_file_id or
-            owned_file.owned_file_id == avatar.thumbnail_owned_file_id or
-            owned_file.owned_file_id == avatar.base_map_owned_file_id or
-            owned_file.owned_file_id == avatar.emissive_map_owned_file_id or
-            owned_file.owned_file_id == avatar.normal_map_owned_file_id or
-            owned_file.owned_file_id == avatar.orm_map_owned_file_id,
-        where: avatar.account_id == ^account_id
-      )
+  defp avatar_owned_file_query(account_id) when is_serial_id(account_id) do
+    from owned_file in OwnedFile,
+      join: avatar in Avatar,
+      on:
+        owned_file.owned_file_id == avatar.gltf_owned_file_id or
+          owned_file.owned_file_id == avatar.bin_owned_file_id or
+          owned_file.owned_file_id == avatar.thumbnail_owned_file_id or
+          owned_file.owned_file_id == avatar.base_map_owned_file_id or
+          owned_file.owned_file_id == avatar.emissive_map_owned_file_id or
+          owned_file.owned_file_id == avatar.normal_map_owned_file_id or
+          owned_file.owned_file_id == avatar.orm_map_owned_file_id,
+      where: avatar.account_id == ^account_id
+  end
 
   @spec avatar_query(Account.id()) :: Ecto.Query.t()
-  defp avatar_query(account_id) when is_serial_id(account_id),
-    do: Ecto.Query.where(Avatar, account_id: ^account_id)
+  defp avatar_query(account_id) when is_serial_id(account_id) do
+    from Avatar, where: [account_id: ^account_id]
+  end
 
   @spec delete_avatars_multi(Ecto.Multi.t(), Account.id(), Keyword.t()) :: Ecto.Multi.t()
   defp delete_avatars_multi(%Ecto.Multi{} = multi, account_id, reassignment)
@@ -213,58 +215,55 @@ defmodule Ret do
   end
 
   @spec listed_avatar_query(Account.id()) :: Ecto.Query.t()
-  defp listed_avatar_query(account_id) when is_serial_id(account_id),
-    do:
-      Ecto.Query.from(avatar in Avatar,
-        join: listing in AvatarListing,
-        on: avatar.avatar_id == listing.avatar_id,
-        where: avatar.account_id == ^account_id
-      )
+  defp listed_avatar_query(account_id) when is_serial_id(account_id) do
+    from avatar in Avatar,
+      join: listing in AvatarListing,
+      on: avatar.avatar_id == listing.avatar_id,
+      where: avatar.account_id == ^account_id
+  end
 
   @spec listed_scene_query(Account.id()) :: Ecto.Query.t()
-  defp listed_scene_query(account_id) when is_serial_id(account_id),
-    do:
-      Ecto.Query.from(scene in Scene,
-        join: listing in SceneListing,
-        on: scene.scene_id == listing.scene_id,
-        where: scene.account_id == ^account_id
-      )
+  defp listed_scene_query(account_id) when is_serial_id(account_id) do
+    from scene in Scene,
+      join: listing in SceneListing,
+      on: scene.scene_id == listing.scene_id,
+      where: scene.account_id == ^account_id
+  end
 
   @spec parent_avatar_query(Account.id()) :: Ecto.Query.t()
-  defp parent_avatar_query(account_id) when is_serial_id(account_id),
-    do:
-      Ecto.Query.from(parent_avatar in Avatar,
-        join: child_avatar in Avatar,
-        on: parent_avatar.avatar_id == child_avatar.parent_avatar_id,
-        where: parent_avatar.account_id == ^account_id
-      )
+  defp parent_avatar_query(account_id) when is_serial_id(account_id) do
+    from parent_avatar in Avatar,
+      join: child_avatar in Avatar,
+      on: parent_avatar.avatar_id == child_avatar.parent_avatar_id,
+      where: parent_avatar.account_id == ^account_id
+  end
 
   @spec parent_scene_query(Account.id()) :: Ecto.Query.t()
-  defp parent_scene_query(account_id) when is_serial_id(account_id),
-    do:
-      Ecto.Query.from(parent_scene in Scene,
-        join: child_scene in Scene,
-        on: parent_scene.scene_id == child_scene.parent_scene_id,
-        where: parent_scene.account_id == ^account_id
-      )
+  defp parent_scene_query(account_id) when is_serial_id(account_id) do
+    from parent_scene in Scene,
+      join: child_scene in Scene,
+      on: parent_scene.scene_id == child_scene.parent_scene_id,
+      where: parent_scene.account_id == ^account_id
+  end
 
   @spec project_query(Account.id()) :: Ecto.Query.t()
-  defp project_query(account_id) when is_serial_id(account_id),
-    do: Ecto.Query.where(Project, created_by_account_id: ^account_id)
+  defp project_query(account_id) when is_serial_id(account_id) do
+    from Project, where: [created_by_account_id: ^account_id]
+  end
 
   @spec scene_owned_file_query(Account.id()) :: Ecto.Query.t()
-  defp scene_owned_file_query(account_id) when is_serial_id(account_id),
-    do:
-      Ecto.Query.from(owned_file in OwnedFile,
-        join: scene in Scene,
-        on:
-          owned_file.owned_file_id == scene.model_owned_file_id or
-            owned_file.owned_file_id == scene.screenshot_owned_file_id or
-            owned_file.owned_file_id == scene.scene_owned_file_id,
-        where: scene.account_id == ^account_id
-      )
+  defp scene_owned_file_query(account_id) when is_serial_id(account_id) do
+    from owned_file in OwnedFile,
+      join: scene in Scene,
+      on:
+        owned_file.owned_file_id == scene.model_owned_file_id or
+          owned_file.owned_file_id == scene.screenshot_owned_file_id or
+          owned_file.owned_file_id == scene.scene_owned_file_id,
+      where: scene.account_id == ^account_id
+  end
 
   @spec scene_query(Account.id()) :: Ecto.Query.t()
-  defp scene_query(account_id) when is_serial_id(account_id),
-    do: Ecto.Query.where(Scene, account_id: ^account_id)
+  defp scene_query(account_id) when is_serial_id(account_id) do
+    from Scene, where: [account_id: ^account_id]
+  end
 end

--- a/lib/ret.ex
+++ b/lib/ret.ex
@@ -2,7 +2,20 @@ defmodule Ret do
   @moduledoc """
   The boundary of the Ret context.
   """
-  alias Ret.{Account, Asset, Avatar, AvatarListing, Login, OwnedFile, Project, Repo, Scene, SceneListing, Storage}
+  alias Ret.{
+    Account,
+    Asset,
+    Avatar,
+    AvatarListing,
+    Login,
+    OwnedFile,
+    Project,
+    Repo,
+    Scene,
+    SceneListing,
+    Storage
+  }
+
   import Canada, only: [can?: 2]
   import Ret.Schema, only: [is_serial_id: 1]
   require Ecto.Query
@@ -117,14 +130,30 @@ defmodule Ret do
        when is_serial_id(account_id) and is_list(reassignment),
        do:
          multi
-         |> Ecto.Multi.update_all(:reassign_avatar_owned_files, avatar_owned_file_query(account_id), reassignment)
-         |> Ecto.Multi.update_all(:reassign_listed_avatars, listed_avatar_query(account_id), reassignment)
-         |> Ecto.Multi.update_all(:reassign_parent_avatars, parent_avatar_query(account_id), reassignment)
+         |> Ecto.Multi.update_all(
+           :reassign_avatar_owned_files,
+           avatar_owned_file_query(account_id),
+           reassignment
+         )
+         |> Ecto.Multi.update_all(
+           :reassign_listed_avatars,
+           listed_avatar_query(account_id),
+           reassignment
+         )
+         |> Ecto.Multi.update_all(
+           :reassign_parent_avatars,
+           parent_avatar_query(account_id),
+           reassignment
+         )
          |> ecto_multi_all(:avatar_owned_files, avatar_owned_file_query(account_id))
          |> Ecto.Multi.delete_all(:delete_avatars, avatar_query(account_id))
-         |> Ecto.Multi.run(:delete_avatar_owned_files, &delete_owned_files(&2.avatar_owned_files, &1))
+         |> Ecto.Multi.run(
+           :delete_avatar_owned_files,
+           &delete_owned_files(&2.avatar_owned_files, &1)
+         )
 
-  @spec delete_owned_files([OwnedFile.t()], module) :: {:ok, nil} | {:error, Ecto.Changeset.t(OwnedFile.t())}
+  @spec delete_owned_files([OwnedFile.t()], module) ::
+          {:ok, nil} | {:error, Ecto.Changeset.t(OwnedFile.t())}
   defp delete_owned_files(owned_files, repo) when is_list(owned_files) and is_atom(repo) do
     Enum.reduce_while(owned_files, {:ok, nil}, fn owned_file, acc ->
       with {:ok, _} <- OwnedFile.set_inactive(owned_file),
@@ -143,19 +172,37 @@ defmodule Ret do
     do:
       multi
       |> ecto_multi_all(:account_owned_files, account_owned_file_query(account_id))
-      |> Ecto.Multi.run(:delete_account_owned_files, &delete_owned_files(&2.account_owned_files, &1))
+      |> Ecto.Multi.run(
+        :delete_account_owned_files,
+        &delete_owned_files(&2.account_owned_files, &1)
+      )
 
   @spec delete_scenes_multi(Ecto.Multi.t(), Account.id(), Keyword.t()) :: Ecto.Multi.t()
   defp delete_scenes_multi(%Ecto.Multi{} = multi, account_id, reassignment)
        when is_serial_id(account_id) and is_list(reassignment),
        do:
          multi
-         |> Ecto.Multi.update_all(:reassign_scene_owned_files, scene_owned_file_query(account_id), reassignment)
-         |> Ecto.Multi.update_all(:reassign_listed_scenes, listed_scene_query(account_id), reassignment)
-         |> Ecto.Multi.update_all(:reassign_parent_scenes, parent_scene_query(account_id), reassignment)
+         |> Ecto.Multi.update_all(
+           :reassign_scene_owned_files,
+           scene_owned_file_query(account_id),
+           reassignment
+         )
+         |> Ecto.Multi.update_all(
+           :reassign_listed_scenes,
+           listed_scene_query(account_id),
+           reassignment
+         )
+         |> Ecto.Multi.update_all(
+           :reassign_parent_scenes,
+           parent_scene_query(account_id),
+           reassignment
+         )
          |> ecto_multi_all(:scene_owned_files, scene_owned_file_query(account_id))
          |> Ecto.Multi.delete_all(:delete_scenes, scene_query(account_id))
-         |> Ecto.Multi.run(:delete_scene_owned_files, &delete_owned_files(&2.scene_owned_files, &1))
+         |> Ecto.Multi.run(
+           :delete_scene_owned_files,
+           &delete_owned_files(&2.scene_owned_files, &1)
+         )
 
   # TODO: Replace calls with Ecto.Multi.all/3 after Ecto updgrade
   @spec ecto_multi_all(Ecto.Multi.t(), atom, Ecto.Query.t()) :: Ecto.Multi.t()

--- a/lib/ret/account.ex
+++ b/lib/ret/account.ex
@@ -14,31 +14,35 @@ defmodule Ret.Account do
   @schema_prefix "ret0"
   @primary_key {:account_id, :id, autogenerate: true}
   schema "accounts" do
-    field(:min_token_issued_at, :utc_datetime)
-    field(:is_admin, :boolean)
-    field(:state, Account.State)
-    has_one(:login, Login, foreign_key: :account_id)
-    has_one(:identity, Identity, foreign_key: :account_id)
-    has_many(:owned_files, Ret.OwnedFile, foreign_key: :account_id)
-    has_many(:created_hubs, Ret.Hub, foreign_key: :created_by_account_id)
-    has_many(:oauth_providers, Ret.OAuthProvider, foreign_key: :account_id)
-    has_many(:projects, Ret.Project, foreign_key: :created_by_account_id)
-    has_many(:assets, Ret.Asset, foreign_key: :account_id)
+    field :min_token_issued_at, :utc_datetime
+    field :is_admin, :boolean
+    field :state, Account.State
+
+    has_one :login, Login, foreign_key: :account_id
+    has_one :identity, Identity, foreign_key: :account_id
+
+    has_many :owned_files, Ret.OwnedFile, foreign_key: :account_id
+    has_many :created_hubs, Ret.Hub, foreign_key: :created_by_account_id
+    has_many :oauth_providers, Ret.OAuthProvider, foreign_key: :account_id
+    has_many :projects, Ret.Project, foreign_key: :created_by_account_id
+    has_many :assets, Ret.Asset, foreign_key: :account_id
+
     timestamps()
   end
 
   def query do
-    from(account in Account)
+    from(Account)
   end
 
   def where_account_id_is(query, id) do
-    from(account in query, where: account.account_id == ^id)
+    from account in query, where: account.account_id == ^id
   end
 
-  def has_accounts?(), do: from(a in Account, limit: 1) |> Repo.exists?()
+  def has_accounts?,
+    do: Repo.exists?(Account)
 
-  def has_admin_accounts?(),
-    do: from(a in Account, limit: 1) |> where(is_admin: true) |> Repo.exists?()
+  def has_admin_accounts?,
+    do: Repo.exists?(from a in Account, where: a.is_admin)
 
   def exists_for_email?(email), do: account_for_email(email) != nil
 
@@ -49,10 +53,7 @@ defmodule Ret.Account do
   def find_or_create_account_for_email(email), do: account_for_email(email, true)
 
   def account_for_login_identifier_hash(identifier_hash, create_if_not_exists \\ false) do
-    login =
-      Login
-      |> where([t], t.identifier_hash == ^identifier_hash)
-      |> Repo.one()
+    login = Repo.one(from l in Login, where: l.identifier_hash == ^identifier_hash)
 
     cond do
       login != nil ->
@@ -131,7 +132,7 @@ defmodule Ret.Account do
   end
 
   def revoke_identity!(%Account{account_id: account_id} = account) do
-    from(i in Identity, where: i.account_id == ^account_id) |> Repo.delete_all()
+    Repo.delete_all(from i in Identity, where: i.account_id == ^account_id)
     Repo.preload(account, @account_preloads, force: true)
   end
 

--- a/lib/ret/account.ex
+++ b/lib/ret/account.ex
@@ -36,7 +36,10 @@ defmodule Ret.Account do
   end
 
   def has_accounts?(), do: from(a in Account, limit: 1) |> Repo.exists?()
-  def has_admin_accounts?(), do: from(a in Account, limit: 1) |> where(is_admin: true) |> Repo.exists?()
+
+  def has_admin_accounts?(),
+    do: from(a in Account, limit: 1) |> where(is_admin: true) |> Repo.exists?()
+
   def exists_for_email?(email), do: account_for_email(email) != nil
 
   def account_for_email(email, create_if_not_exists \\ false) do
@@ -108,7 +111,8 @@ defmodule Ret.Account do
     end)
   end
 
-  def oauth_provider_for_source(%Ret.Account{} = account, oauth_provider_source) when is_atom(oauth_provider_source) do
+  def oauth_provider_for_source(%Ret.Account{} = account, oauth_provider_source)
+      when is_atom(oauth_provider_source) do
     account.oauth_providers
     |> Enum.find(fn provider ->
       provider.source == oauth_provider_source

--- a/lib/ret/account_favorite.ex
+++ b/lib/ret/account_favorite.ex
@@ -8,9 +8,10 @@ defmodule Ret.AccountFavorite do
   @primary_key {:account_favorite_id, :id, autogenerate: true}
 
   schema "account_favorites" do
-    belongs_to(:account, Ret.Account, references: :account_id)
-    belongs_to(:hub, Ret.Hub, references: :hub_id)
-    field(:last_activated_at, :utc_datetime)
+    field :last_activated_at, :utc_datetime
+
+    belongs_to :account, Ret.Account, references: :account_id
+    belongs_to :hub, Ret.Hub, references: :hub_id
 
     timestamps()
   end

--- a/lib/ret/api/can_credentials.ex
+++ b/lib/ret/api/can_credentials.ex
@@ -79,7 +79,11 @@ defimpl Canada.Can, for: Ret.Api.Credentials do
     Scopes.read_rooms() in scopes && can?(:reticulum_app_token, embed_hub(hub))
   end
 
-  def can?(%Credentials{subject_type: :account, account: subject, scopes: scopes}, :embed_hub, %Hub{} = hub) do
+  def can?(
+        %Credentials{subject_type: :account, account: subject, scopes: scopes},
+        :embed_hub,
+        %Hub{} = hub
+      ) do
     Scopes.read_rooms() in scopes && can?(subject, embed_hub(hub))
   end
 

--- a/lib/ret/api/credentials.ex
+++ b/lib/ret/api/credentials.ex
@@ -15,13 +15,14 @@ defmodule Ret.Api.Credentials do
   @primary_key {:api_credentials_id, :id, autogenerate: true}
 
   schema "api_credentials" do
-    field(:api_credentials_sid, :string)
-    field(:token_hash, :string)
-    field(:subject_type, TokenSubjectType)
-    field(:is_revoked, :boolean)
-    field(:scopes, {:array, ScopeType})
+    field :api_credentials_sid, :string
+    field :token_hash, :string
+    field :subject_type, TokenSubjectType
+    field :is_revoked, :boolean
+    field :scopes, {:array, ScopeType}
 
-    belongs_to(:account, Account, references: :account_id)
+    belongs_to :account, Account, references: :account_id
+
     timestamps()
   end
 
@@ -106,38 +107,29 @@ defmodule Ret.Api.Credentials do
   end
 
   def query do
-    from(c in Credentials,
+    from c in Credentials,
       left_join: a in Account,
       on: c.account_id == a.account_id,
       preload: [account: a]
-    )
   end
 
   def where_sid_is(query, sid) do
-    from([credential, _account] in query,
-      where: credential.api_credentials_sid == ^sid
-    )
+    from [credential, _account] in query, where: credential.api_credentials_sid == ^sid
   end
 
   def where_token_hash_is(query, hash) do
-    from([credential, _account] in query,
-      where: credential.token_hash == ^hash
-    )
+    from [credential, _account] in query, where: credential.token_hash == ^hash
   end
 
   def where_account_is(query, %Account{account_id: id}) do
-    from([credential, _account] in query,
-      where: credential.account_id == ^id
-    )
+    from [credential, _account] in query, where: credential.account_id == ^id
   end
 
   def where_token_is_not_revoked(query) do
-    from([credential, _account] in query,
-      where: not credential.is_revoked
-    )
+    from [credential, _account] in query, where: not credential.is_revoked
   end
 
   def app_token_query() do
-    from(c in Credentials, where: c.subject_type == ^:app)
+    from c in Credentials, where: c.subject_type == ^:app
   end
 end

--- a/lib/ret/api/credentials.ex
+++ b/lib/ret/api/credentials.ex
@@ -28,7 +28,9 @@ defmodule Ret.Api.Credentials do
   @required_keys [:api_credentials_sid, :token_hash, :subject_type, :is_revoked, :scopes]
   @permitted_keys @required_keys
 
-  def generate_credentials(%{subject_type: _st, scopes: _sc, account_or_nil: account_or_nil} = params) do
+  def generate_credentials(
+        %{subject_type: _st, scopes: _sc, account_or_nil: account_or_nil} = params
+      ) do
     sid = Ret.Sids.generate_sid()
 
     # Use 18 bytes (not 16, the default) to avoid having all tokens end in "09"
@@ -89,7 +91,10 @@ defmodule Ret.Api.Credentials do
     if TokenSubjectType.valid_value?(subject_type) do
       []
     else
-      [invalid_subject_type: "Unrecognized subject type. Must be app or account. Got #{subject_type}."]
+      [
+        invalid_subject_type:
+          "Unrecognized subject type. Must be app or account. Got #{subject_type}."
+      ]
     end
   end
 
@@ -101,7 +106,11 @@ defmodule Ret.Api.Credentials do
   end
 
   def query do
-    from(c in Credentials, left_join: a in Account, on: c.account_id == a.account_id, preload: [account: a])
+    from(c in Credentials,
+      left_join: a in Account,
+      on: c.account_id == a.account_id,
+      preload: [account: a]
+    )
   end
 
   def where_sid_is(query, sid) do

--- a/lib/ret/api/dataloader.ex
+++ b/lib/ret/api/dataloader.ex
@@ -6,6 +6,11 @@ defmodule Ret.Api.Dataloader do
 
   def source(), do: Dataloader.Ecto.new(Repo, query: &query/2)
   # Guard against loading removed scenes or delisted scene listings
-  def query(Scene, _), do: from(s in Scene, where: s.state != ^:removed)
-  def query(SceneListing, _), do: from(sl in SceneListing, where: sl.state != ^:delisted)
+  def query(Scene, _) do
+    from s in Scene, where: s.state != ^:removed
+  end
+
+  def query(SceneListing, _) do
+    from sl in SceneListing, where: sl.state != ^:delisted
+  end
 end

--- a/lib/ret/api/rooms.ex
+++ b/lib/ret/api/rooms.ex
@@ -48,7 +48,8 @@ defmodule Ret.Api.Rooms do
   end
 
   def authed_update_room(hub_sid, %Credentials{} = credentials, params) do
-    hub = Hub |> Repo.get_by(hub_sid: hub_sid) |> Repo.preload([:hub_role_memberships, :hub_bindings])
+    hub =
+      Hub |> Repo.get_by(hub_sid: hub_sid) |> Repo.preload([:hub_role_memberships, :hub_bindings])
 
     if is_nil(hub) do
       {:error, "Cannot find room with id: " <> hub_sid}
@@ -87,7 +88,11 @@ defmodule Ret.Api.Rooms do
       {:ok, hub} ->
         hub = Repo.preload(hub, Hub.hub_preloads())
 
-        case broadcast_hub_refresh(hub, subject, Map.keys(changeset.changes) |> Enum.map(&Atom.to_string(&1))) do
+        case broadcast_hub_refresh(
+               hub,
+               subject,
+               Map.keys(changeset.changes) |> Enum.map(&Atom.to_string(&1))
+             ) do
           {:error, reason} -> {:error, reason}
           :ok -> {:ok, hub}
         end

--- a/lib/ret/api/token_utils.ex
+++ b/lib/ret/api/token_utils.ex
@@ -15,7 +15,10 @@ defmodule Ret.Api.TokenUtils do
     })
   end
 
-  def gen_token_for_account(%Account{} = account, scopes \\ [Scopes.read_rooms(), Scopes.write_rooms()]) do
+  def gen_token_for_account(
+        %Account{} = account,
+        scopes \\ [Scopes.read_rooms(), Scopes.write_rooms()]
+      ) do
     Token.encode_and_sign(nil, %{
       subject_type: :account,
       scopes: scopes,
@@ -56,7 +59,10 @@ defmodule Ret.Api.TokenUtils do
     end
   end
 
-  def to_claims(%Account{} = account, %{"subject_type" => subject_type, "scopes" => scopes} = params) do
+  def to_claims(
+        %Account{} = account,
+        %{"subject_type" => subject_type, "scopes" => scopes} = params
+      ) do
     account_id_for_claims = account_id_from_args(account, params)
 
     case validate_account_id(account, account_id_for_claims) ++

--- a/lib/ret/app_config.ex
+++ b/lib/ret/app_config.ex
@@ -16,9 +16,11 @@ defmodule Ret.AppConfig do
   }
 
   schema "app_configs" do
-    field(:key, :string)
-    field(:value, :map)
-    belongs_to(:owned_file, Ret.OwnedFile, references: :owned_file_id)
+    field :key, :string
+    field :value, :map
+
+    belongs_to :owned_file, Ret.OwnedFile, references: :owned_file_id
+
     timestamps()
   end
 

--- a/lib/ret/application.ex
+++ b/lib/ret/application.ex
@@ -74,7 +74,9 @@ defmodule Ret.Application do
       # Room assigner monitor
       worker(Ret.RoomAssignerMonitor, []),
       # Storage for rate limiting
-      worker(PlugAttack.Storage.Ets, [RetWeb.RateLimit.Storage, [clean_period: 60_000]], id: :rate_limit),
+      worker(PlugAttack.Storage.Ets, [RetWeb.RateLimit.Storage, [clean_period: 60_000]],
+        id: :rate_limit
+      ),
       # Media resolution cache
       worker(
         Cachex,

--- a/lib/ret/asset.ex
+++ b/lib/ret/asset.ex
@@ -11,18 +11,18 @@ defmodule Ret.Asset do
   @schema_prefix "ret0"
   @primary_key {:asset_id, :id, autogenerate: true}
   schema "assets" do
-    field(:asset_sid, :string)
-    field(:name, :string)
-    field(:type, Ret.Asset.Type)
-    belongs_to(:account, Ret.Account, references: :account_id)
-    belongs_to(:asset_owned_file, Ret.OwnedFile, references: :owned_file_id)
-    belongs_to(:thumbnail_owned_file, Ret.OwnedFile, references: :owned_file_id)
+    field :asset_sid, :string
+    field :name, :string
+    field :type, Ret.Asset.Type
 
-    many_to_many(:projects, Ret.Project,
+    belongs_to :account, Ret.Account, references: :account_id
+    belongs_to :asset_owned_file, Ret.OwnedFile, references: :owned_file_id
+    belongs_to :thumbnail_owned_file, Ret.OwnedFile, references: :owned_file_id
+
+    many_to_many :projects, Ret.Project,
       join_through: Ret.ProjectAsset,
       join_keys: [asset_id: :asset_id, project_id: :project_id],
       on_replace: :delete
-    )
 
     timestamps()
   end
@@ -55,11 +55,12 @@ defmodule Ret.Asset do
   end
 
   def asset_by_sid_for_account(asset_sid, account) do
-    from(a in Asset,
-      where: a.asset_sid == ^asset_sid and a.account_id == ^account.account_id,
-      preload: [:account, :asset_owned_file, :thumbnail_owned_file]
+    Repo.one(
+      from a in Asset,
+        where: a.asset_sid == ^asset_sid,
+        where: a.account_id == ^account.account_id,
+        preload: [:account, :asset_owned_file, :thumbnail_owned_file]
     )
-    |> Repo.one()
   end
 
   # Create an Asset

--- a/lib/ret/asset.ex
+++ b/lib/ret/asset.ex
@@ -33,8 +33,15 @@ defmodule Ret.Asset do
     |> Repo.insert()
   end
 
-  def create_asset_and_project_asset(account, project, asset_owned_file, thumbnail_owned_file, params) do
-    asset_changeset = Asset.changeset(%Asset{}, account, asset_owned_file, thumbnail_owned_file, params)
+  def create_asset_and_project_asset(
+        account,
+        project,
+        asset_owned_file,
+        thumbnail_owned_file,
+        params
+      ) do
+    asset_changeset =
+      Asset.changeset(%Asset{}, account, asset_owned_file, thumbnail_owned_file, params)
 
     multi =
       Multi.new()

--- a/lib/ret/avatar.ex
+++ b/lib/ret/avatar.ex
@@ -16,7 +16,12 @@ defmodule Ret.Avatar do
 
   @type t :: %__MODULE__{}
 
-  @image_columns [:base_map_owned_file, :emissive_map_owned_file, :normal_map_owned_file, :orm_map_owned_file]
+  @image_columns [
+    :base_map_owned_file,
+    :emissive_map_owned_file,
+    :normal_map_owned_file,
+    :orm_map_owned_file
+  ]
   @file_columns [:gltf_owned_file, :bin_owned_file, :thumbnail_owned_file] ++ @image_columns
 
   @schema_prefix "ret0"
@@ -31,9 +36,17 @@ defmodule Ret.Avatar do
 
     belongs_to(:account, Account, references: :account_id)
     belongs_to(:parent_avatar, Avatar, references: :avatar_id, on_replace: :nilify)
-    belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id, on_replace: :nilify)
 
-    has_many(:avatar_listings, AvatarListing, foreign_key: :avatar_id, references: :avatar_id, on_replace: :nilify)
+    belongs_to(:parent_avatar_listing, AvatarListing,
+      references: :avatar_listing_id,
+      on_replace: :nilify
+    )
+
+    has_many(:avatar_listings, AvatarListing,
+      foreign_key: :avatar_id,
+      references: :avatar_id,
+      on_replace: :nilify
+    )
 
     field(:allow_remixing, :boolean)
     field(:allow_promotion, :boolean)
@@ -47,7 +60,12 @@ defmodule Ret.Avatar do
     belongs_to(:thumbnail_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 
     belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-    belongs_to(:emissive_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+
+    belongs_to(:emissive_map_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+    )
+
     belongs_to(:normal_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 
@@ -80,8 +98,10 @@ defmodule Ret.Avatar do
   defp avatar_to_collapsed_files(%AvatarListing{parent_avatar_listing: nil} = avatar),
     do: avatar |> Map.take(@file_columns)
 
-  defp avatar_to_collapsed_files(%Avatar{parent_avatar_listing: nil, parent_avatar: nil} = avatar),
-    do: avatar |> Map.take(@file_columns)
+  defp avatar_to_collapsed_files(
+         %Avatar{parent_avatar_listing: nil, parent_avatar: nil} = avatar
+       ),
+       do: avatar |> Map.take(@file_columns)
 
   defp avatar_to_collapsed_files(%AvatarListing{parent_avatar_listing: parent_listing} = avatar) do
     parent_listing
@@ -92,7 +112,9 @@ defmodule Ret.Avatar do
     end)
   end
 
-  defp avatar_to_collapsed_files(%Avatar{parent_avatar_listing: parent_listing, parent_avatar: parent} = avatar) do
+  defp avatar_to_collapsed_files(
+         %Avatar{parent_avatar_listing: parent_listing, parent_avatar: parent} = avatar
+       ) do
     (parent_listing || parent)
     |> avatar_to_collapsed_files
     |> Map.merge(avatar |> Map.take(@file_columns), fn
@@ -112,14 +134,18 @@ defmodule Ret.Avatar do
     do: a.updated_at |> NaiveDateTime.to_erl() |> :calendar.datetime_to_gregorian_seconds()
 
   def url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/avatars/#{avatar.avatar_sid}"
-  def url(%AvatarListing{} = avatar), do: "#{RetWeb.Endpoint.url()}/avatars/#{avatar.avatar_listing_sid}"
 
-  defp api_base_url(%Avatar{} = avatar), do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
+  def url(%AvatarListing{} = avatar),
+    do: "#{RetWeb.Endpoint.url()}/avatars/#{avatar.avatar_listing_sid}"
+
+  defp api_base_url(%Avatar{} = avatar),
+    do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_sid}"
 
   defp api_base_url(%AvatarListing{} = avatar),
     do: "#{RetWeb.Endpoint.url()}/api/v1/avatars/#{avatar.avatar_listing_sid}"
 
-  def gltf_url(%t{} = a) when t in [Avatar, AvatarListing], do: "#{api_base_url(a)}/avatar.gltf?v=#{Avatar.version(a)}"
+  def gltf_url(%t{} = a) when t in [Avatar, AvatarListing],
+    do: "#{api_base_url(a)}/avatar.gltf?v=#{Avatar.version(a)}"
 
   def base_gltf_url(%t{} = a) when t in [Avatar, AvatarListing],
     do: "#{api_base_url(a)}/base.gltf?v=#{Avatar.version(a)}"
@@ -136,7 +162,8 @@ defmodule Ret.Avatar do
       AvatarListing |> Repo.get_by(avatar_listing_sid: sid) |> Repo.preload(:avatar)
   end
 
-  def new_avatar_from_parent_sid(parent_sid, account) when not is_nil(parent_sid) and parent_sid != "" do
+  def new_avatar_from_parent_sid(parent_sid, account)
+      when not is_nil(parent_sid) and parent_sid != "" do
     with parent <-
            parent_sid
            |> avatar_or_avatar_listing_by_sid()
@@ -223,7 +250,10 @@ defmodule Ret.Avatar do
 
   def import_from_url!(uri, account) do
     remote_avatar = uri |> fetch_remote_avatar!() |> collapse_remote_avatar!(uri)
-    [imported_from_host, imported_from_port] = [:host, :port] |> Enum.map(&(uri |> URI.parse() |> Map.get(&1)))
+
+    [imported_from_host, imported_from_port] =
+      [:host, :port] |> Enum.map(&(uri |> URI.parse() |> Map.get(&1)))
+
     imported_from_sid = remote_avatar["avatar_id"]
 
     {file_names, file_urls} =

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -45,7 +45,12 @@ defmodule Ret.AvatarListing do
     belongs_to(:thumbnail_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
 
     belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-    belongs_to(:emissive_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+
+    belongs_to(:emissive_map_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+    )
+
     belongs_to(:normal_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
     belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
   end

--- a/lib/ret/avatar_listing.ex
+++ b/lib/ret/avatar_listing.ex
@@ -18,41 +18,56 @@ defmodule Ret.AvatarListing do
   @schema_prefix "ret0"
   @primary_key {:avatar_listing_id, :id, autogenerate: true}
   schema "avatar_listings" do
-    field(:avatar_listing_sid, :string)
-    field(:slug, AvatarListingSlug.Type)
-    field(:order, :integer)
-    field(:state, AvatarListing.State)
-    field(:tags, :map)
-    belongs_to(:avatar, Avatar, references: :avatar_id)
-    timestamps()
+    field :avatar_listing_sid, :string
+    field :slug, AvatarListingSlug.Type
+    field :order, :integer
+    field :state, AvatarListing.State
+    field :tags, :map
+
+    belongs_to :avatar, Avatar, references: :avatar_id
 
     # Properties cloned from avatars
-    field(:name, :string)
-    field(:description, :string)
-    field(:attributions, :map)
+    field :name, :string
+    field :description, :string
+    field :attributions, :map
 
-    belongs_to(:account, Account, references: :account_id)
-    belongs_to(:parent_avatar_listing, AvatarListing, references: :avatar_listing_id)
+    belongs_to :account, Account, references: :account_id
+    belongs_to :parent_avatar_listing, AvatarListing, references: :avatar_listing_id
 
-    has_many(:child_avatars, Avatar,
+    belongs_to :gltf_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    belongs_to :bin_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    belongs_to :thumbnail_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    belongs_to :base_map_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    belongs_to :emissive_map_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    belongs_to :normal_map_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    belongs_to :orm_map_owned_file, OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    has_many :child_avatars, Avatar,
       references: :avatar_listing_id,
       foreign_key: :parent_avatar_listing_id,
       on_replace: :nilify
-    )
 
-    belongs_to(:gltf_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-    belongs_to(:bin_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-    belongs_to(:thumbnail_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-
-    belongs_to(:base_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-
-    belongs_to(:emissive_map_owned_file, OwnedFile,
-      references: :owned_file_id,
-      on_replace: :nilify
-    )
-
-    belongs_to(:normal_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
-    belongs_to(:orm_map_owned_file, OwnedFile, references: :owned_file_id, on_replace: :nilify)
+    timestamps()
   end
 
   def has_any_in_filter?(filter) do

--- a/lib/ret/cached_file.ex
+++ b/lib/ret/cached_file.ex
@@ -26,7 +26,11 @@ defmodule Ret.CachedFile do
     # nodes for accessing this cache key
     Ret.Locking.exec_after_lock(cache_key, fn ->
       case CachedFile |> where(cache_key: ^cache_key) |> Repo.one() do
-        %CachedFile{file_uuid: file_uuid, file_content_type: file_content_type, file_key: file_key} ->
+        %CachedFile{
+          file_uuid: file_uuid,
+          file_content_type: file_content_type,
+          file_key: file_key
+        } ->
           Storage.uri_for(file_uuid, file_content_type, file_key)
 
         nil ->
@@ -50,7 +54,8 @@ defmodule Ret.CachedFile do
                file_uuid: file_uuid,
                file_key: file_key,
                file_content_type: content_type,
-               accessed_at: Timex.now() |> Timex.to_naive_datetime() |> NaiveDateTime.truncate(:second)
+               accessed_at:
+                 Timex.now() |> Timex.to_naive_datetime() |> NaiveDateTime.truncate(:second)
              })
              |> Repo.insert() do
         Storage.uri_for(file_uuid, content_type, file_key)
@@ -82,7 +87,9 @@ defmodule Ret.CachedFile do
 
   def vacuum(%{expiration: expiration}) do
     Ret.Locking.exec_if_lockable(:cached_file_vacuum, fn ->
-      cached_files_to_delete = from(f in CachedFile, where: f.accessed_at() < ^expiration) |> Repo.all()
+      cached_files_to_delete =
+        from(f in CachedFile, where: f.accessed_at() < ^expiration) |> Repo.all()
+
       keys = Enum.map(cached_files_to_delete, fn v -> v.cache_key end)
 
       case Storage.vacuum(%{cached_files: cached_files_to_delete}) do
@@ -94,11 +101,17 @@ defmodule Ret.CachedFile do
           Repo.delete_all(from(c in CachedFile, where: c.cache_key in ^keys))
           # If a CachedFile is backed by a file in expiring_storage_path, then this version of
           # the Storage.vacuum task will not delete the underlying files.
-          Logger.info("Removing #{length(errors)} cached files without finding underlying assets.")
+          Logger.info(
+            "Removing #{length(errors)} cached files without finding underlying assets."
+          )
+
           %{vacuumed: vacuumed, errors: errors}
 
         _ ->
-          Logger.info("Failed to vacuum cached files. #{length(cached_files_to_delete)} files will not be deleted.")
+          Logger.info(
+            "Failed to vacuum cached files. #{length(cached_files_to_delete)} files will not be deleted."
+          )
+
           %{vacuumed: [], errors: cached_files_to_delete}
       end
     end)

--- a/lib/ret/crypto.ex
+++ b/lib/ret/crypto.ex
@@ -23,7 +23,10 @@ defmodule Ret.Crypto do
   def encrypt(plaintext, key \\ default_secret_key()) do
     iv = :crypto.strong_rand_bytes(16)
     hashed_key = :crypto.hash(:sha256, key)
-    {ciphertext, tag} = :crypto.block_encrypt(:aes_gcm, hashed_key, iv, {"AES256GCM", plaintext |> to_string(), 16})
+
+    {ciphertext, tag} =
+      :crypto.block_encrypt(:aes_gcm, hashed_key, iv, {"AES256GCM", plaintext |> to_string(), 16})
+
     iv <> tag <> ciphertext
   end
 
@@ -65,7 +68,8 @@ defmodule Ret.Crypto do
     aes_key = :crypto.hash(:sha256, key)
     state = :crypto.stream_init(:aes_ctr, aes_key, <<0::size(128)>>)
 
-    [<<header_ciphertext::binary-size(12), _header_chunk::binary>>] = infile |> Stream.take(1) |> Enum.map(& &1)
+    [<<header_ciphertext::binary-size(12), _header_chunk::binary>>] =
+      infile |> Stream.take(1) |> Enum.map(& &1)
 
     case :crypto.stream_decrypt(state, header_ciphertext) do
       {_state, <<@header_bytes, file_size::size(32)>>} ->
@@ -107,7 +111,8 @@ defmodule Ret.Crypto do
 
   # At beginning, skip header
   defp decrypt_chunk(ciphertext, {nil, total_bytes, state, _plaintext}) do
-    {state, <<_header::binary-size(12), body::binary>>} = :crypto.stream_decrypt(state, ciphertext)
+    {state, <<_header::binary-size(12), body::binary>>} =
+      :crypto.stream_decrypt(state, ciphertext)
 
     {byte_size(body), total_bytes, state, body}
   end
@@ -115,7 +120,8 @@ defmodule Ret.Crypto do
   defp decrypt_chunk(ciphertext, {decrypted_bytes, total_bytes, state, _plaintext}) do
     max_bytes = min(total_bytes - decrypted_bytes, byte_size(ciphertext))
 
-    {state, <<plaintext::binary-size(max_bytes), _padding::binary>>} = :crypto.stream_decrypt(state, ciphertext)
+    {state, <<plaintext::binary-size(max_bytes), _padding::binary>>} =
+      :crypto.stream_decrypt(state, ciphertext)
 
     {decrypted_bytes + byte_size(plaintext), total_bytes, state, plaintext}
   end

--- a/lib/ret/db_warmer_job.ex
+++ b/lib/ret/db_warmer_job.ex
@@ -6,7 +6,7 @@ defmodule Ret.DbWarmerJob do
   def warm_db_if_has_ccu do
     if RetWeb.Presence.has_present_members?() do
       # Ping DB to keep up
-      from(h in Ret.Hub, limit: 0) |> Ret.Repo.all()
+      Ret.Repo.all(from h in Ret.Hub, limit: 0)
     end
   end
 end

--- a/lib/ret/enums.ex
+++ b/lib/ret/enums.ex
@@ -3,12 +3,20 @@ import EctoEnum
 defenum(Ret.Hub.EntryMode, :hub_entry_mode, [:allow, :invite, :deny], schema: "ret0")
 defenum(Ret.HubInvite.State, :hub_invite_state, [:active, :revoked], schema: "ret0")
 defenum(Ret.HubBinding.Type, :hub_binding_type, [:discord, :slack], schema: "ret0")
-defenum(Ret.OAuthProvider.Source, :oauth_provider_source, [:discord, :slack, :twitter], schema: "ret0")
+
+defenum(Ret.OAuthProvider.Source, :oauth_provider_source, [:discord, :slack, :twitter],
+  schema: "ret0"
+)
+
 defenum(Ret.OwnedFile.State, :owned_file_state, [:active, :inactive, :removed], schema: "ret0")
 defenum(Ret.Scene.State, :scene_state, [:active, :removed], schema: "ret0")
 defenum(Ret.SceneListing.State, :scene_listing_state, [:active, :delisted], schema: "ret0")
 defenum(Ret.Avatar.State, :avatar_state, [:active, :removed], schema: "ret0")
-defenum(Ret.AvatarListing.State, :avatar_listing_state, [:active, :delisted, :removed], schema: "ret0")
+
+defenum(Ret.AvatarListing.State, :avatar_listing_state, [:active, :delisted, :removed],
+  schema: "ret0"
+)
+
 defenum(Ret.Account.State, :account_state, [:enabled, :disabled], schema: "ret0")
 defenum(Ret.Asset.Type, :asset_type, [:image, :video, :model, :audio], schema: "ret0")
 defenum(Ret.Api.TokenSubjectType, :api_token_subject_type, [:app, :account], schema: "ret0")

--- a/lib/ret/guardian.ex
+++ b/lib/ret/guardian.ex
@@ -18,13 +18,14 @@ defmodule Ret.Guardian do
   def resource_from_claims(%{"sub" => account_id, "iat" => issued_at}) do
     issued_at_utc_datetime = DateTime.from_unix!(issued_at, :second) |> DateTime.to_iso8601()
 
-    Account
-    |> where(
-      [a],
-      a.account_id == ^account_id and a.min_token_issued_at <= ^issued_at_utc_datetime
-    )
+    query =
+      from a in Account,
+        where: a.account_id == ^account_id,
+        where: a.min_token_issued_at <= ^issued_at_utc_datetime,
+        preload: [:oauth_providers, :identity]
+
+    query
     |> Repo.one()
-    |> Repo.preload([:oauth_providers, :identity])
     |> result_for_account
   end
 

--- a/lib/ret/guardian.ex
+++ b/lib/ret/guardian.ex
@@ -19,7 +19,10 @@ defmodule Ret.Guardian do
     issued_at_utc_datetime = DateTime.from_unix!(issued_at, :second) |> DateTime.to_iso8601()
 
     Account
-    |> where([a], a.account_id == ^account_id and a.min_token_issued_at <= ^issued_at_utc_datetime)
+    |> where(
+      [a],
+      a.account_id == ^account_id and a.min_token_issued_at <= ^issued_at_utc_datetime
+    )
     |> Repo.one()
     |> Repo.preload([:oauth_providers, :identity])
     |> result_for_account

--- a/lib/ret/http_utils.ex
+++ b/lib/ret/http_utils.ex
@@ -45,7 +45,10 @@ defmodule Ret.HttpUtils do
     headers =
       if options[:append_browser_user_agent] do
         options[:headers] ++
-          [{"User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0"}]
+          [
+            {"User-Agent",
+             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0"}
+          ]
       else
         options[:headers]
       end
@@ -57,7 +60,11 @@ defmodule Ret.HttpUtils do
         []
       end
 
-    retry with: exponential_backoff() |> randomize |> cap(options[:cap_ms]) |> expiry(options[:expiry_ms]) do
+    retry with:
+            exponential_backoff()
+            |> randomize
+            |> cap(options[:cap_ms])
+            |> expiry(options[:expiry_ms]) do
       http_client = module_config(:http_client) || HTTPoison
 
       case http_client.request(verb, url, body, headers,

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -103,7 +103,12 @@ defmodule Ret.Hub do
     field(:entry_mode, Ret.Hub.EntryMode)
     field(:user_data, :map)
     belongs_to(:scene, Ret.Scene, references: :scene_id, on_replace: :nilify)
-    belongs_to(:scene_listing, Ret.SceneListing, references: :scene_listing_id, on_replace: :nilify)
+
+    belongs_to(:scene_listing, Ret.SceneListing,
+      references: :scene_listing_id,
+      on_replace: :nilify
+    )
+
     has_many(:web_push_subscriptions, Ret.WebPushSubscription, foreign_key: :hub_id)
     belongs_to(:created_by_account, Ret.Account, references: :account_id)
     has_many(:hub_invites, Ret.HubInvite, foreign_key: :hub_id)
@@ -221,7 +226,11 @@ defmodule Ret.Hub do
 
   defp scene_change_from_params(%{scene_id: _id, scene_url: _url}) do
     {:error,
-     %{key: :scene_id, message: "Cannot specify both scene_id and scene_url. Choose one or the other (or neither)."}}
+     %{
+       key: :scene_id,
+       message:
+         "Cannot specify both scene_id and scene_url. Choose one or the other (or neither)."
+     }}
   end
 
   defp scene_change_from_params(%{scene_url: nil}) do
@@ -237,7 +246,8 @@ defmodule Ret.Hub do
 
     case url |> URI.parse() do
       %URI{host: ^endpoint_host, path: "/scenes/" <> scene_path} ->
-        scene_or_scene_listing = scene_path |> String.split("/") |> Enum.at(0) |> Scene.scene_or_scene_listing_by_sid()
+        scene_or_scene_listing =
+          scene_path |> String.split("/") |> Enum.at(0) |> Scene.scene_or_scene_listing_by_sid()
 
         if is_nil(scene_or_scene_listing) do
           {:error, %{key: :scene_url, message: "Cannot find scene with url: " <> url}}
@@ -349,7 +359,10 @@ defmodule Ret.Hub do
 
   def get_my_rooms(account, params) do
     Hub
-    |> where([h], h.created_by_account_id == ^account.account_id and h.entry_mode in ^["allow", "invite"])
+    |> where(
+      [h],
+      h.created_by_account_id == ^account.account_id and h.entry_mode in ^["allow", "invite"]
+    )
     |> order_by(desc: :inserted_at)
     |> preload(^Hub.hub_preloads())
     |> Repo.paginate(params)
@@ -358,7 +371,9 @@ defmodule Ret.Hub do
   def get_favorite_rooms(account, params) do
     Hub
     |> where([h], h.entry_mode in ^["allow", "invite"])
-    |> join(:inner, [h], f in AccountFavorite, on: f.hub_id == h.hub_id and f.account_id == ^account.account_id)
+    |> join(:inner, [h], f in AccountFavorite,
+      on: f.hub_id == h.hub_id and f.account_id == ^account.account_id
+    )
     |> order_by([h, f], desc: f.last_activated_at)
     |> preload(^Hub.hub_preloads())
     |> Repo.paginate(params)
@@ -408,7 +423,9 @@ defmodule Ret.Hub do
   end
 
   def member_permissions_from_attrs(%{} = attrs) do
-    attrs["member_permissions"] |> Map.new(fn {k, v} -> {String.to_atom(k), v} end) |> member_permissions_to_int
+    attrs["member_permissions"]
+    |> Map.new(fn {k, v} -> {String.to_atom(k), v} end)
+    |> member_permissions_to_int
   end
 
   defp add_member_permissions_update_to_changeset(changeset, hub, member_permissions) do
@@ -435,7 +452,10 @@ defmodule Ret.Hub do
 
   def add_promotion_to_changeset(changeset, attrs) do
     changeset
-    |> put_change(:allow_promotion, Map.get(attrs, "allow_promotion", false) || Map.get(attrs, :allow_promotion, false))
+    |> put_change(
+      :allow_promotion,
+      Map.get(attrs, "allow_promotion", false) || Map.get(attrs, :allow_promotion, false)
+    )
   end
 
   def maybe_add_entry_mode_to_changeset(changeset, attrs) do
@@ -469,7 +489,8 @@ defmodule Ret.Hub do
     |> validate_required([:max_occupant_count])
   end
 
-  def changeset_for_seen_embedded_hub(%Hub{} = hub), do: hub |> cast(%{embedded: true}, [:embedded])
+  def changeset_for_seen_embedded_hub(%Hub{} = hub),
+    do: hub |> cast(%{embedded: true}, [:embedded])
 
   # NOTE occupant_count is 1 when there is 1 *other* user in the room with you, so active is when >= 1.
   defp maybe_add_last_active_at_to_changeset(changeset, occupant_count) when occupant_count >= 1,
@@ -538,10 +559,15 @@ defmodule Ret.Hub do
   def add_account_to_changeset(changeset, nil), do: changeset
 
   def add_account_to_changeset(changeset, %Account{} = account) do
-    changeset |> put_assoc(:created_by_account, account) |> put_change(:creator_assignment_token, nil)
+    changeset
+    |> put_assoc(:created_by_account, account)
+    |> put_change(:creator_assignment_token, nil)
   end
 
-  def send_push_messages_for_join(%Hub{web_push_subscriptions: subscriptions} = hub, endpoint_to_skip \\ nil) do
+  def send_push_messages_for_join(
+        %Hub{web_push_subscriptions: subscriptions} = hub,
+        endpoint_to_skip \\ nil
+      ) do
     body = hub |> push_message_for_join
 
     for subscription <- subscriptions |> Enum.filter(&(&1.endpoint != endpoint_to_skip)) do
@@ -550,7 +576,13 @@ defmodule Ret.Hub do
   end
 
   defp push_message_for_join(%Hub{} = hub) do
-    %{type: "join", hub_name: hub.name, hub_id: hub.hub_sid, hub_url: hub |> url_for, image: hub |> image_url_for}
+    %{
+      type: "join",
+      hub_name: hub.name,
+      hub_id: hub.hub_sid,
+      hub_url: hub |> url_for,
+      image: hub |> image_url_for
+    }
     |> Poison.encode!()
   end
 
@@ -575,7 +607,10 @@ defmodule Ret.Hub do
   def member_count_for(hub_sid) do
     RetWeb.Presence.list("hub:#{hub_sid}")
     |> Enum.filter(fn {_, %{metas: m}} ->
-      m |> Enum.any?(fn %{presence: p, context: c} -> p == :room and !(c != nil and Map.get(c, "discord", false)) end)
+      m
+      |> Enum.any?(fn %{presence: p, context: c} ->
+        p == :room and !(c != nil and Map.get(c, "discord", false))
+      end)
     end)
     |> Enum.count()
   end
@@ -585,7 +620,10 @@ defmodule Ret.Hub do
   def lobby_count_for(hub_sid) do
     RetWeb.Presence.list("hub:#{hub_sid}")
     |> Enum.filter(fn {_, %{metas: m}} ->
-      m |> Enum.any?(fn %{presence: p, context: c} -> p == :lobby and !(c != nil and Map.get(c, "discord", false)) end)
+      m
+      |> Enum.any?(fn %{presence: p, context: c} ->
+        p == :lobby and !(c != nil and Map.get(c, "discord", false))
+      end)
     end)
     |> Enum.count()
   end
@@ -630,7 +668,9 @@ defmodule Ret.Hub do
         |> Enum.map(& &1.hub_sid)
 
       present_hub_sids = RetWeb.Presence.present_hub_sids()
-      clearable_hub_sids = candidate_hub_sids |> Enum.filter(&(!Enum.member?(present_hub_sids, &1)))
+
+      clearable_hub_sids =
+        candidate_hub_sids |> Enum.filter(&(!Enum.member?(present_hub_sids, &1)))
 
       from(h in Hub, where: h.hub_sid in ^clearable_hub_sids) |> Repo.update_all(set: [host: nil])
     end)
@@ -678,13 +718,20 @@ defmodule Ret.Hub do
 
   defp add_default_member_permissions_to_changeset(changeset) do
     if Ret.AppConfig.get_config_bool("features|permissive_rooms") do
-      changeset |> put_change(:member_permissions, @default_member_permissions |> member_permissions_to_int)
+      changeset
+      |> put_change(:member_permissions, @default_member_permissions |> member_permissions_to_int)
     else
-      changeset |> put_change(:member_permissions, @default_restrictive_member_permissions |> member_permissions_to_int)
+      changeset
+      |> put_change(
+        :member_permissions,
+        @default_restrictive_member_permissions |> member_permissions_to_int
+      )
     end
   end
 
-  def add_owner!(%Hub{created_by_account_id: created_by_account_id} = hub, %Account{account_id: account_id})
+  def add_owner!(%Hub{created_by_account_id: created_by_account_id} = hub, %Account{
+        account_id: account_id
+      })
       when created_by_account_id != nil and created_by_account_id === account_id,
       do: hub
 
@@ -714,7 +761,8 @@ defmodule Ret.Hub do
   def is_creator?(_hub, _account), do: false
 
   def is_owner?(%Hub{hub_role_memberships: hub_role_memberships} = hub, account_id) do
-    is_creator?(hub, account_id) || hub_role_memberships |> Enum.any?(&(&1.account_id === account_id))
+    is_creator?(hub, account_id) ||
+      hub_role_memberships |> Enum.any?(&(&1.account_id === account_id))
   end
 
   @doc """
@@ -722,7 +770,8 @@ defmodule Ret.Hub do
   Does not throw on invalid permissions
   """
   def lenient_member_permissions_to_int(%{} = member_permissions) do
-    invalid_member_permissions = member_permissions |> Map.drop(@member_permissions_keys) |> Map.keys()
+    invalid_member_permissions =
+      member_permissions |> Map.drop(@member_permissions_keys) |> Map.keys()
 
     if invalid_member_permissions |> Enum.count() > 0 do
       {ArgumentError, "Invalid permissions #{invalid_member_permissions |> Enum.join(", ")}"}
@@ -750,7 +799,9 @@ defmodule Ret.Hub do
 
   def has_member_permission?(%Hub{} = hub, member_permission) do
     case @member_permissions
-         |> Enum.find(fn {_, member_permission_name} -> member_permission_name == member_permission end) do
+         |> Enum.find(fn {_, member_permission_name} ->
+           member_permission_name == member_permission
+         end) do
       nil -> raise ArgumentError, "Invalid permission #{member_permission}"
       {val, _} -> (hub.member_permissions &&& val) > 0
     end
@@ -826,7 +877,11 @@ defmodule Ret.Hub do
     do: %{owner: false, creator: false, signed_in: false}
 
   def roles_for_account(%Ret.Hub{} = hub, account),
-    do: %{owner: hub |> is_owner?(account.account_id), creator: hub |> is_creator?(account.account_id), signed_in: true}
+    do: %{
+      owner: hub |> is_owner?(account.account_id),
+      creator: hub |> is_creator?(account.account_id),
+      signed_in: true
+    }
 end
 
 defimpl Canada.Can, for: Ret.Account do
@@ -850,7 +905,9 @@ defimpl Canada.Can, for: Ret.Account do
     false
   end
 
-  def can?(%Ret.Account{account_id: account_id}, :revoke_credentials, %Credentials{account_id: account_id}) do
+  def can?(%Ret.Account{account_id: account_id}, :revoke_credentials, %Credentials{
+        account_id: account_id
+      }) do
     true
   end
 
@@ -938,7 +995,8 @@ defimpl Canada.Can, for: Ret.Account do
         created_by_account_id: created_by_account_id,
         hub_bindings: []
       })
-      when action in @creator_actions and created_by_account_id != nil and created_by_account_id == account_id,
+      when action in @creator_actions and created_by_account_id != nil and
+             created_by_account_id == account_id,
       do: true
 
   # Unbound hubs - Owners can perform special actions
@@ -947,7 +1005,8 @@ defimpl Canada.Can, for: Ret.Account do
       do: hub |> Ret.Hub.is_owner?(account_id)
 
   # Unbound hubs - Object actions can be performed if granted in member permissions or if account is an owner
-  def can?(%Ret.Account{account_id: account_id}, action, %Hub{hub_bindings: []} = hub) when action in @object_actions do
+  def can?(%Ret.Account{account_id: account_id}, action, %Hub{hub_bindings: []} = hub)
+      when action in @object_actions do
     hub |> Hub.has_member_permission?(action) or hub |> Ret.Hub.is_owner?(account_id)
   end
 
@@ -966,7 +1025,9 @@ defimpl Canada.Can, for: Ret.Account do
 
   # Create accounts
   def can?(%Ret.Account{is_admin: true}, :create_account, _), do: true
-  def can?(_account, :create_account, _), do: !AppConfig.get_cached_config_value("features|disable_sign_up")
+
+  def can?(_account, :create_account, _),
+    do: !AppConfig.get_cached_config_value("features|disable_sign_up")
 
   # Deny permissions for any other case that falls through
   def can?(_, _, _), do: false
@@ -986,7 +1047,15 @@ defimpl Canada.Can, for: Ret.OAuthProvider do
     :voice_chat,
     :text_chat
   ]
-  @special_actions [:update_hub, :update_roles, :close_hub, :embed_hub, :kick_users, :mute_users, :amplify_audio]
+  @special_actions [
+    :update_hub,
+    :update_roles,
+    :close_hub,
+    :embed_hub,
+    :kick_users,
+    :mute_users,
+    :amplify_audio
+  ]
 
   # Always deny access to non-enterable hubs
   def can?(%Ret.OAuthProvider{}, :join_hub, %Ret.Hub{entry_mode: :deny}), do: false
@@ -1001,9 +1070,15 @@ defimpl Canada.Can, for: Ret.OAuthProvider do
   end
 
   # Object permissions for OAuthProvider users are based on member permission settings
-  def can?(%Ret.OAuthProvider{} = oauth_provider, action, %Ret.Hub{hub_bindings: hub_bindings} = hub)
+  def can?(
+        %Ret.OAuthProvider{} = oauth_provider,
+        action,
+        %Ret.Hub{hub_bindings: hub_bindings} = hub
+      )
       when action in @object_actions do
-    is_member = hub_bindings |> Enum.any?(&(oauth_provider |> Ret.HubBinding.member_of_channel?(&1)))
+    is_member =
+      hub_bindings |> Enum.any?(&(oauth_provider |> Ret.HubBinding.member_of_channel?(&1)))
+
     is_member and hub |> Hub.has_member_permission?(action)
   end
 
@@ -1067,7 +1142,8 @@ defimpl Canada.Can, for: Atom do
     do: !AppConfig.get_cached_config_value("features|disable_room_creation")
 
   # Create accounts
-  def can?(_, :create_account, _), do: !AppConfig.get_cached_config_value("features|disable_sign_up")
+  def can?(_, :create_account, _),
+    do: !AppConfig.get_cached_config_value("features|disable_sign_up")
 
   def can?(_, _, _), do: false
 end

--- a/lib/ret/hub_binding.ex
+++ b/lib/ret/hub_binding.ex
@@ -17,7 +17,10 @@ defmodule Ret.HubBinding do
     timestamps()
   end
 
-  def bind_hub(%{"community_id" => community_id, "channel_id" => channel_id, "type" => _, "hub_id" => _} = params) do
+  def bind_hub(
+        %{"community_id" => community_id, "channel_id" => channel_id, "type" => _, "hub_id" => _} =
+          params
+      ) do
     hub_binding = HubBinding |> Repo.get_by(community_id: community_id, channel_id: channel_id)
 
     (hub_binding || %HubBinding{})
@@ -42,12 +45,18 @@ defmodule Ret.HubBinding do
 
   def can_manage_channel?(%Ret.Account{} = account, %Ret.HubBinding{type: type} = hub_binding) do
     chat_client = get_chat_client(type)
-    account |> matching_oauth_provider(hub_binding) |> chat_client.has_permission?(hub_binding, :manage_channels)
+
+    account
+    |> matching_oauth_provider(hub_binding)
+    |> chat_client.has_permission?(hub_binding, :manage_channels)
   end
 
   def can_moderate_users?(%Ret.Account{} = account, %Ret.HubBinding{type: type} = hub_binding) do
     chat_client = get_chat_client(type)
-    account |> matching_oauth_provider(hub_binding) |> chat_client.has_permission?(hub_binding, :kick_members)
+
+    account
+    |> matching_oauth_provider(hub_binding)
+    |> chat_client.has_permission?(hub_binding, :kick_members)
   end
 
   def member_of_channel?(%Ret.Account{} = account, %Ret.HubBinding{} = hub_binding) do
@@ -72,7 +81,10 @@ defmodule Ret.HubBinding do
 
   def member_of_channel?(_, _), do: false
 
-  def fetch_display_name(%Ret.OAuthProvider{source: source} = oauth_provider, %Ret.HubBinding{} = hub_binding) do
+  def fetch_display_name(
+        %Ret.OAuthProvider{source: source} = oauth_provider,
+        %Ret.HubBinding{} = hub_binding
+      ) do
     chat_client = get_chat_client(source)
     chat_client.fetch_display_name(oauth_provider, hub_binding)
   end

--- a/lib/ret/hub_binding.ex
+++ b/lib/ret/hub_binding.ex
@@ -9,10 +9,11 @@ defmodule Ret.HubBinding do
   @primary_key {:hub_binding_id, :id, autogenerate: true}
 
   schema "hub_bindings" do
-    field(:type, HubBinding.Type)
-    field(:community_id, :string)
-    field(:channel_id, :string)
-    belongs_to(:hub, Hub, references: :hub_id)
+    field :type, HubBinding.Type
+    field :community_id, :string
+    field :channel_id, :string
+
+    belongs_to :hub, Hub, references: :hub_id
 
     timestamps()
   end

--- a/lib/ret/hub_invite.ex
+++ b/lib/ret/hub_invite.ex
@@ -8,9 +8,11 @@ defmodule Ret.HubInvite do
   @primary_key {:hub_invite_id, :id, autogenerate: true}
 
   schema "hub_invites" do
-    field(:hub_invite_sid, :string)
-    field(:state, HubInvite.State)
-    belongs_to(:hub, Hub, references: :hub_id)
+    field :hub_invite_sid, :string
+    field :state, HubInvite.State
+
+    belongs_to :hub, Hub, references: :hub_id
+
     timestamps()
   end
 

--- a/lib/ret/hub_role_membership.ex
+++ b/lib/ret/hub_role_membership.ex
@@ -8,8 +8,8 @@ defmodule Ret.HubRoleMembership do
   @primary_key {:hub_role_membership_id, :id, autogenerate: true}
 
   schema "hub_role_memberships" do
-    belongs_to(:hub, Ret.Hub, references: :hub_id)
-    belongs_to(:account, Ret.Account, references: :account_id)
+    belongs_to :hub, Ret.Hub, references: :hub_id
+    belongs_to :account, Ret.Account, references: :account_id
 
     # Right now role membership is implicit to be the single role of "owners", no db state for now in accordance with YAGNI
 

--- a/lib/ret/identity.ex
+++ b/lib/ret/identity.ex
@@ -8,8 +8,9 @@ defmodule Ret.Identity do
   @primary_key {:identity_id, :id, autogenerate: true}
 
   schema "identities" do
-    field(:name, :string)
-    belongs_to(:account, Ret.Account, references: :account_id)
+    field :name, :string
+
+    belongs_to :account, Ret.Account, references: :account_id
 
     timestamps()
   end

--- a/lib/ret/load_balancing/janus_load_status.ex
+++ b/lib/ret/load_balancing/janus_load_status.ex
@@ -14,7 +14,10 @@ defmodule Ret.JanusLoadStatus do
           {:ok, [{:host_to_ccu, pods}]}
         else
           _ ->
-            Logger.warn("falling back to default_janus_host because get_dialog_pods() returned []")
+            Logger.warn(
+              "falling back to default_janus_host because get_dialog_pods() returned []"
+            )
+
             {:ok, [{:host_to_ccu, [{module_config(:default_janus_host), 0}]}]}
         end
       end
@@ -78,7 +81,8 @@ defmodule Ret.JanusLoadStatus do
         admin_secret: janus_secret
       }
 
-      janus_resp = retry_api_post_until_success("http://#{janus_ip}:#{janus_port}/admin", janus_payload)
+      janus_resp =
+        retry_api_post_until_success("http://#{janus_ip}:#{janus_port}/admin", janus_payload)
 
       case janus_resp do
         %HTTPoison.Response{status_code: 200, body: body} ->
@@ -103,7 +107,10 @@ defmodule Ret.JanusLoadStatus do
         end
 
       # For local dev, allow insecure SSL because of webpack server
-      case HTTPoison.post(url, payload |> Poison.encode!(), [{"Content-Type", "application/json"}],
+      case HTTPoison.post(
+             url,
+             payload |> Poison.encode!(),
+             [{"Content-Type", "application/json"}],
              hackney: hackney_options
            ) do
         {:ok, %HTTPoison.Response{status_code: 200} = resp} -> resp

--- a/lib/ret/locking.ex
+++ b/lib/ret/locking.ex
@@ -27,7 +27,8 @@ defmodule Ret.Locking do
       )
 
     try do
-      <<lock_key::little-signed-integer-size(64), _::binary>> = :crypto.hash(:sha256, lock_name |> to_string)
+      <<lock_key::little-signed-integer-size(64), _::binary>> =
+        :crypto.hash(:sha256, lock_name |> to_string)
 
       case Postgrex.query!(pid, "select pg_try_advisory_lock($1)", [lock_key], timeout: 60_000) do
         %Postgrex.Result{rows: [[true]]} ->
@@ -50,13 +51,21 @@ defmodule Ret.Locking do
 
     Repo.checkout(
       fn ->
-        Ecto.Adapters.SQL.query!(Repo, "set idle_in_transaction_session_timeout = #{timeout};", [], timeout: 60_000)
+        Ecto.Adapters.SQL.query!(
+          Repo,
+          "set idle_in_transaction_session_timeout = #{timeout};",
+          [],
+          timeout: 60_000
+        )
 
         res =
           Repo.transaction(fn ->
-            <<lock_key::little-signed-integer-size(64), _::binary>> = :crypto.hash(:sha256, lock_name |> to_string)
+            <<lock_key::little-signed-integer-size(64), _::binary>> =
+              :crypto.hash(:sha256, lock_name |> to_string)
 
-            case Ecto.Adapters.SQL.query!(Repo, "select pg_try_advisory_xact_lock($1);", [lock_key]) do
+            case Ecto.Adapters.SQL.query!(Repo, "select pg_try_advisory_xact_lock($1);", [
+                   lock_key
+                 ]) do
               %Postgrex.Result{rows: [[true]]} ->
                 exec.()
 
@@ -77,11 +86,17 @@ defmodule Ret.Locking do
 
     Repo.checkout(
       fn ->
-        Ecto.Adapters.SQL.query!(Repo, "set idle_in_transaction_session_timeout = #{timeout};", [], timeout: 60_000)
+        Ecto.Adapters.SQL.query!(
+          Repo,
+          "set idle_in_transaction_session_timeout = #{timeout};",
+          [],
+          timeout: 60_000
+        )
 
         res =
           Repo.transaction(fn ->
-            <<lock_key::little-signed-integer-size(64), _::binary>> = :crypto.hash(:sha256, lock_name |> to_string)
+            <<lock_key::little-signed-integer-size(64), _::binary>> =
+              :crypto.hash(:sha256, lock_name |> to_string)
 
             Ecto.Adapters.SQL.query!(Repo, "select pg_advisory_xact_lock($1);", [lock_key])
 

--- a/lib/ret/login.ex
+++ b/lib/ret/login.ex
@@ -8,8 +8,9 @@ defmodule Ret.Login do
   @primary_key {:login_id, :id, autogenerate: true}
 
   schema "logins" do
-    field(:identifier_hash, :string)
-    belongs_to(:account, Account, references: :account_id)
+    field :identifier_hash, :string
+
+    belongs_to :account, Account, references: :account_id
 
     timestamps()
   end

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -63,7 +63,10 @@ defmodule Ret.MediaResolver do
   end
 
   # auto convert dropbox urls to "raw" urls
-  def resolve(%MediaResolverQuery{url: %URI{host: "www.dropbox.com", path: "/s/" <> _rest} = url}, _root_host) do
+  def resolve(
+        %MediaResolverQuery{url: %URI{host: "www.dropbox.com", path: "/s/" <> _rest} = url},
+        _root_host
+      ) do
     {:commit,
      url
      |> Map.put(
@@ -275,19 +278,31 @@ defmodule Ret.MediaResolver do
     {:commit, uri |> resolved(meta)}
   end
 
-  defp resolve_non_video(%MediaResolverQuery{url: %URI{path: "/gifs/" <> _rest} = uri}, "giphy.com") do
+  defp resolve_non_video(
+         %MediaResolverQuery{url: %URI{path: "/gifs/" <> _rest} = uri},
+         "giphy.com"
+       ) do
     resolve_giphy_media_uri(uri, "mp4")
   end
 
-  defp resolve_non_video(%MediaResolverQuery{url: %URI{path: "/stickers/" <> _rest} = uri}, "giphy.com") do
+  defp resolve_non_video(
+         %MediaResolverQuery{url: %URI{path: "/stickers/" <> _rest} = uri},
+         "giphy.com"
+       ) do
     resolve_giphy_media_uri(uri, "url")
   end
 
-  defp resolve_non_video(%MediaResolverQuery{url: %URI{path: "/videos/" <> _rest} = uri}, "tenor.com") do
+  defp resolve_non_video(
+         %MediaResolverQuery{url: %URI{path: "/videos/" <> _rest} = uri},
+         "tenor.com"
+       ) do
     {:commit, uri |> resolved(%{expected_content_type: "video/mp4"})}
   end
 
-  defp resolve_non_video(%MediaResolverQuery{url: %URI{path: "/gallery/" <> gallery_id} = uri}, "imgur.com") do
+  defp resolve_non_video(
+         %MediaResolverQuery{url: %URI{path: "/gallery/" <> gallery_id} = uri},
+         "imgur.com"
+       ) do
     [resolved_url, meta] =
       "https://imgur-apiv3.p.mashape.com/3/gallery/#{gallery_id}"
       |> image_data_for_imgur_collection_api_url
@@ -295,7 +310,10 @@ defmodule Ret.MediaResolver do
     {:commit, (resolved_url || uri) |> resolved(meta)}
   end
 
-  defp resolve_non_video(%MediaResolverQuery{url: %URI{path: "/a/" <> album_id} = uri}, "imgur.com") do
+  defp resolve_non_video(
+         %MediaResolverQuery{url: %URI{path: "/a/" <> album_id} = uri},
+         "imgur.com"
+       ) do
     [resolved_url, meta] =
       "https://imgur-apiv3.p.mashape.com/3/album/#{album_id}"
       |> image_data_for_imgur_collection_api_url
@@ -347,7 +365,10 @@ defmodule Ret.MediaResolver do
     end
   end
 
-  defp fallback_to_screenshot_opengraph_or_nothing(%MediaResolverQuery{url: %URI{host: host} = uri, version: version}) do
+  defp fallback_to_screenshot_opengraph_or_nothing(%MediaResolverQuery{
+         url: %URI{host: host} = uri,
+         version: version
+       }) do
     photomnemonic_endpoint = module_config(:photomnemonic_endpoint)
 
     # Crawl og tags for hubs rooms + scenes
@@ -355,7 +376,10 @@ defmodule Ret.MediaResolver do
 
     case uri
          |> URI.to_string()
-         |> retry_head_then_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_user_agent: true) do
+         |> retry_head_then_get_until_success(
+           headers: [{"Range", "bytes=0-32768"}],
+           append_browser_user_agent: true
+         ) do
       :error ->
         :error
 
@@ -412,7 +436,10 @@ defmodule Ret.MediaResolver do
   defp opengraph_result_for_uri(uri) do
     case uri
          |> URI.to_string()
-         |> retry_get_until_success(headers: [{"Range", "bytes=0-32768"}], append_browser_user_agent: true) do
+         |> retry_get_until_success(
+           headers: [{"Range", "bytes=0-32768"}],
+           append_browser_user_agent: true
+         ) do
       :error ->
         :error
 
@@ -454,7 +481,11 @@ defmodule Ret.MediaResolver do
 
   defp get_sketchfab_model_zip_url(%{model_id: model_id, api_key: api_key}) do
     case "https://api.sketchfab.com/v3/models/#{model_id}/download"
-         |> retry_get_until_success(headers: [{"Authorization", "Token #{api_key}"}], cap_ms: 15_000, expiry_ms: 15_000) do
+         |> retry_get_until_success(
+           headers: [{"Authorization", "Token #{api_key}"}],
+           cap_ms: 15_000,
+           expiry_ms: 15_000
+         ) do
       :error ->
         {:error, "Failed to get sketchfab metadata"}
 
@@ -625,11 +656,15 @@ defmodule Ret.MediaResolver do
   defp ytdl_resolution(%MediaResolverQuery{quality: :high_360}), do: "[height<=2160]"
   defp ytdl_resolution(_query), do: "[height<=720]"
 
-  defp ytdl_qualifier(%MediaResolverQuery{quality: quality}) when quality in [:low, :high], do: "best"
+  defp ytdl_qualifier(%MediaResolverQuery{quality: quality}) when quality in [:low, :high],
+    do: "best"
+
   # for 360, we always grab dedicated audio track
   defp ytdl_qualifier(_query), do: "bestvideo"
 
-  defp query_ytdl_audio?(%MediaResolverQuery{quality: quality}) when quality in [:low, :high], do: false
+  defp query_ytdl_audio?(%MediaResolverQuery{quality: quality}) when quality in [:low, :high],
+    do: false
+
   defp query_ytdl_audio?(_query), do: true
 
   defp ytdl_format(query, "crunchyroll.com") do

--- a/lib/ret/meta.ex
+++ b/lib/ret/meta.ex
@@ -8,7 +8,9 @@ defmodule Ret.Meta do
   defp base_meta do
     %{
       version: @version,
-      phx_host: module_config(:phx_host) || :net_adm.localhost() |> :net_adm.dns_hostname() |> elem(1) |> to_string,
+      phx_host:
+        module_config(:phx_host) ||
+          :net_adm.localhost() |> :net_adm.dns_hostname() |> elem(1) |> to_string,
       phx_port: Application.get_env(:ret, RetWeb.Endpoint)[:https][:port] |> to_string,
       pool: Application.get_env(:ret, Ret)[:pool]
     }

--- a/lib/ret/node_stat.ex
+++ b/lib/ret/node_stat.ex
@@ -8,10 +8,10 @@ defmodule Ret.NodeStat do
   @primary_key false
 
   schema "node_stats" do
-    field(:node_id, :binary)
-    field(:measured_at, :utc_datetime)
-    field(:present_sessions, :integer)
-    field(:present_rooms, :integer)
+    field :node_id, :binary
+    field :measured_at, :utc_datetime
+    field :present_sessions, :integer
+    field :present_rooms, :integer
   end
 
   def changeset(%NodeStat{} = node_stat, attrs) do
@@ -29,11 +29,12 @@ defmodule Ret.NodeStat do
     end_time_truncated = end_time |> NaiveDateTime.truncate(:second)
 
     max_ccu =
-      from(ns in NodeStat,
-        select: max(ns.present_sessions),
-        where: ns.measured_at >= ^start_time_truncated and ns.measured_at < ^end_time_truncated
+      Repo.one(
+        from stat in NodeStat,
+          select: max(stat.present_sessions),
+          where: stat.measured_at >= ^start_time_truncated,
+          where: stat.measured_at < ^end_time_truncated
       )
-      |> Repo.one()
 
     if max_ccu === nil, do: 0, else: max_ccu
   end

--- a/lib/ret/oauth_provider.ex
+++ b/lib/ret/oauth_provider.ex
@@ -5,11 +5,12 @@ defmodule Ret.OAuthProvider do
   @primary_key {:oauth_provider_id, :id, autogenerate: true}
 
   schema "oauth_providers" do
-    field(:source, Ret.OAuthProvider.Source)
-    field(:provider_account_id, :string)
-    field(:provider_access_token, Ret.EncryptedField)
-    field(:provider_access_token_secret, Ret.EncryptedField)
-    belongs_to(:account, Ret.Account, references: :account_id)
+    field :source, Ret.OAuthProvider.Source
+    field :provider_account_id, :string
+    field :provider_access_token, Ret.EncryptedField
+    field :provider_access_token_secret, Ret.EncryptedField
+
+    belongs_to :account, Ret.Account, references: :account_id
 
     timestamps()
   end

--- a/lib/ret/owned_file.ex
+++ b/lib/ret/owned_file.ex
@@ -9,12 +9,13 @@ defmodule Ret.OwnedFile do
   @schema_prefix "ret0"
   @primary_key {:owned_file_id, :id, autogenerate: true}
   schema "owned_files" do
-    field(:owned_file_uuid, :string)
-    field(:key, :string)
-    field(:content_type, :string)
-    field(:content_length, :integer)
-    field(:state, OwnedFile.State)
-    belongs_to(:account, Account, references: :account_id)
+    field :owned_file_uuid, :string
+    field :key, :string
+    field :content_type, :string
+    field :content_length, :integer
+    field :state, OwnedFile.State
+
+    belongs_to :account, Account, references: :account_id
 
     timestamps()
   end
@@ -35,9 +36,7 @@ defmodule Ret.OwnedFile do
   end
 
   def inactive() do
-    OwnedFile
-    |> where(state: "inactive")
-    |> Repo.all()
+    Repo.all(from OwnedFile, where: [state: ^:inactive])
   end
 
   def set_active(owned_file_uuid, account_id) do
@@ -53,9 +52,7 @@ defmodule Ret.OwnedFile do
   end
 
   def get_by_uuid_and_account(owned_file_uuid, account_id) do
-    OwnedFile
-    |> where(owned_file_uuid: ^owned_file_uuid, account_id: ^account_id)
-    |> Repo.one()
+    Repo.one(from OwnedFile, where: [owned_file_uuid: ^owned_file_uuid, account_id: ^account_id])
   end
 
   defp set_state(nil, _state), do: nil

--- a/lib/ret/page_origin_warmer.ex
+++ b/lib/ret/page_origin_warmer.ex
@@ -39,7 +39,9 @@ defmodule Ret.PageOriginWarmer do
           if last_aggregated_etag !== latest_aggregated_etag do
             cache_values =
               @pages
-              |> Enum.map(fn {source, page} -> Task.async(fn -> page_to_cache_entry(source, page) end) end)
+              |> Enum.map(fn {source, page} ->
+                Task.async(fn -> page_to_cache_entry(source, page) end)
+              end)
               |> Enum.map(&Task.await(&1, 15_000))
               |> Enum.reject(&is_nil/1)
 

--- a/lib/ret/perms_token.ex
+++ b/lib/ret/perms_token.ex
@@ -3,7 +3,10 @@ defmodule Ret.PermsToken do
   PermsTokens grant granular permissions to users in various contexts.
   They are signed with an RSA algorithm so that external systems can verify tokens with our corresponding public key.
   """
-  use Guardian, otp_app: :ret, secret_fetcher: Ret.PermsTokenSecretFetcher, allowed_algos: ["RS512"]
+  use Guardian,
+    otp_app: :ret,
+    secret_fetcher: Ret.PermsTokenSecretFetcher,
+    allowed_algos: ["RS512"]
 
   def subject_for_token(_resource, %{"account_id" => account_id, "hub_id" => hub_id}) do
     {:ok, "#{account_id}_#{hub_id}"}

--- a/lib/ret/project.ex
+++ b/lib/ret/project.ex
@@ -17,7 +17,11 @@ defmodule Ret.Project do
     belongs_to(:thumbnail_owned_file, Ret.OwnedFile, references: :owned_file_id)
 
     belongs_to(:parent_scene, Scene, references: :scene_id, on_replace: :nilify)
-    belongs_to(:parent_scene_listing, SceneListing, references: :scene_listing_id, on_replace: :nilify)
+
+    belongs_to(:parent_scene_listing, SceneListing,
+      references: :scene_listing_id,
+      on_replace: :nilify
+    )
 
     many_to_many(:assets, Ret.Asset,
       join_through: Ret.ProjectAsset,
@@ -100,7 +104,9 @@ defmodule Ret.Project do
       from(Project, select: [:project_id, :project_owned_file_id, :created_by_account_id])
       |> Repo.stream()
       |> Stream.chunk_every(@rewrite_chunk_size)
-      |> Stream.flat_map(fn chunk -> Repo.preload(chunk, [:project_owned_file, :created_by_account]) end)
+      |> Stream.flat_map(fn chunk ->
+        Repo.preload(chunk, [:project_owned_file, :created_by_account])
+      end)
 
     Repo.transaction(fn ->
       Enum.each(project_stream, fn project ->

--- a/lib/ret/project_asset.ex
+++ b/lib/ret/project_asset.ex
@@ -7,8 +7,9 @@ defmodule Ret.ProjectAsset do
   @schema_prefix "ret0"
   @primary_key {:project_asset_id, :id, autogenerate: true}
   schema "project_assets" do
-    belongs_to(:project, Ret.Project, references: :project_id)
-    belongs_to(:asset, Ret.Asset, references: :asset_id)
+    belongs_to :project, Ret.Project, references: :project_id
+    belongs_to :asset, Ret.Asset, references: :asset_id
+
     timestamps()
   end
 

--- a/lib/ret/room_object.ex
+++ b/lib/ret/room_object.ex
@@ -17,7 +17,11 @@ defmodule Ret.RoomObject do
     timestamps()
   end
 
-  def perform_pin!(%Hub{hub_id: hub_id} = hub, %Account{} = account, %{object_id: object_id} = attrs) do
+  def perform_pin!(
+        %Hub{hub_id: hub_id} = hub,
+        %Account{} = account,
+        %{object_id: object_id} = attrs
+      ) do
     attrs = attrs |> Map.put(:gltf_node, attrs |> Map.get(:gltf_node) |> Poison.encode!())
 
     room_object =

--- a/lib/ret/scene.ex
+++ b/lib/ret/scene.ex
@@ -19,38 +19,42 @@ defmodule Ret.Scene do
   @schema_prefix "ret0"
   @primary_key {:scene_id, :id, autogenerate: true}
   schema "scenes" do
-    field(:scene_sid, :string)
-    field(:slug, SceneSlug.Type)
-    field(:name, :string)
-    field(:description, :string)
-    field(:attribution, :string)
-    field(:attributions, :map)
-    field(:allow_remixing, :boolean)
-    field(:allow_promotion, :boolean)
+    field :scene_sid, :string
+    field :slug, SceneSlug.Type
+    field :name, :string
+    field :description, :string
+    field :attribution, :string
+    field :attributions, :map
+    field :allow_remixing, :boolean
+    field :allow_promotion, :boolean
+    field :imported_from_host, :string
+    field :imported_from_port, :integer
+    field :imported_from_sid, :string
+    field :state, Scene.State
 
-    field(:imported_from_host, :string)
-    field(:imported_from_port, :integer)
-    field(:imported_from_sid, :string)
+    belongs_to :account, Ret.Account, references: :account_id
 
-    belongs_to(:parent_scene, Scene, references: :scene_id, on_replace: :nilify)
+    belongs_to :parent_scene, Scene,
+      references: :scene_id,
+      on_replace: :nilify
 
-    belongs_to(:parent_scene_listing, SceneListing,
+    belongs_to :parent_scene_listing, SceneListing,
       references: :scene_listing_id,
       on_replace: :nilify
-    )
 
-    has_one(:project, Project, foreign_key: :scene_id)
-
-    belongs_to(:account, Ret.Account, references: :account_id)
-    belongs_to(:model_owned_file, Ret.OwnedFile, references: :owned_file_id, on_replace: :nilify)
-
-    belongs_to(:screenshot_owned_file, Ret.OwnedFile,
+    belongs_to :model_owned_file, Ret.OwnedFile,
       references: :owned_file_id,
       on_replace: :nilify
-    )
 
-    belongs_to(:scene_owned_file, Ret.OwnedFile, references: :owned_file_id, on_replace: :nilify)
-    field(:state, Scene.State)
+    belongs_to :screenshot_owned_file, Ret.OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    belongs_to :scene_owned_file, Ret.OwnedFile,
+      references: :owned_file_id,
+      on_replace: :nilify
+
+    has_one :project, Project, foreign_key: :scene_id
 
     timestamps()
   end
@@ -75,14 +79,13 @@ defmodule Ret.Scene do
 
   def projectless_scenes_for_account(account) do
     Repo.all(
-      from(s in Scene,
+      from s in Scene,
         left_join: project in assoc(s, :project),
-        where:
-          s.account_id == ^account.account_id and is_nil(s.scene_owned_file_id) and
-            is_nil(project),
+        where: s.account_id == ^account.account_id,
+        where: is_nil(s.scene_owned_file_id),
+        where: is_nil(project),
         preload: ^Scene.scene_preloads(),
         order_by: [desc: s.updated_at]
-      )
     )
   end
 
@@ -204,8 +207,11 @@ defmodule Ret.Scene do
 
   @rewrite_chunk_size 50
   def rewrite_domain_for_all(old_domain_url, new_domain_url) do
+    query =
+      from Scene, select: [:scene_id, :scene_owned_file_id, :model_owned_file_id, :account_id]
+
     scene_stream =
-      from(Scene, select: [:scene_id, :scene_owned_file_id, :model_owned_file_id, :account_id])
+      query
       |> Repo.stream()
       |> Stream.chunk_every(@rewrite_chunk_size)
       |> Stream.flat_map(fn chunk ->

--- a/lib/ret/scene_listing.ex
+++ b/lib/ret/scene_listing.ex
@@ -18,20 +18,22 @@ defmodule Ret.SceneListing do
   @schema_prefix "ret0"
   @primary_key {:scene_listing_id, :id, autogenerate: true}
   schema "scene_listings" do
-    field(:scene_listing_sid, :string)
-    field(:slug, SceneListingSlug.Type)
-    field(:name, :string)
-    field(:description, :string)
-    field(:tags, :map)
-    field(:attributions, :map)
-    belongs_to(:scene, Ret.Scene, references: :scene_id)
-    belongs_to(:model_owned_file, Ret.OwnedFile, references: :owned_file_id)
-    belongs_to(:screenshot_owned_file, Ret.OwnedFile, references: :owned_file_id)
-    belongs_to(:scene_owned_file, Ret.OwnedFile, references: :owned_file_id)
-    has_one(:account, through: [:scene, :account])
-    has_one(:project, through: [:scene, :project])
-    field(:order, :integer)
-    field(:state, SceneListing.State)
+    field :scene_listing_sid, :string
+    field :slug, SceneListingSlug.Type
+    field :name, :string
+    field :description, :string
+    field :tags, :map
+    field :attributions, :map
+    field :order, :integer
+    field :state, SceneListing.State
+
+    belongs_to :scene, Ret.Scene, references: :scene_id
+    belongs_to :model_owned_file, Ret.OwnedFile, references: :owned_file_id
+    belongs_to :screenshot_owned_file, Ret.OwnedFile, references: :owned_file_id
+    belongs_to :scene_owned_file, Ret.OwnedFile, references: :owned_file_id
+
+    has_one :account, through: [:scene, :account]
+    has_one :project, through: [:scene, :project]
 
     timestamps()
   end

--- a/lib/ret/schema.ex
+++ b/lib/ret/schema.ex
@@ -5,7 +5,9 @@ defmodule Ret.Schema do
 
   @spec is_struct(term) :: boolean
   defguardp is_struct(term)
-            when is_map(term) and :erlang.is_map_key(:__struct__, term) and is_atom(:erlang.map_get(:__struct__, term))
+            when is_map(term) and
+                   :erlang.is_map_key(:__struct__, term) and
+                   is_atom(:erlang.map_get(:__struct__, term))
 
   @spec is_struct(term, module) :: boolean
   defguardp is_struct(term, module)

--- a/lib/ret/session_stat.ex
+++ b/lib/ret/session_stat.ex
@@ -8,11 +8,11 @@ defmodule Ret.SessionStat do
   @primary_key false
 
   schema "session_stats" do
-    field(:session_id, :binary_id)
-    field(:started_at, :utc_datetime)
-    field(:ended_at, :utc_datetime)
-    field(:entered_event_payload, :map)
-    field(:entered_event_received_at, :utc_datetime)
+    field :session_id, :binary_id
+    field :started_at, :utc_datetime
+    field :ended_at, :utc_datetime
+    field :entered_event_payload, :map
+    field :entered_event_received_at, :utc_datetime
   end
 
   def changeset(%SessionStat{} = session_stat, attrs) do
@@ -28,11 +28,8 @@ defmodule Ret.SessionStat do
 
   def stat_query_for_socket(socket) do
     # Use date constraint to limit partitions to recent partitions, assume sessions don't last more than a week
-    from(
-      s in SessionStat,
-      where:
-        s.session_id == ^socket.assigns.session_id and
-          s.started_at >= datetime_add(^NaiveDateTime.utc_now(), -1, "week")
-    )
+    from s in SessionStat,
+      where: s.session_id == ^socket.assigns.session_id,
+      where: s.started_at >= datetime_add(^NaiveDateTime.utc_now(), -1, "week")
   end
 end

--- a/lib/ret/session_token.ex
+++ b/lib/ret/session_token.ex
@@ -4,7 +4,10 @@ defmodule Ret.SessionToken do
   Session uuids are generated on the server and the tokens containing them are stored in clients' localStorage.
   They allow us to re-establish an verify a session if a client needs to re-connect, without losing session state.
   """
-  use Guardian, otp_app: :ret, secret_fetcher: Ret.SessionTokenSecretFetcher, allowed_algos: ["HS512"]
+  use Guardian,
+    otp_app: :ret,
+    secret_fetcher: Ret.SessionTokenSecretFetcher,
+    allowed_algos: ["HS512"]
 
   def subject_for_token(_resource, %{"session_id" => session_id}) do
     {:ok, "#{session_id}"}

--- a/lib/ret/slack_client.ex
+++ b/lib/ret/slack_client.ex
@@ -27,7 +27,9 @@ defmodule Ret.SlackClient do
 
     %{"authed_user" => authed_user} =
       "#{@slack_api_base}/api/oauth.v2.access"
-      |> Ret.HttpUtils.retry_post_until_success(body, headers: [{"content-type", "application/x-www-form-urlencoded"}])
+      |> Ret.HttpUtils.retry_post_until_success(body,
+        headers: [{"content-type", "application/x-www-form-urlencoded"}]
+      )
       |> Map.get(:body)
       |> Poison.decode!()
 
@@ -48,7 +50,11 @@ defmodule Ret.SlackClient do
 
   def has_permission?(nil, _, _), do: false
 
-  def has_permission?(%Ret.OAuthProvider{} = oauth_provider, %Ret.HubBinding{} = hub_binding, permission) do
+  def has_permission?(
+        %Ret.OAuthProvider{} = oauth_provider,
+        %Ret.HubBinding{} = hub_binding,
+        permission
+      ) do
     oauth_provider.provider_account_id |> has_permission?(hub_binding, permission)
   end
 
@@ -100,7 +106,10 @@ defmodule Ret.SlackClient do
     name
   end
 
-  def fetch_community_identifier(%Ret.OAuthProvider{source: _type, provider_account_id: provider_account_id}) do
+  def fetch_community_identifier(%Ret.OAuthProvider{
+        source: _type,
+        provider_account_id: provider_account_id
+      }) do
     %{"user" => %{"real_name" => real_name}} =
       case Cachex.fetch(
              :slack_api,
@@ -114,7 +123,9 @@ defmodule Ret.SlackClient do
 
   def api_request(path) do
     "#{@slack_api_base}#{path}"
-    |> Ret.HttpUtils.retry_get_until_success(headers: [{"authorization", "Bearer #{module_config(:bot_token)}"}])
+    |> Ret.HttpUtils.retry_get_until_success(
+      headers: [{"authorization", "Bearer #{module_config(:bot_token)}"}]
+    )
     |> Map.get(:body)
     |> Poison.decode!()
   end

--- a/lib/ret/speelycaptor.ex
+++ b/lib/ret/speelycaptor.ex
@@ -2,7 +2,8 @@ defmodule Ret.Speelycaptor do
   import Ret.HttpUtils
 
   def convert(%Plug.Upload{path: path, content_type: "video/" <> _tail}, "video/mp4") do
-    with speelycaptor_endpoint when is_binary(speelycaptor_endpoint) <- module_config(:speelycaptor_endpoint) do
+    with speelycaptor_endpoint when is_binary(speelycaptor_endpoint) <-
+           module_config(:speelycaptor_endpoint) do
       case retry_get_until_success("#{speelycaptor_endpoint}/init") do
         %HTTPoison.Response{body: body} ->
           resp_body = body |> Poison.decode!()

--- a/lib/ret/storage.ex
+++ b/lib/ret/storage.ex
@@ -132,7 +132,10 @@ defmodule Ret.Storage do
   end
 
   def fetch(%CachedFile{} = cached_file) do
-    fetch_at(cached_file, Timex.now() |> Timex.to_naive_datetime() |> NaiveDateTime.truncate(:second))
+    fetch_at(
+      cached_file,
+      Timex.now() |> Timex.to_naive_datetime() |> NaiveDateTime.truncate(:second)
+    )
   end
 
   defp maybe_bump_accessed_at(%CachedFile{accessed_at: accessed_at} = cached_file, time) do
@@ -198,8 +201,10 @@ defmodule Ret.Storage do
   defp migrate(%CachedFile{file_uuid: id, file_key: file_key} = cached_file) do
     with {:ok, _meta, _stream} <- fetch_blob(id, file_key, expiring_file_path()),
          {:ok, uuid} <- Ecto.UUID.cast(id),
-         [_src_file_directory, src_meta_file_path, src_blob_file_path] <- paths_for_uuid(uuid, expiring_file_path()),
-         [dest_file_directory, dest_meta_file_path, dest_blob_file_path] <- paths_for_uuid(uuid, cached_file_path()),
+         [_src_file_directory, src_meta_file_path, src_blob_file_path] <-
+           paths_for_uuid(uuid, expiring_file_path()),
+         [dest_file_directory, dest_meta_file_path, dest_blob_file_path] <-
+           paths_for_uuid(uuid, cached_file_path()),
          :ok <- File.mkdir_p(dest_file_directory),
          :ok <- File.cp(src_meta_file_path, dest_meta_file_path),
          :ok <- File.cp(src_blob_file_path, dest_blob_file_path) do
@@ -269,7 +274,13 @@ defmodule Ret.Storage do
     |> Enum.into(%{})
   end
 
-  defp promote_or_return_owned_file(%OwnedFile{} = owned_file, _id, _key, _promotion_token, _account) do
+  defp promote_or_return_owned_file(
+         %OwnedFile{} = owned_file,
+         _id,
+         _key,
+         _promotion_token,
+         _account
+       ) do
     {:ok, owned_file}
   end
 
@@ -283,9 +294,14 @@ defmodule Ret.Storage do
       storage_path when is_binary(storage_path) <- module_config(:storage_path),
       {:ok, uuid} <- Ecto.UUID.cast(id),
       [_, meta_file_path, blob_file_path] <- paths_for_uuid(uuid, expiring_file_path()),
-      [dest_path, dest_meta_file_path, dest_blob_file_path] <- paths_for_uuid(uuid, owned_file_path()),
+      [dest_path, dest_meta_file_path, dest_blob_file_path] <-
+        paths_for_uuid(uuid, owned_file_path()),
       [{:ok, _}, {:ok, _}] <- [File.stat(meta_file_path), File.stat(blob_file_path)],
-      %{"content_type" => content_type, "content_length" => content_length, "promotion_token" => actual_promotion_token} <-
+      %{
+        "content_type" => content_type,
+        "content_length" => content_length,
+        "promotion_token" => actual_promotion_token
+      } <-
         File.read!(meta_file_path) |> Poison.decode!(),
       {:ok} <- check_promotion_token(actual_promotion_token, promotion_token),
       {:ok} <- check_blob_file_key(blob_file_path, key)
@@ -317,7 +333,9 @@ defmodule Ret.Storage do
   # promotion token, including nil.
   defp check_promotion_token(nil, _token), do: {:ok}
   defp check_promotion_token(actual_token, token) when actual_token == token, do: {:ok}
-  defp check_promotion_token(actual_token, token) when actual_token != token, do: {:error, :invalid_key}
+
+  defp check_promotion_token(actual_token, token) when actual_token != token,
+    do: {:error, :invalid_key}
 
   # Vacuums up TTLed out files
   def vacuum do
@@ -336,7 +354,9 @@ defmodule Ret.Storage do
           seconds_since_access = DateTime.diff(now, atime_datetime)
 
           if seconds_since_access > ttl do
-            Logger.info("Stored Files: Removing #{blob_file} after #{seconds_since_access}s since last access.")
+            Logger.info(
+              "Stored Files: Removing #{blob_file} after #{seconds_since_access}s since last access."
+            )
 
             File.rm!(blob_file)
             File.rm(blob_file |> String.replace_suffix(".blob", ".meta.json"))
@@ -360,7 +380,10 @@ defmodule Ret.Storage do
     end)
   end
 
-  defp remove_underlying_assets(%{cached_file: %CachedFile{file_uuid: id} = cached_file, path: path}) do
+  defp remove_underlying_assets(%{
+         cached_file: %CachedFile{file_uuid: id} = cached_file,
+         path: path
+       }) do
     try do
       {:ok, uuid} = Ecto.UUID.cast(id)
       [_file_path, meta_file_path, blob_file_path] = paths_for_uuid(uuid, path)
@@ -456,7 +479,8 @@ defmodule Ret.Storage do
   defp move_file_to_expiring_storage(uuid) do
     with(
       [_, meta_file_path, blob_file_path] <- paths_for_uuid(uuid, owned_file_path()),
-      [dest_path, dest_meta_file_path, dest_blob_file_path] <- paths_for_uuid(uuid, expiring_file_path())
+      [dest_path, dest_meta_file_path, dest_blob_file_path] <-
+        paths_for_uuid(uuid, expiring_file_path())
     ) do
       File.mkdir_p!(dest_path)
       File.rename(meta_file_path, dest_meta_file_path)
@@ -466,7 +490,9 @@ defmodule Ret.Storage do
 
   @spec rm_files_for_owned_file(OwnedFile.t()) :: :ok
   def rm_files_for_owned_file(%OwnedFile{} = owned_file) do
-    [_, meta_file_path, blob_file_path] = paths_for_uuid(owned_file.owned_file_uuid, owned_file_path())
+    [_, meta_file_path, blob_file_path] =
+      paths_for_uuid(owned_file.owned_file_uuid, owned_file_path())
+
     File.rm!(meta_file_path)
     File.rm!(blob_file_path)
   end
@@ -499,7 +525,12 @@ defmodule Ret.Storage do
   end
 
   defp encrypt_stream_to_file(source_stream, source_size, destination_path, key) do
-    Ret.Crypto.encrypt_stream_to_file(source_stream, source_size, destination_path, key |> Ret.Crypto.hash())
+    Ret.Crypto.encrypt_stream_to_file(
+      source_stream,
+      source_size,
+      destination_path,
+      key |> Ret.Crypto.hash()
+    )
   end
 
   @spec paths_for_owned_file(OwnedFile.t()) :: [String.t(), ...]
@@ -508,7 +539,10 @@ defmodule Ret.Storage do
   end
 
   defp paths_for_uuid(uuid, subpath) do
-    path = "#{module_config(:storage_path)}/#{subpath}/#{String.slice(uuid, 0, 2)}/#{String.slice(uuid, 2, 2)}"
+    path =
+      "#{module_config(:storage_path)}/#{subpath}/#{String.slice(uuid, 0, 2)}/#{
+        String.slice(uuid, 2, 2)
+      }"
 
     blob_file_path = "#{path}/#{uuid}.blob"
     meta_file_path = "#{path}/#{uuid}.meta.json"
@@ -516,7 +550,11 @@ defmodule Ret.Storage do
     [path, meta_file_path, blob_file_path]
   end
 
-  def duplicate_and_transform(%OwnedFile{owned_file_uuid: id, key: key}, %Account{} = account, transform)
+  def duplicate_and_transform(
+        %OwnedFile{owned_file_uuid: id, key: key},
+        %Account{} = account,
+        transform
+      )
       when is_function(transform, 2) do
     {:ok,
      %{
@@ -555,7 +593,9 @@ defmodule Ret.Storage do
   end
 
   def duplicate(%OwnedFile{} = owned_file, %Account{} = account) do
-    duplicate_and_transform(owned_file, account, fn stream, content_length -> {stream, content_length} end)
+    duplicate_and_transform(owned_file, account, fn stream, content_length ->
+      {stream, content_length}
+    end)
   end
 
   defp download!(url) do

--- a/lib/ret/storage_used.ex
+++ b/lib/ret/storage_used.ex
@@ -28,7 +28,8 @@ defmodule Ret.StorageUsed do
         {lines, 0} ->
           line = lines |> String.split("\n") |> Enum.at(1)
 
-          {:ok, [_FS, _kb, used, _Avail], _RestStr} = :io_lib.fread('~s~d~d~d', line |> to_charlist)
+          {:ok, [_FS, _kb, used, _Avail], _RestStr} =
+            :io_lib.fread('~s~d~d~d', line |> to_charlist)
 
           {:ok, [{:storage_used, used}]}
 

--- a/lib/ret/support.ex
+++ b/lib/ret/support.ex
@@ -30,13 +30,16 @@ defmodule Ret.Support do
     at_handles = handles |> Enum.map(fn h -> "@#{h}" end)
 
     message =
-      "*Incoming support request*\nOn call: #{at_handles |> Enum.join(" ")}\n<#{RetWeb.Endpoint.url()}/#{hub.hub_sid}|Enter Now>"
+      "*Incoming support request*\nOn call: #{at_handles |> Enum.join(" ")}\n<#{
+        RetWeb.Endpoint.url()
+      }/#{hub.hub_sid}|Enter Now>"
 
     notify_slack(":quest", message)
   end
 
   defp notify_slack(emoji, message) do
-    with slack_url when is_binary(slack_url) and slack_url != "" <- module_config(:slack_webhook_url) do
+    with slack_url when is_binary(slack_url) and slack_url != "" <-
+           module_config(:slack_webhook_url) do
       payload =
         %{
           "icon_emoji" => emoji,

--- a/lib/ret/support.ex
+++ b/lib/ret/support.ex
@@ -9,10 +9,13 @@ defmodule Ret.Support do
 
   def request_support_for_hub(hub) do
     if Support.available?() do
-      SupportSubscription
-      |> where(channel: "slack")
+      query =
+        from sub in SupportSubscription,
+          where: [channel: "slack"],
+          select: sub.identifier
+
+      query
       |> Repo.all()
-      |> Enum.map(&Map.get(&1, :identifier))
       |> notify_slack_handles_of_hub_support(hub)
     end
   end

--- a/lib/ret/support_subscription.ex
+++ b/lib/ret/support_subscription.ex
@@ -8,8 +8,8 @@ defmodule Ret.SupportSubscription do
   @primary_key {:support_subscription_id, :id, autogenerate: true}
 
   schema "support_subscriptions" do
-    field(:channel, :string)
-    field(:identifier, :string)
+    field :channel, :string
+    field :identifier, :string
 
     timestamps()
   end

--- a/lib/ret/twitter_client.ex
+++ b/lib/ret/twitter_client.ex
@@ -31,7 +31,8 @@ defmodule Ret.TwitterClient do
         {:error, reason}
 
       _ ->
-        "#{@twitter_api_base}/oauth/authorize?" <> URI.encode_query(%{oauth_token: token_response["oauth_token"]})
+        "#{@twitter_api_base}/oauth/authorize?" <>
+          URI.encode_query(%{oauth_token: token_response["oauth_token"]})
     end
   end
 
@@ -103,7 +104,9 @@ defmodule Ret.TwitterClient do
   end
 
   def available?() do
-    !!(module_config(:consumer_key) && module_config(:consumer_secret) && module_config(:access_token) &&
+    !!(module_config(:consumer_key) &&
+         module_config(:consumer_secret) &&
+         module_config(:access_token) &&
          module_config(:access_token_secret))
   end
 
@@ -138,7 +141,14 @@ defmodule Ret.TwitterClient do
     post(url, [{"status", body}, {"media_ids", "#{media_id}"}], creds, :json)
   end
 
-  defp post(url, params, creds, response_type \\ :urlencoded, cap_ms \\ 5_000, expiry_ms \\ 10_000) do
+  defp post(
+         url,
+         params,
+         creds,
+         response_type \\ :urlencoded,
+         cap_ms \\ 5_000,
+         expiry_ms \\ 10_000
+       ) do
     params = OAuther.sign("post", url, params, creds)
     encoded_params = URI.encode_query(params)
 

--- a/lib/ret/web_push_subscription.ex
+++ b/lib/ret/web_push_subscription.ex
@@ -35,12 +35,17 @@ defmodule Ret.WebPushSubscription do
         %Hub{hub_id: hub_id},
         subscription
       ) do
-    with %WebPushSubscription{} = web_push_subscription <- find_by_hub_id_and_subscription(hub_id, subscription) do
+    with %WebPushSubscription{} = web_push_subscription <-
+           find_by_hub_id_and_subscription(hub_id, subscription) do
       web_push_subscription |> Repo.delete!()
     end
   end
 
-  def maybe_send(%WebPushSubscription{endpoint: endpoint, p256dh: p256dh, auth: auth} = web_push_subscription, body) do
+  def maybe_send(
+        %WebPushSubscription{endpoint: endpoint, p256dh: p256dh, auth: auth} =
+          web_push_subscription,
+        body
+      ) do
     if may_send?(web_push_subscription) do
       subscription = %{
         endpoint: endpoint,

--- a/lib/ret/web_push_subscription.ex
+++ b/lib/ret/web_push_subscription.ex
@@ -11,12 +11,12 @@ defmodule Ret.WebPushSubscription do
   @push_rate_limit_seconds 60
 
   schema "web_push_subscriptions" do
-    field(:p256dh, :string)
-    field(:endpoint, :string)
-    field(:auth, EncryptedField)
-    field(:last_notified_at, :utc_datetime)
+    field :p256dh, :string
+    field :endpoint, :string
+    field :auth, EncryptedField
+    field :last_notified_at, :utc_datetime
 
-    belongs_to(:hub, Hub, references: :hub_id)
+    belongs_to :hub, Hub, references: :hub_id
 
     timestamps()
   end
@@ -76,15 +76,15 @@ defmodule Ret.WebPushSubscription do
   end
 
   defp find_by_hub_id_and_subscription(hub_id, %{"endpoint" => endpoint}) do
-    WebPushSubscription
-    |> where([t], t.hub_id == ^hub_id and t.endpoint == ^endpoint)
-    |> Repo.one()
+    Repo.one(
+      from sub in WebPushSubscription,
+        where: sub.hub_id == ^hub_id,
+        where: sub.endpoint == ^endpoint
+    )
   end
 
   def endpoint_has_subscriptions?(endpoint) do
-    WebPushSubscription
-    |> where([t], t.endpoint == ^endpoint)
-    |> Repo.aggregate(:count, :web_push_subscription_id) > 0
+    Repo.exists?(from sub in WebPushSubscription, where: sub.endpoint == ^endpoint)
   end
 
   def changeset_for_new(%WebPushSubscription{} = subscription, hub, params) do

--- a/lib/ret_web/api_helpers.ex
+++ b/lib/ret_web/api_helpers.ex
@@ -13,7 +13,9 @@ defmodule RetWeb.ApiHelpers do
   end
 
   defp create_records(conn, record, schema, handler) when is_map(record) do
-    case ExJsonSchema.Validator.validate(schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
+    case ExJsonSchema.Validator.validate(schema, record,
+           error_formatter: Ret.JsonSchemaApiErrorFormatter
+         ) do
       :ok ->
         case handler.(record, "data") do
           {:ok, {status, result}} ->
@@ -26,7 +28,9 @@ defmodule RetWeb.ApiHelpers do
       {:error, errors} ->
         conn
         |> send_error_resp(
-          Enum.map(errors, fn {code, detail, source} -> {code, detail, source |> String.replace(~r/^#/, "data")} end)
+          Enum.map(errors, fn {code, detail, source} ->
+            {code, detail, source |> String.replace(~r/^#/, "data")}
+          end)
         )
     end
   end
@@ -36,7 +40,9 @@ defmodule RetWeb.ApiHelpers do
       records
       |> Enum.with_index()
       |> Enum.map(fn {record, index} ->
-        case ExJsonSchema.Validator.validate(schema, record, error_formatter: Ret.JsonSchemaApiErrorFormatter) do
+        case ExJsonSchema.Validator.validate(schema, record,
+               error_formatter: Ret.JsonSchemaApiErrorFormatter
+             ) do
           :ok ->
             case handler.(record, "data[#{index}]") do
               {:ok, {status, result}} ->
@@ -67,19 +73,31 @@ defmodule RetWeb.ApiHelpers do
     |> send_error_resp([{:MALFORMED_RECORD, "Malformed record in 'data' property.", "data"}])
   end
 
-  defp send_error_resp(conn, [{:RECORD_EXISTS, _detail, _source}] = errors), do: conn |> send_error_resp(409, errors)
+  defp send_error_resp(conn, [{:RECORD_EXISTS, _detail, _source}] = errors),
+    do: conn |> send_error_resp(409, errors)
+
   defp send_error_resp(conn, errors), do: send_error_resp(conn, 400, errors)
 
   defp send_error_resp(conn, status, errors) do
     conn
     |> send_resp(
       status,
-      %{errors: Enum.map(errors, fn {code, detail, source} -> %{code: code, detail: detail, source: source} end)}
+      %{
+        errors:
+          Enum.map(errors, fn {code, detail, source} ->
+            %{code: code, detail: detail, source: source}
+          end)
+      }
       |> Poison.encode!()
     )
   end
 
   defp to_error_multi_request_response(errors) do
-    %{errors: Enum.map(errors, fn {code, detail, source} -> %{code: code, detail: detail, source: source} end)}
+    %{
+      errors:
+        Enum.map(errors, fn {code, detail, source} ->
+          %{code: code, detail: detail, source: source}
+        end)
+    }
   end
 end

--- a/lib/ret_web/auth_optional_pipeline.ex
+++ b/lib/ret_web/auth_optional_pipeline.ex
@@ -5,6 +5,6 @@ defmodule RetWeb.Guardian.AuthOptionalPipeline do
     module: Ret.Guardian,
     error_handler: RetWeb.Guardian.AuthErrorHandler
 
-  plug(Guardian.Plug.VerifyHeader, realm: "Bearer")
-  plug(Guardian.Plug.LoadResource, allow_blank: true)
+  plug Guardian.Plug.VerifyHeader, realm: "Bearer"
+  plug Guardian.Plug.LoadResource, allow_blank: true
 end

--- a/lib/ret_web/auth_pipeline.ex
+++ b/lib/ret_web/auth_pipeline.ex
@@ -4,7 +4,7 @@ defmodule RetWeb.Guardian.AuthPipeline do
     module: Ret.Guardian,
     error_handler: RetWeb.Guardian.AuthErrorHandler
 
-  plug(Guardian.Plug.VerifyHeader, realm: "Bearer")
-  plug(Guardian.Plug.EnsureAuthenticated)
-  plug(Guardian.Plug.LoadResource)
+  plug Guardian.Plug.VerifyHeader, realm: "Bearer"
+  plug Guardian.Plug.EnsureAuthenticated
+  plug Guardian.Plug.LoadResource
 end

--- a/lib/ret_web/channels/auth_channel.ex
+++ b/lib/ret_web/channels/auth_channel.ex
@@ -28,9 +28,14 @@ defmodule RetWeb.AuthChannel do
 
       if !account_disabled && (can?(nil, create_account(nil)) || !!account) do
         # Create token + send email
-        %LoginToken{token: token, payload_key: payload_key} = LoginToken.new_login_token_for_email(email)
+        %LoginToken{token: token, payload_key: payload_key} =
+          LoginToken.new_login_token_for_email(email)
 
-        encrypted_payload = %{"email" => email} |> Poison.encode!() |> Crypto.encrypt(payload_key) |> :base64.encode()
+        encrypted_payload =
+          %{"email" => email}
+          |> Poison.encode!()
+          |> Crypto.encrypt(payload_key)
+          |> :base64.encode()
 
         signin_args = %{
           auth_topic: socket.topic,
@@ -62,7 +67,8 @@ defmodule RetWeb.AuthChannel do
 
     case LoginToken.lookup_by_token(token) do
       %LoginToken{identifier_hash: identifier_hash, payload_key: payload_key} ->
-        decrypted_payload = auth_payload |> :base64.decode() |> Ret.Crypto.decrypt(payload_key) |> Poison.decode!()
+        decrypted_payload =
+          auth_payload |> :base64.decode() |> Ret.Crypto.decrypt(payload_key) |> Poison.decode!()
 
         broadcast_credentials_and_payload(identifier_hash, decrypted_payload, socket)
 
@@ -98,7 +104,9 @@ defmodule RetWeb.AuthChannel do
   defp broadcast_credentials_and_payload(nil, _payload, _socket), do: nil
 
   defp broadcast_credentials_and_payload(identifier_hash, payload, socket) do
-    account = identifier_hash |> Account.account_for_login_identifier_hash(can?(nil, create_account(nil)))
+    account =
+      identifier_hash |> Account.account_for_login_identifier_hash(can?(nil, create_account(nil)))
+
     credentials = account |> Account.credentials_for_account()
     broadcast!(socket, "auth_credentials", %{credentials: credentials, payload: payload})
   end

--- a/lib/ret_web/channels/auth_channel.ex
+++ b/lib/ret_web/channels/auth_channel.ex
@@ -6,7 +6,7 @@ defmodule RetWeb.AuthChannel do
 
   alias Ret.{Statix, LoginToken, Account, Crypto}
 
-  intercept(["auth_credentials"])
+  intercept ["auth_credentials"]
 
   def join("auth:" <> _topic_key, _payload, socket) do
     # Expire channel in 5 minutes

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -55,7 +55,14 @@ defmodule RetWeb.HubChannel do
     |> perform_join(
       hub,
       context,
-      params |> Map.take(["push_subscription_endpoint", "auth_token", "perms_token", "bot_access_key", "hub_invite_id"])
+      params
+      |> Map.take([
+        "push_subscription_endpoint",
+        "auth_token",
+        "perms_token",
+        "bot_access_key",
+        "hub_invite_id"
+      ])
     )
   end
 
@@ -76,7 +83,8 @@ defmodule RetWeb.HubChannel do
     bot_access_key = Application.get_env(:ret, :bot_access_key)
     has_valid_bot_access_key = !!(bot_access_key && params["bot_access_key"] == bot_access_key)
 
-    account_has_provider_for_hub = account |> Ret.Account.matching_oauth_providers(hub) |> Enum.empty?() |> Kernel.not()
+    account_has_provider_for_hub =
+      account |> Ret.Account.matching_oauth_providers(hub) |> Enum.empty?() |> Kernel.not()
 
     account_can_join = account |> can?(join_hub(hub))
     account_can_update = account |> can?(update_hub(hub))
@@ -128,7 +136,12 @@ defmodule RetWeb.HubChannel do
     # We expect the client to have stripped the "isFirstSync" keys from the message
     # for this optimization.
     if !String.contains?(naf_payload, "isFirstSync") do
-      broadcast_from!(socket, event |> internal_naf_event_for(socket), payload |> payload_with_from(socket))
+      broadcast_from!(
+        socket,
+        event |> internal_naf_event_for(socket),
+        payload |> payload_with_from(socket)
+      )
+
       {:noreply, socket}
     else
       # Full syncs must be properly authorized
@@ -139,7 +152,8 @@ defmodule RetWeb.HubChannel do
   # Captures all inbound NAF messages that result in spawned objects.
   def handle_in(
         "naf" = event,
-        %{"data" => %{"isFirstSync" => true, "persistent" => false, "template" => template}} = payload,
+        %{"data" => %{"isFirstSync" => true, "persistent" => false, "template" => template}} =
+          payload,
         socket
       ) do
     data = payload["data"]
@@ -152,7 +166,11 @@ defmodule RetWeb.HubChannel do
 
       payload = payload |> Map.put("data", data)
 
-      broadcast_from!(socket, event |> internal_naf_event_for(socket), payload |> payload_with_from(socket))
+      broadcast_from!(
+        socket,
+        event |> internal_naf_event_for(socket),
+        payload |> payload_with_from(socket)
+      )
 
       {:noreply, socket}
     else
@@ -161,13 +179,21 @@ defmodule RetWeb.HubChannel do
   end
 
   # Captures all inbound NAF Update Multi messages
-  def handle_in("naf" = event, %{"dataType" => "um", "data" => %{"d" => updates}} = payload, socket) do
+  def handle_in(
+        "naf" = event,
+        %{"dataType" => "um", "data" => %{"d" => updates}} = payload,
+        socket
+      ) do
     if updates |> Enum.any?(& &1["isFirstSync"]) do
       # Do not broadcast "um" messages that contain isFirstSyncs. NAF should never send these, so we'd only see them
       # from a malicious client.
       {:noreply, socket}
     else
-      broadcast_from!(socket, event |> internal_naf_event_for(socket), payload |> payload_with_from(socket))
+      broadcast_from!(
+        socket,
+        event |> internal_naf_event_for(socket),
+        payload |> payload_with_from(socket)
+      )
 
       {:noreply, socket}
     end
@@ -175,20 +201,31 @@ defmodule RetWeb.HubChannel do
 
   # Fallthrough for all other NAF dataTypes
   def handle_in("naf" = event, payload, socket) do
-    broadcast_from!(socket, event |> internal_naf_event_for(socket), payload |> payload_with_from(socket))
+    broadcast_from!(
+      socket,
+      event |> internal_naf_event_for(socket),
+      payload |> payload_with_from(socket)
+    )
+
     {:noreply, socket}
   end
 
   def handle_in("events:entering", _payload, socket) do
     context = socket.assigns.context || %{}
-    socket = socket |> assign(:context, context |> Map.put("entering", true)) |> broadcast_presence_update
+
+    socket =
+      socket
+      |> assign(:context, context |> Map.put("entering", true))
+      |> broadcast_presence_update
 
     {:noreply, socket}
   end
 
   def handle_in("events:entering_cancelled", _payload, socket) do
     context = socket.assigns.context || %{}
-    socket = socket |> assign(:context, context |> Map.delete("entering")) |> broadcast_presence_update
+
+    socket =
+      socket |> assign(:context, context |> Map.delete("entering")) |> broadcast_presence_update
 
     {:noreply, socket}
   end
@@ -232,14 +269,29 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  def handle_in("events:begin_recording", _payload, socket), do: socket |> set_presence_flag(:recording, true)
-  def handle_in("events:end_recording", _payload, socket), do: socket |> set_presence_flag(:recording, false)
-  def handle_in("events:raise_hand", _payload, socket), do: socket |> set_presence_flag(:hand_raised, true)
-  def handle_in("events:lower_hand", _payload, socket), do: socket |> set_presence_flag(:hand_raised, false)
-  def handle_in("events:begin_streaming", _payload, socket), do: socket |> set_presence_flag(:streaming, true)
-  def handle_in("events:end_streaming", _payload, socket), do: socket |> set_presence_flag(:streaming, false)
-  def handle_in("events:begin_typing", _payload, socket), do: socket |> set_presence_flag(:typing, true)
-  def handle_in("events:end_typing", _payload, socket), do: socket |> set_presence_flag(:typing, false)
+  def handle_in("events:begin_recording", _payload, socket),
+    do: socket |> set_presence_flag(:recording, true)
+
+  def handle_in("events:end_recording", _payload, socket),
+    do: socket |> set_presence_flag(:recording, false)
+
+  def handle_in("events:raise_hand", _payload, socket),
+    do: socket |> set_presence_flag(:hand_raised, true)
+
+  def handle_in("events:lower_hand", _payload, socket),
+    do: socket |> set_presence_flag(:hand_raised, false)
+
+  def handle_in("events:begin_streaming", _payload, socket),
+    do: socket |> set_presence_flag(:streaming, true)
+
+  def handle_in("events:end_streaming", _payload, socket),
+    do: socket |> set_presence_flag(:streaming, false)
+
+  def handle_in("events:begin_typing", _payload, socket),
+    do: socket |> set_presence_flag(:typing, true)
+
+  def handle_in("events:end_typing", _payload, socket),
+    do: socket |> set_presence_flag(:typing, false)
 
   def handle_in("message" = event, %{"type" => type} = payload, socket) do
     account = Guardian.Phoenix.Socket.current_resource(socket)
@@ -292,7 +344,8 @@ defmodule RetWeb.HubChannel do
     |> hub_for_socket
     |> WebPushSubscription.unsubscribe_from_hub(subscription)
 
-    has_remaining_subscriptions = WebPushSubscription.endpoint_has_subscriptions?(subscription["endpoint"])
+    has_remaining_subscriptions =
+      WebPushSubscription.endpoint_has_subscriptions?(subscription["endpoint"])
 
     {:reply, {:ok, %{has_remaining_subscriptions: has_remaining_subscriptions}}, socket}
   end
@@ -404,7 +457,9 @@ defmodule RetWeb.HubChannel do
 
   def handle_in("get_host", _args, socket) do
     hub = socket |> hub_for_socket |> Hub.ensure_host()
-    {:reply, {:ok, %{host: hub.host, port: Hub.janus_port(), turn: Hub.generate_turn_info()}}, socket}
+
+    {:reply, {:ok, %{host: hub.host, port: Hub.janus_port(), turn: Hub.generate_turn_info()}},
+     socket}
   end
 
   def handle_in("update_hub", payload, socket) do
@@ -414,19 +469,36 @@ defmodule RetWeb.HubChannel do
     if account |> can?(update_hub(hub)) do
       name_changed = hub.name != payload["name"]
       description_changed = hub.description != payload["description"]
-      member_permissions_changed = hub.member_permissions != payload |> Hub.member_permissions_from_attrs()
+
+      member_permissions_changed =
+        hub.member_permissions != payload |> Hub.member_permissions_from_attrs()
+
       room_size_changed = hub.room_size != payload["room_size"]
       can_change_promotion = account |> can?(update_hub_promotion(hub))
-      promotion_changed = can_change_promotion and hub.allow_promotion != payload["allow_promotion"]
+
+      promotion_changed =
+        can_change_promotion and hub.allow_promotion != payload["allow_promotion"]
+
       # Older clients may not send an entry_mode in the payload.
-      entry_mode_changed = payload["entry_mode"] !== nil and hub.entry_mode != payload["entry_mode"]
+      entry_mode_changed =
+        payload["entry_mode"] !== nil and hub.entry_mode != payload["entry_mode"]
 
       stale_fields = []
       stale_fields = if name_changed, do: ["name" | stale_fields], else: stale_fields
-      stale_fields = if description_changed, do: ["description" | stale_fields], else: stale_fields
-      stale_fields = if member_permissions_changed, do: ["member_permissions" | stale_fields], else: stale_fields
+
+      stale_fields =
+        if description_changed, do: ["description" | stale_fields], else: stale_fields
+
+      stale_fields =
+        if member_permissions_changed,
+          do: ["member_permissions" | stale_fields],
+          else: stale_fields
+
       stale_fields = if room_size_changed, do: ["room_size" | stale_fields], else: stale_fields
-      stale_fields = if promotion_changed, do: ["allow_promotion" | stale_fields], else: stale_fields
+
+      stale_fields =
+        if promotion_changed, do: ["allow_promotion" | stale_fields], else: stale_fields
+
       stale_fields = if entry_mode_changed, do: ["entry_mode" | stale_fields], else: stale_fields
 
       hub
@@ -460,6 +532,7 @@ defmodule RetWeb.HubChannel do
 
     if account |> can?(update_hub(hub)) and HubInvite.active?(hub, payload["hub_invite_id"]) do
       HubInvite.revoke_invite(hub, payload["hub_invite_id"])
+
       # Hubs can only have one invite for now, so we create a new one when the old one was revoked.
       hub_invite = hub |> HubInvite.find_or_create_invite_for_hub()
       {:reply, {:ok, %{hub_invite_id: hub_invite.hub_invite_sid}}, socket}
@@ -481,7 +554,9 @@ defmodule RetWeb.HubChannel do
 
       case url |> URI.parse() do
         %URI{host: ^endpoint_host, path: "/scenes/" <> scene_path} ->
-          scene_or_listing = scene_path |> String.split("/") |> Enum.at(0) |> Scene.scene_or_scene_listing_by_sid()
+          scene_or_listing =
+            scene_path |> String.split("/") |> Enum.at(0) |> Scene.scene_or_scene_listing_by_sid()
+
           hub |> Hub.changeset_for_new_scene(scene_or_listing)
 
         _ ->
@@ -521,7 +596,10 @@ defmodule RetWeb.HubChannel do
   def handle_in("block" = event, %{"session_id" => session_id} = payload, socket) do
     socket =
       socket
-      |> assign(:blocked_session_ids, socket.assigns.blocked_session_ids |> Map.put(session_id, true))
+      |> assign(
+        :blocked_session_ids,
+        socket.assigns.blocked_session_ids |> Map.put(session_id, true)
+      )
       |> assign_has_blocks
 
     broadcast_from!(socket, event, payload |> payload_with_from(socket))
@@ -531,7 +609,10 @@ defmodule RetWeb.HubChannel do
   def handle_in("unblock" = event, %{"session_id" => session_id} = payload, socket) do
     socket =
       socket
-      |> assign(:blocked_session_ids, socket.assigns.blocked_session_ids |> Map.delete(session_id))
+      |> assign(
+        :blocked_session_ids,
+        socket.assigns.blocked_session_ids |> Map.delete(session_id)
+      )
       |> assign_has_blocks
 
     broadcast_from!(socket, event, payload |> payload_with_from(socket))
@@ -552,9 +633,12 @@ defmodule RetWeb.HubChannel do
   # NOTE: block_naf will only work if the hub is embedded. We *only* enable packet filtering
   # (and therefore, only respect block_naf) when a hub is embedded (or if there are blocks on the socket.)
   def handle_in("block_naf", _payload, socket), do: {:noreply, socket |> assign(:block_naf, true)}
-  def handle_in("unblock_naf", _payload, socket), do: {:noreply, socket |> assign(:block_naf, false)}
 
-  def handle_in(event, %{"session_id" => _session_id} = payload, socket) when event in ["add_owner", "remove_owner"] do
+  def handle_in("unblock_naf", _payload, socket),
+    do: {:noreply, socket |> assign(:block_naf, false)}
+
+  def handle_in(event, %{"session_id" => _session_id} = payload, socket)
+      when event in ["add_owner", "remove_owner"] do
     account = Guardian.Phoenix.Socket.current_resource(socket)
     hub = socket |> hub_for_socket
 
@@ -587,17 +671,25 @@ defmodule RetWeb.HubChannel do
   # If the maybe- variant of the naf/nafr messages are seen, we are performing packet filtering due to blocks
   # or iframe embeds opting out of NAF traffic. Handle them appropriately. (This is expensive, and should be rare!)
   def handle_out(event, payload, socket) when event in ["maybe-nafr"] do
-    %{block_naf: block_naf, blocked_session_ids: blocked_session_ids, blocked_by_session_ids: blocked_by_session_ids} =
-      socket.assigns
+    %{
+      block_naf: block_naf,
+      blocked_session_ids: blocked_session_ids,
+      blocked_by_session_ids: blocked_by_session_ids
+    } = socket.assigns
 
-    socket |> maybe_push_naf("nafr", payload, block_naf, blocked_session_ids, blocked_by_session_ids)
+    socket
+    |> maybe_push_naf("nafr", payload, block_naf, blocked_session_ids, blocked_by_session_ids)
   end
 
   def handle_out(event, payload, socket) when event in ["maybe-naf"] do
-    %{block_naf: block_naf, blocked_session_ids: blocked_session_ids, blocked_by_session_ids: blocked_by_session_ids} =
-      socket.assigns
+    %{
+      block_naf: block_naf,
+      blocked_session_ids: blocked_session_ids,
+      blocked_by_session_ids: blocked_by_session_ids
+    } = socket.assigns
 
-    socket |> maybe_push_naf("naf", payload, block_naf, blocked_session_ids, blocked_by_session_ids)
+    socket
+    |> maybe_push_naf("naf", payload, block_naf, blocked_session_ids, blocked_by_session_ids)
   end
 
   def handle_out("mute" = event, %{"session_id" => session_id} = payload, socket) do
@@ -620,11 +712,18 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  def handle_out("block", %{"session_id" => session_id, :from_session_id => from_session_id}, socket) do
+  def handle_out(
+        "block",
+        %{"session_id" => session_id, :from_session_id => from_session_id},
+        socket
+      ) do
     socket =
       if socket.assigns.session_id === session_id do
         socket
-        |> assign(:blocked_by_session_ids, socket.assigns.blocked_by_session_ids |> Map.put(from_session_id, true))
+        |> assign(
+          :blocked_by_session_ids,
+          socket.assigns.blocked_by_session_ids |> Map.put(from_session_id, true)
+        )
         |> assign_has_blocks
       else
         socket
@@ -633,11 +732,18 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  def handle_out("unblock", %{"session_id" => session_id, :from_session_id => from_session_id}, socket) do
+  def handle_out(
+        "unblock",
+        %{"session_id" => session_id, :from_session_id => from_session_id},
+        socket
+      ) do
     socket =
       if socket.assigns.session_id === session_id do
         socket
-        |> assign(:blocked_by_session_ids, socket.assigns.blocked_by_session_ids |> Map.delete(from_session_id))
+        |> assign(
+          :blocked_by_session_ids,
+          socket.assigns.blocked_by_session_ids |> Map.delete(from_session_id)
+        )
         |> assign_has_blocks
       else
         socket
@@ -646,7 +752,8 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
-  def handle_out(event, %{"session_id" => session_id}, socket) when event in ["add_owner", "remove_owner"] do
+  def handle_out(event, %{"session_id" => session_id}, socket)
+      when event in ["add_owner", "remove_owner"] do
     account = Guardian.Phoenix.Socket.current_resource(socket)
 
     if account && socket.assigns.session_id == session_id do
@@ -671,14 +778,22 @@ defmodule RetWeb.HubChannel do
     blocked_session_ids = socket.assigns.blocked_session_ids
     blocked_by_session_ids = socket.assigns.blocked_by_session_ids
 
-    if !Map.has_key?(blocked_session_ids, from_session_id) and !Map.has_key?(blocked_by_session_ids, from_session_id) do
+    if !Map.has_key?(blocked_session_ids, from_session_id) and
+         !Map.has_key?(blocked_by_session_ids, from_session_id) do
       push(socket, event, payload |> payload_without_from)
     end
 
     {:noreply, socket}
   end
 
-  defp maybe_push_naf(socket, event, payload, false = _block_naf, blocked_session_ids, blocked_by_session_ids)
+  defp maybe_push_naf(
+         socket,
+         event,
+         payload,
+         false = _block_naf,
+         blocked_session_ids,
+         blocked_by_session_ids
+       )
        when blocked_session_ids === %{} and blocked_by_session_ids === %{} do
     push(socket, event, payload)
     {:noreply, socket}
@@ -692,7 +807,8 @@ defmodule RetWeb.HubChannel do
          blocked_session_ids,
          blocked_by_session_ids
        ) do
-    if !Map.has_key?(blocked_session_ids, from_session_id) and !Map.has_key?(blocked_by_session_ids, from_session_id) do
+    if !Map.has_key?(blocked_session_ids, from_session_id) and
+         !Map.has_key?(blocked_by_session_ids, from_session_id) do
       push(socket, event, payload)
     end
 
@@ -700,7 +816,14 @@ defmodule RetWeb.HubChannel do
   end
 
   # Sockets can block NAF as an optimization, eg iframe embeds do not need NAF messages until user clicks load
-  defp maybe_push_naf(socket, _event, _payload, true = _block_naf, _blocked_session_ids, _blocked_by_session_ids) do
+  defp maybe_push_naf(
+         socket,
+         _event,
+         _payload,
+         true = _block_naf,
+         _blocked_session_ids,
+         _blocked_by_session_ids
+       ) do
     {:noreply, socket}
   end
 
@@ -794,7 +917,11 @@ defmodule RetWeb.HubChannel do
   end
 
   defp broadcast_pinned_media(socket, object_id, gltf_node) do
-    broadcast!(socket, "pin", %{object_id: object_id, gltf_node: gltf_node, pinned_by: socket.assigns.session_id})
+    broadcast!(socket, "pin", %{
+      object_id: object_id,
+      gltf_node: gltf_node,
+      pinned_by: socket.assigns.session_id
+    })
   end
 
   # Broadcasts the full hub info as well as an (optional) list of specific fields which
@@ -824,7 +951,17 @@ defmodule RetWeb.HubChannel do
     |> maybe_override_identifiers(account)
     |> Map.put(:roles, hub |> Hub.roles_for_account(account))
     |> Map.put(:permissions, hub |> Hub.perms_for_account(account))
-    |> Map.take([:presence, :profile, :context, :roles, :permissions, :streaming, :recording, :hand_raised, :typing])
+    |> Map.take([
+      :presence,
+      :profile,
+      :context,
+      :roles,
+      :permissions,
+      :streaming,
+      :recording,
+      :hand_raised,
+      :typing
+    ])
   end
 
   # Hubs Bot can set their own display name.
@@ -879,7 +1016,9 @@ defmodule RetWeb.HubChannel do
     # There's no way tell which oauth_provider a user would like to identify with. We're just going to pick
     # the first one for now.
     oauth_provider =
-      account.oauth_providers |> Enum.filter(fn provider -> hub_binding.type == provider.source end) |> Enum.at(0)
+      account.oauth_providers
+      |> Enum.filter(fn provider -> hub_binding.type == provider.source end)
+      |> Enum.at(0)
 
     assigns |> override_display_name_via_binding(oauth_provider, hub_binding)
   end
@@ -1046,13 +1185,17 @@ defmodule RetWeb.HubChannel do
            |> assign(:oauth_account_id, params[:oauth_account_id])
            |> assign(:oauth_source, params[:oauth_source])
            |> assign(:has_valid_bot_access_key, params[:has_valid_bot_access_key]),
-         response <- HubView.render("show.json", %{hub: hub, embeddable: account |> can?(embed_hub(hub))}) do
+         response <-
+           HubView.render("show.json", %{hub: hub, embeddable: account |> can?(embed_hub(hub))}) do
       perms_token = params["perms_token"] || get_perms_token(hub, account)
 
       response =
         response
         |> Map.put(:session_id, socket.assigns.session_id)
-        |> Map.put(:session_token, socket.assigns.session_id |> Ret.SessionToken.token_for_session())
+        |> Map.put(
+          :session_token,
+          socket.assigns.session_id |> Ret.SessionToken.token_for_session()
+        )
         |> Map.put(:subscriptions, %{web_push: is_push_subscribed, favorites: is_favorited})
         |> Map.put(:perms_token, perms_token)
         |> Map.put(:hub_requires_oauth, params[:hub_requires_oauth])
@@ -1076,7 +1219,9 @@ defmodule RetWeb.HubChannel do
 
       # Send join push notification if this is the first joiner
       if Presence.list(socket.topic) |> Enum.count() == 0 do
-        Task.start_link(fn -> hub |> Hub.send_push_messages_for_join(push_subscription_endpoint) end)
+        Task.start_link(fn ->
+          hub |> Hub.send_push_messages_for_join(push_subscription_endpoint)
+        end)
       end
 
       Statix.increment("ret.channels.hub.joins.ok")
@@ -1104,7 +1249,10 @@ defmodule RetWeb.HubChannel do
     )
   end
 
-  defp get_perms_token(hub, %Ret.OAuthProvider{provider_account_id: provider_account_id, source: source} = account) do
+  defp get_perms_token(
+         hub,
+         %Ret.OAuthProvider{provider_account_id: provider_account_id, source: source} = account
+       ) do
     hub
     |> Hub.perms_for_account(account)
     |> Map.put(:oauth_account_id, provider_account_id)
@@ -1125,11 +1273,15 @@ defmodule RetWeb.HubChannel do
   end
 
   defp handle_entered_event(socket, payload) do
-    stat_attributes = [entered_event_payload: payload, entered_event_received_at: NaiveDateTime.utc_now()]
+    stat_attributes = [
+      entered_event_payload: payload,
+      entered_event_received_at: NaiveDateTime.utc_now()
+    ]
 
     # Flip context to have HMD if entered with display type
     socket =
-      with %{"entryDisplayType" => display} when is_binary(display) and display != "Screen" <- payload,
+      with %{"entryDisplayType" => display} when is_binary(display) and display != "Screen" <-
+             payload,
            %{context: context} when is_map(context) <- socket.assigns do
         socket |> assign(:context, context |> Map.put("hmd", true))
       else
@@ -1167,7 +1319,8 @@ defmodule RetWeb.HubChannel do
   end
 
   defp hub_for_socket(socket) do
-    Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid) |> Repo.preload([:hub_bindings, :hub_role_memberships])
+    Repo.get_by(Hub, hub_sid: socket.assigns.hub_sid)
+    |> Repo.preload([:hub_bindings, :hub_role_memberships])
   end
 
   defp payload_with_from(payload, socket) do
@@ -1180,7 +1333,8 @@ defmodule RetWeb.HubChannel do
 
   defp assign_has_blocks(socket) do
     has_blocks =
-      socket.assigns.blocked_session_ids |> Enum.any?() || socket.assigns.blocked_by_session_ids |> Enum.any?()
+      socket.assigns.blocked_session_ids |> Enum.any?() ||
+        socket.assigns.blocked_by_session_ids |> Enum.any?()
 
     socket |> assign(:has_blocks, has_blocks)
   end
@@ -1191,8 +1345,16 @@ defmodule RetWeb.HubChannel do
   # This is done via the intercepted maybe-nafr and maybe-naf events.
   #
   # We avoid doing this in general because it's extremely expensive, since it re-encodes all outgoing messages.
-  defp internal_naf_event_for("nafr", %Phoenix.Socket{assigns: %{has_blocks: false, has_embeds: false}}), do: "nafr"
-  defp internal_naf_event_for("naf", %Phoenix.Socket{assigns: %{has_blocks: false, has_embeds: false}}), do: "naf"
+  defp internal_naf_event_for("nafr", %Phoenix.Socket{
+         assigns: %{has_blocks: false, has_embeds: false}
+       }),
+       do: "nafr"
+
+  defp internal_naf_event_for("naf", %Phoenix.Socket{
+         assigns: %{has_blocks: false, has_embeds: false}
+       }),
+       do: "naf"
+
   defp internal_naf_event_for("nafr", _socket), do: "maybe-nafr"
   defp internal_naf_event_for("naf", _socket), do: "maybe-naf"
 end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -25,7 +25,7 @@ defmodule RetWeb.HubChannel do
   alias RetWeb.{Presence}
   alias RetWeb.Api.V1.{HubView}
 
-  intercept([
+  intercept [
     "hub_refresh",
     "mute",
     "add_owner",
@@ -36,7 +36,7 @@ defmodule RetWeb.HubChannel do
     # See internal_naf_event_for/2
     "maybe-naf",
     "maybe-nafr"
-  ])
+  ]
 
   def join("hub:" <> hub_sid, %{"profile" => profile, "context" => context} = params, socket) do
     hub =

--- a/lib/ret_web/channels/link_channel.ex
+++ b/lib/ret_web/channels/link_channel.ex
@@ -6,7 +6,7 @@ defmodule RetWeb.LinkChannel do
   alias Ret.{Statix}
   alias RetWeb.{Presence}
 
-  intercept(["link_response"])
+  intercept ["link_response"]
 
   def join("link:" <> link_code, _payload, socket) do
     if Regex.match?(~r/\A[0-9A-Z]{4,6}\z/, link_code) do

--- a/lib/ret_web/channels/ret_channel.ex
+++ b/lib/ret_web/channels/ret_channel.ex
@@ -6,7 +6,7 @@ defmodule RetWeb.RetChannel do
   alias Ret.{Account, Statix}
   alias RetWeb.{Presence}
 
-  intercept(["presence_diff"])
+  intercept ["presence_diff"]
 
   def join("ret", %{"hub_id" => hub_id, "token" => token}, socket) do
     case Ret.Guardian.resource_from_token(token) do

--- a/lib/ret_web/channels/session_socket.ex
+++ b/lib/ret_web/channels/session_socket.ex
@@ -1,10 +1,10 @@
 defmodule RetWeb.SessionSocket do
   use Phoenix.Socket
 
-  channel("ret", RetWeb.RetChannel)
-  channel("hub:*", RetWeb.HubChannel)
-  channel("link:*", RetWeb.LinkChannel)
-  channel("auth:*", RetWeb.AuthChannel)
+  channel "ret", RetWeb.RetChannel
+  channel "hub:*", RetWeb.HubChannel
+  channel "link:*", RetWeb.LinkChannel
+  channel "auth:*", RetWeb.AuthChannel
 
   def id(socket) do
     "session:#{socket.assigns.session_id}"

--- a/lib/ret_web/controllers/api/v1/account_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_controller.ex
@@ -65,7 +65,8 @@ defmodule RetWeb.Api.V1.AccountController do
           account
         end
 
-      {:ok, {200, Phoenix.View.render(AccountView, "create.json", account: account, email: email)}}
+      {:ok,
+       {200, Phoenix.View.render(AccountView, "create.json", account: account, email: email)}}
     end
   end
 
@@ -82,7 +83,8 @@ defmodule RetWeb.Api.V1.AccountController do
           account
         end
 
-      {:ok, {200, Phoenix.View.render(AccountView, "create.json", account: account, email: email)}}
+      {:ok,
+       {200, Phoenix.View.render(AccountView, "create.json", account: account, email: email)}}
     end
   end
 end

--- a/lib/ret_web/controllers/api/v1/account_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/account_search_controller.ex
@@ -10,7 +10,12 @@ defmodule RetWeb.Api.V1.AccountSearchController do
       record = Phoenix.View.render(AccountView, "show.json", account: account)
       conn |> send_resp(200, %{data: [record]} |> Poison.encode!())
     else
-      _ -> conn |> send_resp(404, %{errors: [%{code: :NOT_FOUND, detail: "No accounts found."}]} |> Poison.encode!())
+      _ ->
+        conn
+        |> send_resp(
+          404,
+          %{errors: [%{code: :NOT_FOUND, detail: "No accounts found."}]} |> Poison.encode!()
+        )
     end
   end
 end

--- a/lib/ret_web/controllers/api/v1/assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/assets_controller.ex
@@ -11,14 +11,21 @@ defmodule RetWeb.Api.V1.AssetsController do
 
     thumbnail_result =
       if params["thumbnail_file_id"] && params["thumbnail_access_token"] do
-        Storage.promote(params["thumbnail_file_id"], params["thumbnail_access_token"], nil, account)
+        Storage.promote(
+          params["thumbnail_file_id"],
+          params["thumbnail_access_token"],
+          nil,
+          account
+        )
       else
         {:ok, nil}
       end
 
-    with {:ok, asset_owned_file} <- Storage.promote(params["file_id"], params["access_token"], nil, account),
+    with {:ok, asset_owned_file} <-
+           Storage.promote(params["file_id"], params["access_token"], nil, account),
          {:ok, thumbnail_owned_file} <- thumbnail_result,
-         {:ok, asset} <- Asset.create_asset(account, asset_owned_file, thumbnail_owned_file, params) do
+         {:ok, asset} <-
+           Asset.create_asset(account, asset_owned_file, thumbnail_owned_file, params) do
       render(conn, "show.json", asset: asset)
     else
       {:error, error} -> render_error_json(conn, error)

--- a/lib/ret_web/controllers/api/v1/assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/assets_controller.ex
@@ -4,7 +4,7 @@ defmodule RetWeb.Api.V1.AssetsController do
   alias Ret.{Asset, Repo, Storage}
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit when action in [:create])
+  plug RetWeb.Plugs.RateLimit when action in [:create]
 
   def create(conn, %{"asset" => params}) do
     account = Guardian.Plug.current_resource(conn)

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -16,7 +16,11 @@ defmodule RetWeb.Api.V1.AvatarController do
   end
 
   defp preload(%Avatar{} = a, preloads) do
-    a |> Repo.preload([Avatar.file_columns() ++ [:parent_avatar, :parent_avatar_listing, :avatar_listings] ++ preloads])
+    a
+    |> Repo.preload([
+      Avatar.file_columns() ++
+        [:parent_avatar, :parent_avatar_listing, :avatar_listings] ++ preloads
+    ])
   end
 
   defp preload(%AvatarListing{} = a, preloads) do
@@ -80,14 +84,19 @@ defmodule RetWeb.Api.V1.AvatarController do
       end)
       |> Enum.into(%{})
 
-    promotion_error = owned_file_results |> Map.values() |> Enum.filter(&(elem(&1, 0) == :error)) |> Enum.at(0)
+    promotion_error =
+      owned_file_results |> Map.values() |> Enum.filter(&(elem(&1, 0) == :error)) |> Enum.at(0)
 
     case promotion_error do
       nil ->
         owned_files =
-          owned_file_results |> Enum.map(fn {k, {:ok, file}} -> {:"#{k}_owned_file", file} end) |> Enum.into(%{})
+          owned_file_results
+          |> Enum.map(fn {k, {:ok, file}} -> {:"#{k}_owned_file", file} end)
+          |> Enum.into(%{})
 
-        parent_avatar = params["parent_avatar_id"] && Repo.get_by(Avatar, avatar_sid: params["parent_avatar_id"])
+        parent_avatar =
+          params["parent_avatar_id"] &&
+            Repo.get_by(Avatar, avatar_sid: params["parent_avatar_id"])
 
         parent_avatar_listing =
           params["parent_avatar_listing_id"] &&
@@ -141,8 +150,11 @@ defmodule RetWeb.Api.V1.AvatarController do
       # For avatars with a parent, base is the same as the parents collapsed avatar plus gltf override
       %{parent_avatar_listing: parent_listing} = avatar when not is_nil(parent_listing) ->
         case avatar.gltf_owned_file do
-          nil -> conn |> show_gltf(parent_listing |> preload, true)
-          gltf -> conn |> show_gltf(parent_listing |> preload |> Map.put(:gltf_owned_file, gltf), true)
+          nil ->
+            conn |> show_gltf(parent_listing |> preload, true)
+
+          gltf ->
+            conn |> show_gltf(parent_listing |> preload |> Map.put(:gltf_owned_file, gltf), true)
         end
 
       # Otherwise base is just not applying overrides the the avatar
@@ -155,8 +167,11 @@ defmodule RetWeb.Api.V1.AvatarController do
     conn |> send_resp(404, "Avatar not found")
   end
 
-  def show_gltf(conn, %Avatar{state: :removed}, _overrides), do: conn |> send_resp(404, "Avatar not found")
-  def show_gltf(conn, %AvatarListing{state: :removed}, _overrides), do: conn |> send_resp(404, "Avatar not found")
+  def show_gltf(conn, %Avatar{state: :removed}, _overrides),
+    do: conn |> send_resp(404, "Avatar not found")
+
+  def show_gltf(conn, %AvatarListing{state: :removed}, _overrides),
+    do: conn |> send_resp(404, "Avatar not found")
 
   def show_gltf(conn, %t{} = a, apply_overrides) when t in [Avatar, AvatarListing],
     do: conn |> show_gltf(a |> Avatar.collapsed_files(), apply_overrides)
@@ -196,7 +211,9 @@ defmodule RetWeb.Api.V1.AvatarController do
 
   def delete(conn, _avatar), do: conn |> send_resp(401, "You do not own this avatar")
 
-  def delete(conn, %Avatar{account_id: avatar_account_id} = avatar, %Account{account_id: account_id})
+  def delete(conn, %Avatar{account_id: avatar_account_id} = avatar, %Account{
+        account_id: account_id
+      })
       when not is_nil(avatar_account_id) and avatar_account_id == account_id do
     avatar
     |> Avatar.delete_avatar_and_delist_listings()

--- a/lib/ret_web/controllers/api/v1/avatar_controller.ex
+++ b/lib/ret_web/controllers/api/v1/avatar_controller.ex
@@ -3,7 +3,7 @@ defmodule RetWeb.Api.V1.AvatarController do
 
   alias Ret.{Account, Repo, Avatar, AvatarListing, Storage, GLTFUtils}
 
-  plug(RetWeb.Plugs.RateLimit when action in [:create, :update])
+  plug RetWeb.Plugs.RateLimit when action in [:create, :update]
 
   defp get_avatar(avatar_sid, preloads \\ []) do
     avatar_sid

--- a/lib/ret_web/controllers/api/v1/hub_binding_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_binding_controller.ex
@@ -5,7 +5,8 @@ defmodule RetWeb.Api.V1.HubBindingController do
 
   def create(
         conn,
-        %{"hub_binding" => %{"hub_id" => _, "type" => _, "community_id" => _, "channel_id" => _}} = params
+        %{"hub_binding" => %{"hub_id" => _, "type" => _, "community_id" => _, "channel_id" => _}} =
+          params
       ) do
     {result, _} = HubBinding.bind_hub(params["hub_binding"])
 

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -6,10 +6,10 @@ defmodule RetWeb.Api.V1.HubController do
   import Canada, only: [can?: 2]
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit)
+  plug RetWeb.Plugs.RateLimit
 
   # Only allow access to remove hubs with secret header
-  plug(RetWeb.Plugs.HeaderAuthorization when action in [:delete])
+  plug RetWeb.Plugs.HeaderAuthorization when action in [:delete]
 
   def create(conn, %{"hub" => _hub_params} = params) do
     Hub.create_new_room(params["hub"], false)

--- a/lib/ret_web/controllers/api/v1/hub_controller.ex
+++ b/lib/ret_web/controllers/api/v1/hub_controller.ex
@@ -78,7 +78,8 @@ defmodule RetWeb.Api.V1.HubController do
 
   defp maybe_add_new_scene(changeset, nil), do: changeset
 
-  defp maybe_add_new_scene(changeset, scene), do: changeset |> Hub.add_new_scene_to_changeset(scene)
+  defp maybe_add_new_scene(changeset, scene),
+    do: changeset |> Hub.add_new_scene_to_changeset(scene)
 
   def delete(conn, %{"id" => hub_sid}) do
     Hub

--- a/lib/ret_web/controllers/api/v1/media_search_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_search_controller.ex
@@ -16,7 +16,9 @@ defmodule RetWeb.Api.V1.MediaSearchController do
   end
 
   def index(conn, %{"source" => "sketchfab", "user" => user}) do
-    {:commit, results} = %Ret.MediaSearchQuery{source: "sketchfab", user: user} |> Ret.MediaSearch.search()
+    {:commit, results} =
+      %Ret.MediaSearchQuery{source: "sketchfab", user: user} |> Ret.MediaSearch.search()
+
     conn |> render("index.json", results: results)
   end
 
@@ -73,7 +75,14 @@ defmodule RetWeb.Api.V1.MediaSearchController do
   end
 
   def index(conn, %{"source" => source} = params)
-      when source in ["sketchfab", "tenor", "youtube_videos", "bing_videos", "bing_images", "twitch"] do
+      when source in [
+             "sketchfab",
+             "tenor",
+             "youtube_videos",
+             "bing_videos",
+             "bing_images",
+             "twitch"
+           ] do
     query = %Ret.MediaSearchQuery{
       source: source,
       cursor: params["cursor"],

--- a/lib/ret_web/controllers/api/v1/oauth_controller.ex
+++ b/lib/ret_web/controllers/api/v1/oauth_controller.ex
@@ -15,7 +15,7 @@ defmodule RetWeb.Api.V1.OAuthController do
 
   import Canada, only: [can?: 2]
 
-  plug(RetWeb.Plugs.RateLimit when action in [:show])
+  plug RetWeb.Plugs.RateLimit when action in [:show]
 
   def show(conn, %{
         "type" => "twitter",

--- a/lib/ret_web/controllers/api/v1/oauth_controller.ex
+++ b/lib/ret_web/controllers/api/v1/oauth_controller.ex
@@ -1,7 +1,18 @@
 defmodule RetWeb.Api.V1.OAuthController do
   use RetWeb, :controller
 
-  alias Ret.{Repo, OAuthToken, OAuthProvider, DiscordClient, SlackClient, TwitterClient, Hub, Account, PermsToken}
+  alias Ret.{
+    Account,
+    DiscordClient,
+    Hub,
+    OAuthProvider,
+    OAuthToken,
+    PermsToken,
+    Repo,
+    SlackClient,
+    TwitterClient
+  }
+
   import Canada, only: [can?: 2]
 
   plug(RetWeb.Plugs.RateLimit when action in [:show])
@@ -19,8 +30,11 @@ defmodule RetWeb.Api.V1.OAuthController do
 
     case OAuthToken.decode_and_verify(state) do
       {:ok, _} ->
-        %{"user_id" => twitter_user_id, "oauth_token" => access_token, "oauth_token_secret" => access_token_secret} =
-          TwitterClient.get_access_token_and_user_info(oauth_verifier, oauth_token)
+        %{
+          "user_id" => twitter_user_id,
+          "oauth_token" => access_token,
+          "oauth_token_secret" => access_token_secret
+        } = TwitterClient.get_access_token_and_user_info(oauth_verifier, oauth_token)
 
         conn
         |> process_twitter_oauth(account, access_token, access_token_secret, twitter_user_id)
@@ -94,7 +108,11 @@ defmodule RetWeb.Api.V1.OAuthController do
       token: account |> Account.credentials_for_account()
     }
 
-    conn |> put_short_lived_cookie("ret-oauth-flow-account-credentials", credentials |> Poison.encode!())
+    conn
+    |> put_short_lived_cookie(
+      "ret-oauth-flow-account-credentials",
+      credentials |> Poison.encode!()
+    )
   end
 
   # Discord user does not have a verified email, so we can't create an account for them. Instead, we generate a perms
@@ -137,7 +155,12 @@ defmodule RetWeb.Api.V1.OAuthController do
 
   # If an oauthprovider exists for the given chat_user_id, return the associated account, updating the email
   # if necessary.
-  defp account_for_oauth_provider(%OAuthProvider{} = oauth_provider, email, _chat_user_id, _source) do
+  defp account_for_oauth_provider(
+         %OAuthProvider{} = oauth_provider,
+         email,
+         _chat_user_id,
+         _source
+       ) do
     account = oauth_provider.account |> Repo.preload(:login)
     login = account.login
     current_identifier_hash = login.identifier_hash

--- a/lib/ret_web/controllers/api/v1/project_assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_assets_controller.ex
@@ -39,11 +39,23 @@ defmodule RetWeb.Api.V1.ProjectAssetsController do
   end
 
   defp create(conn, params, account, project) do
-    with {:ok, asset_owned_file} <- Storage.promote(params["file_id"], params["access_token"], nil, account),
+    with {:ok, asset_owned_file} <-
+           Storage.promote(params["file_id"], params["access_token"], nil, account),
          {:ok, thumbnail_owned_file} <-
-           Storage.promote(params["thumbnail_file_id"], params["thumbnail_access_token"], nil, account),
+           Storage.promote(
+             params["thumbnail_file_id"],
+             params["thumbnail_access_token"],
+             nil,
+             account
+           ),
          {:ok, result} <-
-           Asset.create_asset_and_project_asset(account, project, asset_owned_file, thumbnail_owned_file, params) do
+           Asset.create_asset_and_project_asset(
+             account,
+             project,
+             asset_owned_file,
+             thumbnail_owned_file,
+             params
+           ) do
       asset = Repo.preload(result.asset, [:asset_owned_file, :thumbnail_owned_file])
       conn |> render("show.json", asset: asset)
     else

--- a/lib/ret_web/controllers/api/v1/project_assets_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_assets_controller.ex
@@ -4,7 +4,7 @@ defmodule RetWeb.Api.V1.ProjectAssetsController do
   alias Ret.{Asset, Project, ProjectAsset, Repo, Storage}
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit when action in [:create])
+  plug RetWeb.Plugs.RateLimit when action in [:create]
 
   def index(conn, %{"project_id" => project_sid}) do
     account = Guardian.Plug.current_resource(conn)

--- a/lib/ret_web/controllers/api/v1/project_controller.ex
+++ b/lib/ret_web/controllers/api/v1/project_controller.ex
@@ -4,7 +4,7 @@ defmodule RetWeb.Api.V1.ProjectController do
   alias Ret.{Project, Repo, Storage, Scene, SceneListing}
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit when action in [:create])
+  plug RetWeb.Plugs.RateLimit when action in [:create]
 
   defp preload(project) do
     project

--- a/lib/ret_web/controllers/api/v1/ret_notice_controller.ex
+++ b/lib/ret_web/controllers/api/v1/ret_notice_controller.ex
@@ -2,10 +2,10 @@ defmodule RetWeb.Api.V1.RetNoticeController do
   use RetWeb, :controller
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit)
+  plug RetWeb.Plugs.RateLimit
 
   # Only allow access to send ret notifications via admin secret
-  plug(RetWeb.Plugs.HeaderAuthorization when action in [:create])
+  plug RetWeb.Plugs.HeaderAuthorization when action in [:create]
 
   def create(conn, payload) do
     RetWeb.Endpoint.broadcast("ret", "notice", payload)

--- a/lib/ret_web/controllers/api/v1/scene_controller.ex
+++ b/lib/ret_web/controllers/api/v1/scene_controller.ex
@@ -25,14 +25,22 @@ defmodule RetWeb.Api.V1.SceneController do
     account = Guardian.Plug.current_resource(conn)
 
     case scene_sid |> get_scene() do
-      %t{} = s when t in [Scene, SceneListing] -> conn |> render("show.json", scene: s, account: account)
-      _ -> conn |> send_resp(404, "not found")
+      %t{} = s when t in [Scene, SceneListing] ->
+        conn |> render("show.json", scene: s, account: account)
+
+      _ ->
+        conn |> send_resp(404, "not found")
     end
   end
 
   def index_projectless(conn, _params) do
     account = Guardian.Plug.current_resource(conn)
-    conn |> render("index.json", scenes: Scene.projectless_scenes_for_account(account), account: account)
+
+    conn
+    |> render("index.json",
+      scenes: Scene.projectless_scenes_for_account(account),
+      account: account
+    )
   end
 
   def update(conn, %{"id" => scene_sid, "scene" => params}) do
@@ -102,14 +110,16 @@ defmodule RetWeb.Api.V1.SceneController do
         account
       )
 
-    promotion_error = owned_file_results |> Map.values() |> Enum.filter(&(elem(&1, 0) == :error)) |> Enum.at(0)
+    promotion_error =
+      owned_file_results |> Map.values() |> Enum.filter(&(elem(&1, 0) == :error)) |> Enum.at(0)
 
     # Legacy
     params = params |> Map.put_new("attributions", %{"extras" => params["attribution"]})
 
     case promotion_error do
       nil ->
-        %{model: {:ok, model_file}, screenshot: {:ok, screenshot_file}, scene: {:ok, scene_file}} = owned_file_results
+        %{model: {:ok, model_file}, screenshot: {:ok, screenshot_file}, scene: {:ok, scene_file}} =
+          owned_file_results
 
         {result, scene} =
           scene

--- a/lib/ret_web/controllers/api/v1/scene_controller.ex
+++ b/lib/ret_web/controllers/api/v1/scene_controller.ex
@@ -3,7 +3,7 @@ defmodule RetWeb.Api.V1.SceneController do
 
   alias Ret.{Account, Repo, Scene, SceneListing, Storage}
 
-  plug(RetWeb.Plugs.RateLimit when action in [:create, :update])
+  plug RetWeb.Plugs.RateLimit when action in [:create, :update]
 
   defp preload(%Scene{} = a) do
     a |> Repo.preload(Scene.scene_preloads())

--- a/lib/ret_web/controllers/api/v1/slack_controller.ex
+++ b/lib/ret_web/controllers/api/v1/slack_controller.ex
@@ -85,7 +85,10 @@ defmodule RetWeb.Api.V1.SlackController do
     %{"channel" => %{"topic" => %{"value" => topic}}} = get_channel_info(channel_id)
 
     if !has_hubs_url(topic) do
-      send_message_to_channel(channel_id, "No Hubs room is bridged in the topic, so doing nothing :eyes:")
+      send_message_to_channel(
+        channel_id,
+        "No Hubs room is bridged in the topic, so doing nothing :eyes:"
+      )
     else
       update_topic(channel_id, remove_hub_topic(topic))
     end
@@ -97,7 +100,10 @@ defmodule RetWeb.Api.V1.SlackController do
 
   # catches requests that do not match the specified commands above
   defp handle_command(_command, channel_id, _args, _team_id) do
-    send_message_to_channel(channel_id, "Type \"/hubs help\" if you need the list of available commands")
+    send_message_to_channel(
+      channel_id,
+      "Type \"/hubs help\" if you need the list of available commands"
+    )
   end
 
   defp has_hubs_url(topic) do
@@ -134,7 +140,8 @@ defmodule RetWeb.Api.V1.SlackController do
   end
 
   defp get_channel_info(channel_id) do
-    ("#{@slack_api_base}/api/conversations.info?" <> URI.encode_query(%{token: get_bot_token(), channel: channel_id}))
+    ("#{@slack_api_base}/api/conversations.info?" <>
+       URI.encode_query(%{token: get_bot_token(), channel: channel_id}))
     |> Ret.HttpUtils.retry_get_until_success()
     |> Map.get(:body)
     |> Poison.decode!()

--- a/lib/ret_web/controllers/api/v1/slack_controller.ex
+++ b/lib/ret_web/controllers/api/v1/slack_controller.ex
@@ -3,7 +3,7 @@ defmodule RetWeb.Api.V1.SlackController do
   alias Ret.{Hub, HubBinding}
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit)
+  plug RetWeb.Plugs.RateLimit
 
   @slack_api_base "https://slack.com"
   @help_prefix "Hi! I'm the Hubs bot. I connect Slack channels with rooms on Hubs (https://hubs.mozilla.com/). Type `/hubs help` for more information."

--- a/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
+++ b/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
@@ -6,10 +6,10 @@ defmodule RetWeb.Api.V1.SupportSubscriptionController do
   alias Ret.Repo
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit when action in [:create, :delete])
+  plug RetWeb.Plugs.RateLimit when action in [:create, :delete]
 
   # Only allow access with secret header
-  plug(RetWeb.Plugs.HeaderAuthorization when action in [:create, :delete])
+  plug RetWeb.Plugs.HeaderAuthorization when action in [:create, :delete]
 
   def index(conn, _params) do
     case Support.available?() do

--- a/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
+++ b/lib/ret_web/controllers/api/v1/support_subscription_controller.ex
@@ -36,10 +36,7 @@ defmodule RetWeb.Api.V1.SupportSubscriptionController do
   end
 
   def delete(conn, %{"id" => identifier}) do
-    SupportSubscription
-    |> where(identifier: ^identifier)
-    |> Repo.delete_all()
-
+    Repo.delete_all(from SupportSubscription, where: [identifier: ^identifier])
     conn |> send_resp(200, "OK")
   end
 end

--- a/lib/ret_web/controllers/api/v1/whats_new_controller.ex
+++ b/lib/ret_web/controllers/api/v1/whats_new_controller.ex
@@ -74,7 +74,9 @@ defmodule RetWeb.Api.V1.WhatsNewController do
     resp_body |> Poison.decode() |> extract_pull_requests
   end
 
-  defp extract_pull_requests({:ok, %{"data" => data}}), do: data["repository"]["pullRequests"]["edges"]
+  defp extract_pull_requests({:ok, %{"data" => data}}),
+    do: data["repository"]["pullRequests"]["edges"]
+
   defp extract_pull_requests(_), do: []
 
   defp format_pull_request(%{"node" => pull_request}) do

--- a/lib/ret_web/controllers/api/v2/credentials_controller.ex
+++ b/lib/ret_web/controllers/api/v2/credentials_controller.ex
@@ -14,7 +14,7 @@ defmodule RetWeb.Api.V2.CredentialsController do
     ]
 
   # Limit to 1 TPS
-  plug(RetWeb.Plugs.RateLimit when action in [:create, :update])
+  plug RetWeb.Plugs.RateLimit when action in [:create, :update]
 
   def index(conn, %{"app" => _anything} = _params) do
     handle_list_credentials_result(

--- a/lib/ret_web/controllers/api/v2/credentials_controller.ex
+++ b/lib/ret_web/controllers/api/v2/credentials_controller.ex
@@ -6,17 +6,28 @@ defmodule RetWeb.Api.V2.CredentialsController do
   alias Ecto.Changeset
 
   import Ret.Api.TokenUtils,
-    only: [to_claims: 2, authed_create_credentials: 2, authed_list_credentials: 2, authed_revoke_credentials: 2]
+    only: [
+      authed_create_credentials: 2,
+      authed_list_credentials: 2,
+      authed_revoke_credentials: 2,
+      to_claims: 2
+    ]
 
   # Limit to 1 TPS
   plug(RetWeb.Plugs.RateLimit when action in [:create, :update])
 
   def index(conn, %{"app" => _anything} = _params) do
-    handle_list_credentials_result(conn, authed_list_credentials(Guardian.Plug.current_resource(conn), :app))
+    handle_list_credentials_result(
+      conn,
+      authed_list_credentials(Guardian.Plug.current_resource(conn), :app)
+    )
   end
 
   def index(conn, _params) do
-    handle_list_credentials_result(conn, authed_list_credentials(Guardian.Plug.current_resource(conn), :account))
+    handle_list_credentials_result(
+      conn,
+      authed_list_credentials(Guardian.Plug.current_resource(conn), :account)
+    )
   end
 
   def show(conn, %{"id" => credentials_sid}) do
@@ -59,7 +70,11 @@ defmodule RetWeb.Api.V2.CredentialsController do
   end
 
   defp handle_list_credentials_result(conn, {:error, :unauthorized}) do
-    render_errors(conn, 401, {:unauthorized, "You do not have permission to view these credentials."})
+    render_errors(
+      conn,
+      401,
+      {:unauthorized, "You do not have permission to view these credentials."}
+    )
   end
 
   defp handle_list_credentials_result(conn, {:error, reason}) do
@@ -74,7 +89,11 @@ defmodule RetWeb.Api.V2.CredentialsController do
   end
 
   defp handle_create_credentials_result(conn, {:error, :unauthorized}) do
-    render_errors(conn, 401, {:unauthorized, "You do not have permission to create these credentials."})
+    render_errors(
+      conn,
+      401,
+      {:unauthorized, "You do not have permission to create these credentials."}
+    )
   end
 
   defp handle_create_credentials_result(conn, {:error, reason}) do
@@ -96,7 +115,11 @@ defmodule RetWeb.Api.V2.CredentialsController do
   end
 
   defp handle_revoke_credentials_result(conn, {:error, :unauthorized}) do
-    render_errors(conn, 401, {:unauthorized, "You do not have permission to revoke these credentials."})
+    render_errors(
+      conn,
+      401,
+      {:unauthorized, "You do not have permission to revoke these credentials."}
+    )
   end
 
   defp handle_revoke_credentials_result(conn, {:error, reason}) do
@@ -119,7 +142,8 @@ defmodule RetWeb.Api.V2.CredentialsController do
 
   defp render_errors(conn, status, %Changeset{} = changeset) do
     render_errors(conn, status,
-      errors: changeset |> Ecto.Changeset.traverse_errors(fn {err, _opts} -> err end) |> Enum.to_list()
+      errors:
+        changeset |> Ecto.Changeset.traverse_errors(fn {err, _opts} -> err end) |> Enum.to_list()
     )
   end
 

--- a/lib/ret_web/controllers/file_controller.ex
+++ b/lib/ret_web/controllers/file_controller.ex
@@ -161,7 +161,10 @@ defmodule RetWeb.FileController do
           {:ok, conn, ranges, is_partial} ->
             conn =
               conn
-              |> put_resp_content_type(content_type |> RetWeb.ContentType.sanitize_content_type(), nil)
+              |> put_resp_content_type(
+                content_type |> RetWeb.ContentType.sanitize_content_type(),
+                nil
+              )
               |> put_resp_header("content-length", "#{ranges |> total_range_length}")
               |> put_resp_header("cache-control", "public, max-age=31536000")
               |> put_resp_header("accept-ranges", "bytes")
@@ -236,7 +239,10 @@ defmodule RetWeb.FileController do
         if length(parsed_ranges) === 1 do
           conn =
             conn
-            |> put_resp_header("content-range", "bytes #{response_ranges_for_ranges(parsed_ranges)}/#{content_length}")
+            |> put_resp_header(
+              "content-range",
+              "bytes #{response_ranges_for_ranges(parsed_ranges)}/#{content_length}"
+            )
 
           {:ok, conn, parsed_ranges, true}
         else

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -5,7 +5,7 @@ defmodule RetWeb.HealthController do
   def index(conn, _params) do
     # Check database
     if module_config(:check_repo) do
-      from(h in Ret.Hub, limit: 0) |> Ret.Repo.all()
+      Ret.Repo.all(from Ret.Hub, limit: 0)
     end
 
     # Check page cache

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -157,8 +157,11 @@ defmodule RetWeb.PageController do
   end
 
   # Allow loading homepage if auth_token is being used to log in
-  defp render_homepage_content(%Plug.Conn{query_params: %{"auth_token" => _auth_token}} = conn, _default_room_id),
-    do: render_homepage_content(conn, nil)
+  defp render_homepage_content(
+         %Plug.Conn{query_params: %{"auth_token" => _auth_token}} = conn,
+         _default_room_id
+       ),
+       do: render_homepage_content(conn, nil)
 
   defp render_homepage_content(conn, default_room_id) do
     hub = Hub |> Repo.get_by(hub_sid: default_room_id)
@@ -226,7 +229,8 @@ defmodule RetWeb.PageController do
   def render_for_path("/cloud", _params, conn), do: conn |> render_page("cloud.html")
   def render_for_path("/cloud/", _params, conn), do: conn |> render_page("cloud.html")
 
-  def render_for_path("/spoke", _params, conn), do: conn |> render_page("index.html", :spoke, "spoke-index-meta.html")
+  def render_for_path("/spoke", _params, conn),
+    do: conn |> render_page("index.html", :spoke, "spoke-index-meta.html")
 
   def render_for_path("/spoke/" <> _path, _params, conn),
     do: conn |> render_page("index.html", :spoke, "spoke-index-meta.html")
@@ -265,7 +269,8 @@ defmodule RetWeb.PageController do
                 root_url: RetWeb.Endpoint.url(),
                 app_name: get_app_config_value("translations|en|app-name") || "",
                 app_description:
-                  (get_app_config_value("translations|en|app-description") || "") |> String.replace("\\n", " ")
+                  (get_app_config_value("translations|en|app-description") || "")
+                  |> String.replace("\\n", " ")
               )
 
             unless module_config(:skip_cache) do
@@ -300,7 +305,9 @@ defmodule RetWeb.PageController do
 
   def render_for_path("/robots.txt", _params, conn) do
     allow_crawlers = Application.get_env(:ret, RetWeb.Endpoint)[:allow_crawlers] || false
-    robots_txt = Phoenix.View.render_to_string(RetWeb.PageView, "robots.txt", allow_crawlers: allow_crawlers)
+
+    robots_txt =
+      Phoenix.View.render_to_string(RetWeb.PageView, "robots.txt", allow_crawlers: allow_crawlers)
 
     conn
     |> send_resp(200, robots_txt)
@@ -381,7 +388,8 @@ defmodule RetWeb.PageController do
     conn
     |> put_resp_header(
       "hub-name",
-      get_app_config_value("translations|en|app-full-name") || get_app_config_value("translations|en|app-name") || ""
+      get_app_config_value("translations|en|app-full-name") ||
+        get_app_config_value("translations|en|app-name") || ""
     )
     |> put_resp_header(
       "hub-entity-type",
@@ -398,7 +406,8 @@ defmodule RetWeb.PageController do
   end
 
   defp append_csp(conn, directive, source) do
-    csp_header = conn.resp_headers |> Enum.find(fn {key, _value} -> key == "content-security-policy" end)
+    csp_header =
+      conn.resp_headers |> Enum.find(fn {key, _value} -> key == "content-security-policy" end)
 
     new_directive = "#{directive} #{source}"
 
@@ -431,7 +440,9 @@ defmodule RetWeb.PageController do
   end
 
   def render_hub_content(conn, hub, _slug) do
-    hub = hub |> Repo.preload(scene: [:screenshot_owned_file], scene_listing: [:screenshot_owned_file])
+    hub =
+      hub
+      |> Repo.preload(scene: [:screenshot_owned_file], scene_listing: [:screenshot_owned_file])
 
     {app_config, app_config_script} = generate_app_config()
 
@@ -542,7 +553,9 @@ defmodule RetWeb.PageController do
 
     meta_content =
       if meta_template do
-        Phoenix.View.render_to_string(RetWeb.PageView, meta_template, translations: app_config["translations"]["en"])
+        Phoenix.View.render_to_string(RetWeb.PageView, meta_template,
+          translations: app_config["translations"]["en"]
+        )
       else
         []
       end
@@ -568,7 +581,9 @@ defmodule RetWeb.PageController do
 
     meta_tags =
       if meta_template do
-        Phoenix.View.render_to_string(RetWeb.PageView, meta_template, translations: app_config["translations"]["en"])
+        Phoenix.View.render_to_string(RetWeb.PageView, meta_template,
+          translations: app_config["translations"]["en"]
+        )
       else
         []
       end
@@ -576,7 +591,9 @@ defmodule RetWeb.PageController do
     case try_chunks_for_page(conn, page, source) do
       {:ok, chunks} ->
         chunks_with_meta =
-          chunks |> List.insert_at(1, app_config_script |> with_script_tags) |> List.insert_at(1, meta_tags)
+          chunks
+          |> List.insert_at(1, app_config_script |> with_script_tags)
+          |> List.insert_at(1, meta_tags)
 
         conn
         |> append_script_csp(app_config_script)
@@ -613,7 +630,8 @@ defmodule RetWeb.PageController do
 
   defp imgproxy_proxy(%Conn{request_path: "/thumbnail/" <> encoded_url, query_string: qs} = conn) do
     with imgproxy_url <- Application.get_env(:ret, RetWeb.Endpoint)[:imgproxy_url],
-         [scheme, port, host] = [:scheme, :port, :host] |> Enum.map(&Keyword.get(imgproxy_url, &1)),
+         [scheme, port, host] =
+           [:scheme, :port, :host] |> Enum.map(&Keyword.get(imgproxy_url, &1)),
          %{"w" => width, "h" => height} <- qs |> URI.decode_query() do
       thumbnail_url = "#{scheme}://#{host}:#{port}//auto/#{width}/#{height}/sm/1/#{encoded_url}"
 
@@ -637,8 +655,11 @@ defmodule RetWeb.PageController do
     end
   end
 
-  defp cors_proxy(%Conn{request_path: "/" <> url, query_string: ""} = conn), do: cors_proxy(conn, url)
-  defp cors_proxy(%Conn{request_path: "/" <> url, query_string: qs} = conn), do: cors_proxy(conn, "#{url}?#{qs}")
+  defp cors_proxy(%Conn{request_path: "/" <> url, query_string: ""} = conn),
+    do: cors_proxy(conn, url)
+
+  defp cors_proxy(%Conn{request_path: "/" <> url, query_string: qs} = conn),
+    do: cors_proxy(conn, "#{url}?#{qs}")
 
   defp cors_proxy(conn, url) do
     %URI{authority: authority, host: host} = uri = URI.parse(url)
@@ -654,11 +675,17 @@ defmodule RetWeb.PageController do
 
       # Disallow CORS proxying unless request was made to the cors proxy url
       cors_proxy_url = Application.get_env(:ret, RetWeb.Endpoint)[:cors_proxy_url]
-      [cors_scheme, cors_port, cors_host] = [:scheme, :port, :host] |> Enum.map(&Keyword.get(cors_proxy_url, &1))
-      is_cors_proxy_url = cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host && cors_port == conn.port
+
+      [cors_scheme, cors_port, cors_host] =
+        [:scheme, :port, :host] |> Enum.map(&Keyword.get(cors_proxy_url, &1))
+
+      is_cors_proxy_url =
+        cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host &&
+          cors_port == conn.port
 
       if is_cors_proxy_url do
-        allowed_origins = Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")
+        allowed_origins =
+          Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")
 
         opts =
           ReverseProxyPlug.init(
@@ -669,7 +696,9 @@ defmodule RetWeb.PageController do
             # used for ssl verification here so that the connection isn't rejected.
             # Note that we have to convert the authority to a charlist, since this uses Erlang's `ssl` module
             # internally, which expects a charlist.
-            client_options: [ssl: [{:server_name_indication, to_charlist(authority)}, {:versions, [:"tlsv1.2"]}]],
+            client_options: [
+              ssl: [{:server_name_indication, to_charlist(authority)}, {:versions, [:"tlsv1.2"]}]
+            ],
             preserve_host_header: true
           )
 
@@ -707,12 +736,16 @@ defmodule RetWeb.PageController do
   end
 
   defp render_asset(conn) do
-    static_options = Plug.Static.init(at: "/", from: module_config(:assets_path), gzip: true, brotli: true)
+    static_options =
+      Plug.Static.init(at: "/", from: module_config(:assets_path), gzip: true, brotli: true)
+
     Plug.Static.call(conn, static_options)
   end
 
   defp render_docs(conn) do
-    static_options = Plug.Static.init(at: "/docs", from: module_config(:docs_path), gzip: true, brotli: true)
+    static_options =
+      Plug.Static.init(at: "/docs", from: module_config(:docs_path), gzip: true, brotli: true)
+
     Plug.Static.call(conn, static_options)
   end
 
@@ -754,7 +787,9 @@ defmodule RetWeb.PageController do
 
   defp append_script_csp(conn, nil), do: conn
   defp append_script_csp(conn, ""), do: conn
-  defp append_script_csp(conn, script), do: conn |> append_csp("script-src", csp_for_script(script))
+
+  defp append_script_csp(conn, script),
+    do: conn |> append_csp("script-src", csp_for_script(script))
 
   defp with_script_tags(nil), do: ""
   defp with_script_tags(""), do: ""

--- a/lib/ret_web/endpoint.ex
+++ b/lib/ret_web/endpoint.ex
@@ -3,16 +3,22 @@ defmodule RetWeb.Endpoint do
   use Sentry.Phoenix.Endpoint
   use Absinthe.Phoenix.Endpoint
 
-  socket("/socket", RetWeb.SessionSocket, websocket: [check_origin: {RetWeb.Endpoint, :allowed_origin?, []}])
+  socket("/socket", RetWeb.SessionSocket,
+    websocket: [check_origin: {RetWeb.Endpoint, :allowed_origin?, []}]
+  )
 
-  def get_cors_origins, do: Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")
-  def get_cors_origin_urls, do: get_cors_origins() |> Enum.filter(&(&1 != "*")) |> Enum.map(&URI.parse/1)
+  def get_cors_origins,
+    do: Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")
+
+  def get_cors_origin_urls,
+    do: get_cors_origins() |> Enum.filter(&(&1 != "*")) |> Enum.map(&URI.parse/1)
 
   def allowed_origin?(%URI{host: host, port: port, scheme: scheme}) do
     if get_cors_origins() === ["*"] do
       true
     else
-      get_cors_origin_urls() |> Enum.any?(&(&1.host == host && &1.port == port && &1.scheme == scheme))
+      get_cors_origin_urls()
+      |> Enum.any?(&(&1.host == host && &1.port == port && &1.scheme == scheme))
     end
   end
 

--- a/lib/ret_web/endpoint.ex
+++ b/lib/ret_web/endpoint.ex
@@ -3,9 +3,8 @@ defmodule RetWeb.Endpoint do
   use Sentry.Phoenix.Endpoint
   use Absinthe.Phoenix.Endpoint
 
-  socket("/socket", RetWeb.SessionSocket,
+  socket "/socket", RetWeb.SessionSocket,
     websocket: [check_origin: {RetWeb.Endpoint, :allowed_origin?, []}]
-  )
 
   def get_cors_origins,
     do: Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")
@@ -25,24 +24,24 @@ defmodule RetWeb.Endpoint do
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    socket("/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket)
-    plug(Phoenix.LiveReloader)
-    plug(Phoenix.CodeReloader)
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+    plug Phoenix.LiveReloader
+    plug Phoenix.CodeReloader
   end
 
-  plug(Plug.RequestId)
-  plug(Plug.Logger)
+  plug Plug.RequestId
+  plug Plug.Logger
 
-  plug(Plug.MethodOverride)
+  plug Plug.MethodOverride
 
   # We need to handle HEAD for the FileController, but pushing the Plug.Head into the router pipeline
   # prevents matching on HEAD. So this new plug sends a GET as Plug.Head but also adds a x-original-method request
   # header
-  plug(RetWeb.Plugs.Head)
+  plug RetWeb.Plugs.Head
 
-  plug(CORSPlug, origin: &RetWeb.Endpoint.get_cors_origins/0)
-  plug(RetWeb.Plugs.AddVary)
-  plug(RetWeb.Router)
+  plug CORSPlug, origin: &RetWeb.Endpoint.get_cors_origins/0
+  plug RetWeb.Plugs.AddVary
+  plug RetWeb.Router
 
   @doc """
   Callback invoked for dynamically configuring the endpoint.

--- a/lib/ret_web/middleware/handle_api_token_auth_errors.ex
+++ b/lib/ret_web/middleware/handle_api_token_auth_errors.ex
@@ -18,7 +18,8 @@ defmodule RetWeb.Middleware.HandleApiTokenAuthErrors do
     resolution
   end
 
-  def call(%{context: %{api_token_auth_errors: errors}} = resolution, _) when is_list(errors) and length(errors) > 0 do
+  def call(%{context: %{api_token_auth_errors: errors}} = resolution, _)
+      when is_list(errors) and length(errors) > 0 do
     {type, reason} = Enum.at(errors, 0)
     put_error_result(resolution, type, reason)
   end

--- a/lib/ret_web/middleware/timing.ex
+++ b/lib/ret_web/middleware/timing.ex
@@ -18,7 +18,12 @@ defmodule RetWeb.Middleware.StartTiming do
 
   @behaviour Absinthe.Middleware
   def call(resolution, _) do
-    add_timing_info(resolution, resolution.definition.schema_node.identifier, :started_at, NaiveDateTime.utc_now())
+    add_timing_info(
+      resolution,
+      resolution.definition.schema_node.identifier,
+      :started_at,
+      NaiveDateTime.utc_now()
+    )
   end
 end
 
@@ -29,7 +34,12 @@ defmodule RetWeb.Middleware.EndTiming do
 
   @behaviour Absinthe.Middleware
   def call(resolution, _) do
-    add_timing_info(resolution, resolution.definition.schema_node.identifier, :ended_at, NaiveDateTime.utc_now())
+    add_timing_info(
+      resolution,
+      resolution.definition.schema_node.identifier,
+      :ended_at,
+      NaiveDateTime.utc_now()
+    )
   end
 end
 

--- a/lib/ret_web/plugs/add_absinthe_context.ex
+++ b/lib/ret_web/plugs/add_absinthe_context.ex
@@ -13,7 +13,10 @@ defmodule RetWeb.AddAbsintheContext do
 
     case Guardian.Plug.current_claims(conn) do
       {:error, :invalid_token} ->
-        %{api_token_auth_errors: [{:invalid_token, "Invalid token error. Could not find credentials."}] ++ auth_errors}
+        %{
+          api_token_auth_errors:
+            [{:invalid_token, "Invalid token error. Could not find credentials."}] ++ auth_errors
+        }
 
       credentials ->
         %{

--- a/lib/ret_web/plugs/add_csp.ex
+++ b/lib/ret_web/plugs/add_csp.ex
@@ -99,24 +99,26 @@ defmodule RetWeb.Plugs.AddCSP do
     is_subdomain = ret_host |> String.split(".") |> length > 2
     link_url = config_url(:link_url)
     # legacy
-    thumbnail_url = config_url(:thumbnail_url) || cors_proxy_url |> String.replace("cors-proxy", "nearspark")
+    thumbnail_url =
+      config_url(:thumbnail_url) || cors_proxy_url |> String.replace("cors-proxy", "nearspark")
 
     # TODO: The https janus port CSP rules (including the default) can be removed after dialog is deployed,
     # since they are used to snoop and see what SFU it is.
     default_janus_csp_rule =
       if default_janus_host != nil && String.length(String.trim(default_janus_host)) > 0,
-        do: "wss://#{default_janus_host}:#{janus_port} https://#{default_janus_host}:#{janus_port}",
+        do:
+          "wss://#{default_janus_host}:#{janus_port} https://#{default_janus_host}:#{janus_port}",
         else: ""
 
     ret_direct_connect =
       if is_subdomain do
-        "https://*.#{ret_domain}:#{ret_port} wss://*.#{ret_domain}:#{ret_port} wss://*.#{ret_domain}:#{janus_port} https://*.#{
+        "https://*.#{ret_domain}:#{ret_port} wss://*.#{ret_domain}:#{ret_port} wss://*.#{
           ret_domain
-        }:#{janus_port} #{default_janus_csp_rule}"
+        }:#{janus_port} https://*.#{ret_domain}:#{janus_port} #{default_janus_csp_rule}"
       else
-        "https://#{ret_host}:#{ret_port} wss://#{ret_host}:#{janus_port} wss://#{ret_host}:#{ret_port} https://#{
-          ret_host
-        }:#{janus_port} #{default_janus_csp_rule}"
+        "https://#{ret_host}:#{ret_port} wss://#{ret_host}:#{janus_port} wss://#{ret_host}:#{
+          ret_port
+        } https://#{ret_host}:#{janus_port} #{default_janus_csp_rule}"
       end
 
     %{

--- a/lib/ret_web/plugs/api_token_auth_pipeline.ex
+++ b/lib/ret_web/plugs/api_token_auth_pipeline.ex
@@ -5,7 +5,7 @@ defmodule RetWeb.ApiTokenAuthPipeline do
     module: Ret.Api.Token,
     error_handler: RetWeb.ApiTokenAuthErrorHandler
 
-  plug(Guardian.Plug.VerifyHeader, halt: false)
+  plug Guardian.Plug.VerifyHeader, halt: false
 end
 
 defmodule RetWeb.ApiTokenAuthErrorHandler do

--- a/lib/ret_web/plugs/dashboard_header_authorization.ex
+++ b/lib/ret_web/plugs/dashboard_header_authorization.ex
@@ -5,7 +5,8 @@ defmodule RetWeb.Plugs.DashboardHeaderAuthorization do
   def init(default), do: default
 
   def call(conn, _default) do
-    expected_value = Application.get_env(:ret, RetWeb.Plugs.DashboardHeaderAuthorization)[:dashboard_access_key]
+    expected_value =
+      Application.get_env(:ret, RetWeb.Plugs.DashboardHeaderAuthorization)[:dashboard_access_key]
 
     case conn |> get_req_header(@header_name) do
       [""] -> conn |> send_resp(401, "") |> halt()

--- a/lib/ret_web/plugs/redirect_to_main_domain.ex
+++ b/lib/ret_web/plugs/redirect_to_main_domain.ex
@@ -21,8 +21,11 @@ defmodule RetWeb.Plugs.RedirectToMainDomain do
         nil
       end
 
-    if !matches_host(conn, main_host) && !matches_host(conn, secondary_host) && !matches_host(conn, cors_proxy_host) &&
-         !matches_host(conn, assets_host) && !matches_host(conn, link_host) &&
+    if !matches_host(conn, main_host) &&
+         !matches_host(conn, secondary_host) &&
+         !matches_host(conn, cors_proxy_host) &&
+         !matches_host(conn, assets_host) &&
+         !matches_host(conn, link_host) &&
          (!storage_host || !matches_host(conn, storage_host)) do
       conn
       |> put_status(:moved_permanently)

--- a/lib/ret_web/router.ex
+++ b/lib/ret_web/router.ex
@@ -103,7 +103,8 @@ defmodule RetWeb.Router do
 
   scope "/api", RetWeb do
     pipe_through(
-      [:secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: [])
+      [:secure_headers, :parsed_body, :api] ++
+        if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: [])
     )
 
     scope "/v1", as: :api_v1 do
@@ -114,6 +115,7 @@ defmodule RetWeb.Router do
 
       scope "/support" do
         resources("/subscriptions", Api.V1.SupportSubscriptionController, only: [:create, :delete])
+
         resources("/availability", Api.V1.SupportSubscriptionController, only: [:index])
       end
 
@@ -159,7 +161,9 @@ defmodule RetWeb.Router do
       resources("/assets", Api.V1.AssetsController, only: [:create, :delete])
       post("/twitter/tweets", Api.V1.TwitterController, :tweets)
 
-      resources("/projects", Api.V1.ProjectController, only: [:index, :show, :create, :update, :delete]) do
+      resources("/projects", Api.V1.ProjectController,
+        only: [:index, :show, :create, :update, :delete]
+      ) do
         post("/publish", Api.V1.ProjectController, :publish)
         resources("/assets", Api.V1.ProjectAssetsController, only: [:index, :create, :delete])
       end
@@ -180,12 +184,15 @@ defmodule RetWeb.Router do
         if(Mix.env() == :prod, do: [:ssl_only, :canonicalize_domain], else: [])
     )
 
-    resources("/credentials", Api.V2.CredentialsController, only: [:create, :index, :update, :show])
+    resources("/credentials", Api.V2.CredentialsController,
+      only: [:create, :index, :update, :show]
+    )
   end
 
   scope "/api/v2_alpha", as: :api_v2_alpha do
     pipe_through(
-      [:parsed_body, :api, :public_api_access, :graphql] ++ if(Mix.env() == :prod, do: [:ssl_only], else: [])
+      [:parsed_body, :api, :public_api_access, :graphql] ++
+        if(Mix.env() == :prod, do: [:ssl_only], else: [])
     )
 
     forward "/graphiql", Absinthe.Plug.GraphiQL, json_codec: Jason, schema: RetWeb.Schema
@@ -194,7 +201,8 @@ defmodule RetWeb.Router do
 
   scope "/api-internal", RetWeb do
     pipe_through(
-      [:dashboard_header_auth, :secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: [])
+      [:dashboard_header_auth, :secure_headers, :parsed_body, :api] ++
+        if(Mix.env() == :prod, do: [:ssl_only], else: [])
     )
 
     scope "/v1", as: :api_internal_v1 do
@@ -210,7 +218,9 @@ defmodule RetWeb.Router do
   # Directly accessible APIs.
   # Permit direct file uploads without intermediate ALB/Cloudfront/CDN proxying.
   scope "/api", RetWeb do
-    pipe_through([:secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: []))
+    pipe_through(
+      [:secure_headers, :parsed_body, :api] ++ if(Mix.env() == :prod, do: [:ssl_only], else: [])
+    )
 
     scope "/v1", as: :api_v1 do
       resources("/media", Api.V1.MediaController, only: [:create])
@@ -218,7 +228,10 @@ defmodule RetWeb.Router do
   end
 
   scope "/", RetWeb do
-    pipe_through([:strict_secure_headers, :parsed_body, :browser] ++ if(Mix.env() == :prod, do: [:ssl_only], else: []))
+    pipe_through(
+      [:strict_secure_headers, :parsed_body, :browser] ++
+        if(Mix.env() == :prod, do: [:ssl_only], else: [])
+    )
 
     head("/files/:id", FileController, :head)
     get("/files/:id", FileController, :show)

--- a/lib/ret_web/schema.ex
+++ b/lib/ret_web/schema.ex
@@ -9,16 +9,16 @@ defmodule RetWeb.Schema do
     build_middleware(middleware, field, object)
   end
 
-  import_types(Absinthe.Type.Custom)
-  import_types(RetWeb.Schema.RoomTypes)
-  import_types(RetWeb.Schema.SceneTypes)
+  import_types Absinthe.Type.Custom
+  import_types RetWeb.Schema.RoomTypes
+  import_types RetWeb.Schema.SceneTypes
 
   query do
-    import_fields(:room_queries)
+    import_fields :room_queries
   end
 
   mutation do
-    import_fields(:room_mutations)
+    import_fields :room_mutations
   end
 
   def context(ctx) do

--- a/lib/ret_web/schema/room_types.ex
+++ b/lib/ret_web/schema/room_types.ex
@@ -3,143 +3,144 @@ defmodule RetWeb.Schema.RoomTypes do
 
   use Absinthe.Schema.Notation
   alias RetWeb.Resolvers
-  import_types(RetWeb.Schema.Types.Custom.JSON)
+
+  import_types RetWeb.Schema.Types.Custom.JSON
 
   @desc "Public TLS port number used for TURN"
   object :turn_transport do
     @desc "Public TLS port number used for TURN"
-    field(:port, :integer)
+    field :port, :integer
   end
 
   @desc "TURN information for DLTS over TURN fallback, when enabled"
   object :turn_info do
     @desc "Cryptographic credential, good for two minutes"
-    field(:credential, :string)
+    field :credential, :string
     @desc "Whether TURN is enabled/configured"
-    field(:enabled, :boolean)
+    field :enabled, :boolean
     @desc "List of public TLS ports"
-    field(:transports, list_of(:turn_transport))
+    field :transports, list_of(:turn_transport)
     @desc "Username, good for two minutes"
-    field(:username, :string)
+    field :username, :string
   end
 
   @desc "Permissions for participants in the room"
   input_object :input_member_permissions do
     @desc "Allows non-admin participants to spawn and move media"
-    field(:spawn_and_move_media, :boolean)
+    field :spawn_and_move_media, :boolean
     @desc "Allows non-admin participants to spawn in-game cameras"
-    field(:spawn_camera, :boolean)
+    field :spawn_camera, :boolean
     @desc "Allows non-admin participants to draw with a pen"
-    field(:spawn_drawing, :boolean)
+    field :spawn_drawing, :boolean
     @desc "Allows non-admin participants to pin media to the room"
-    field(:pin_objects, :boolean)
+    field :pin_objects, :boolean
     @desc "Allows non-admin participants to spawn emoji"
-    field(:spawn_emoji, :boolean)
+    field :spawn_emoji, :boolean
     @desc "Allows non-admin participants to toggle fly mode"
-    field(:fly, :boolean)
+    field :fly, :boolean
     @desc "Allows non-admin participants to use the voice chat"
-    field(:voice_chat, :boolean)
+    field :voice_chat, :boolean
     @desc "Allows non-admin participants to use the text chat"
-    field(:text_chat, :boolean)
+    field :text_chat, :boolean
   end
 
   @desc "Permissions for participants in the room"
   object :member_permissions do
     @desc "Allows non-admin participants to spawn and move media"
-    field(:spawn_and_move_media, :boolean)
+    field :spawn_and_move_media, :boolean
     @desc "Allows non-admin participants to spawn in-game cameras"
-    field(:spawn_camera, :boolean)
+    field :spawn_camera, :boolean
     @desc "Allows non-admin participants to draw with a pen"
-    field(:spawn_drawing, :boolean)
+    field :spawn_drawing, :boolean
     @desc "Allows non-admin participants to pin media to the room"
-    field(:pin_objects, :boolean)
+    field :pin_objects, :boolean
     @desc "Allows non-admin participants to spawn emoji"
-    field(:spawn_emoji, :boolean)
+    field :spawn_emoji, :boolean
     @desc "Allows non-admin participants to toggle fly mode"
-    field(:fly, :boolean)
+    field :fly, :boolean
     @desc "Allows non-admin participants to use the voice chat"
-    field(:voice_chat, :boolean)
+    field :voice_chat, :boolean
     @desc "Allows non-admin participants to use the text chat"
-    field(:text_chat, :boolean)
+    field :text_chat, :boolean
   end
 
   @desc "A room"
   object :room do
     @desc "The room's unique ID"
-    field(:hub_sid, :id, name: "id")
+    field :hub_sid, :id, name: "id"
     @desc "The room's name"
-    field(:name, :string)
+    field :name, :string
     @desc "The room's name as it appears at the end of its URL"
-    field(:slug, :string)
+    field :slug, :string
     @desc "A description of the room"
-    field(:description, :string)
+    field :description, :string
     @desc "Makes this room as public (while it is still open)"
-    field(:allow_promotion, :boolean)
+    field :allow_promotion, :boolean
 
     @desc "Temporary entry code"
-    field(:entry_code, :string) do
-      deprecate("Entry codes have been removed.")
-      resolve(&Resolvers.RoomResolver.entry_code/3)
+    field :entry_code, :string do
+      deprecate "Entry codes have been removed."
+      resolve &Resolvers.RoomResolver.entry_code/3
     end
 
     @desc "Determines if entry is allowed, denied, or by-invite-only. (Values are \"allow\", \"deny\", or \"invite\".)"
-    field(:entry_mode, :string)
+    field :entry_mode, :string
     @desc "The host server associated with this room via the load balancer"
-    field(:host, :string)
+    field :host, :string
 
     @desc "The port number used to connect to the host server"
-    field(:port, :integer) do
+    field :port, :integer do
       @desc "The port number used to connect to the host server"
-      resolve(&Resolvers.RoomResolver.port/3)
+      resolve &Resolvers.RoomResolver.port/3
     end
 
     @desc "TURN information for DLTS over TURN fallback, when enabled"
-    field(:turn, :turn_info) do
-      resolve(&Resolvers.RoomResolver.turn/3)
+    field :turn, :turn_info do
+      resolve &Resolvers.RoomResolver.turn/3
     end
 
     @desc """
     Can be used to remove the X-Frame-Options header that is usually served to the Hubs client when this room is loaded, so that the client can access this room from a <frame>, <iframe>, <embed> or <object>.
     """
-    field(:embed_token, :string) do
-      resolve(&Resolvers.RoomResolver.embed_token/3)
+    field :embed_token, :string do
+      resolve &Resolvers.RoomResolver.embed_token/3
     end
 
     @desc """
     Can be used to assign the room creator. (It will be blank if the room creator is already assigned.)
     """
-    field(:creator_assignment_token, :string)
+    field :creator_assignment_token, :string
 
     @desc "Permissions for participants in the room"
-    field(:member_permissions, :member_permissions) do
-      resolve(&Resolvers.RoomResolver.member_permissions/3)
+    field :member_permissions, :member_permissions do
+      resolve &Resolvers.RoomResolver.member_permissions/3
     end
 
     @desc "Number of participants allowed to enter the room"
-    field(:room_size, :integer) do
-      resolve(&Resolvers.RoomResolver.room_size/3)
+    field :room_size, :integer do
+      resolve &Resolvers.RoomResolver.room_size/3
     end
 
     @desc "Number of participants in the room as avatars"
-    field(:member_count, :integer) do
-      resolve(&Resolvers.RoomResolver.member_count/3)
+    field :member_count, :integer do
+      resolve &Resolvers.RoomResolver.member_count/3
     end
 
     @desc "Number of participants in the room lobby"
-    field(:lobby_count, :integer) do
-      resolve(&Resolvers.RoomResolver.lobby_count/3)
+    field :lobby_count, :integer do
+      resolve &Resolvers.RoomResolver.lobby_count/3
     end
 
     @desc "Scene currently associated with the room"
-    field(:scene, :scene_or_scene_listing) do
-      resolve(&Resolvers.RoomResolver.scene/3)
+    field :scene, :scene_or_scene_listing do
+      resolve &Resolvers.RoomResolver.scene/3
     end
 
     @desc "Default environment gltf bundle url associated with the room (instead of a scene or scene listing)"
-    field(:default_environment_gltf_bundle_url, :string)
+    field :default_environment_gltf_bundle_url, :string
 
     @desc "Arbitrary json data associated with the room"
-    field(:user_data, :json)
+    field :user_data, :json
   end
 
   @desc """
@@ -147,15 +148,15 @@ defmodule RetWeb.Schema.RoomTypes do
   """
   object :room_list do
     @desc "Total number of rooms for the given query"
-    field(:total_entries, :integer)
+    field :total_entries, :integer
     @desc "Total number of pages for the given query"
-    field(:total_pages, :integer)
+    field :total_pages, :integer
     @desc "Page number returned for this query"
-    field(:page_number, :integer)
+    field :page_number, :integer
     @desc "Number of rooms per page"
-    field(:page_size, :integer)
+    field :page_size, :integer
     @desc "The list of rooms"
-    field(:entries, list_of(:room))
+    field :entries, list_of(:room)
   end
 
   @desc """
@@ -167,10 +168,10 @@ defmodule RetWeb.Schema.RoomTypes do
     """
     field :my_rooms, :room_list do
       @desc "The desired page of data to return"
-      arg(:page, :integer)
+      arg :page, :integer
       @desc "The number of entries per page"
-      arg(:page_size, :integer)
-      resolve(&Resolvers.RoomResolver.my_rooms/3)
+      arg :page_size, :integer
+      resolve &Resolvers.RoomResolver.my_rooms/3
     end
 
     @desc """
@@ -178,10 +179,10 @@ defmodule RetWeb.Schema.RoomTypes do
     """
     field :public_rooms, :room_list do
       @desc "The desired page of data to return"
-      arg(:page, :integer)
+      arg :page, :integer
       @desc "The number of entries per page"
-      arg(:page_size, :integer)
-      resolve(&Resolvers.RoomResolver.public_rooms/3)
+      arg :page_size, :integer
+      resolve &Resolvers.RoomResolver.public_rooms/3
     end
 
     @desc """
@@ -189,10 +190,10 @@ defmodule RetWeb.Schema.RoomTypes do
     """
     field :favorite_rooms, :room_list do
       @desc "The desired page of data to return"
-      arg(:page, :integer)
+      arg :page, :integer
       @desc "The number of entries per page"
-      arg(:page_size, :integer)
-      resolve(&Resolvers.RoomResolver.favorite_rooms/3)
+      arg :page_size, :integer
+      resolve &Resolvers.RoomResolver.favorite_rooms/3
     end
   end
 
@@ -201,49 +202,49 @@ defmodule RetWeb.Schema.RoomTypes do
     @desc "Create a room with the given properties"
     field :create_room, :room do
       @desc "The room name"
-      arg(:name, :string)
+      arg :name, :string
       @desc "A description of the room"
-      arg(:description, :string)
+      arg :description, :string
       @desc "The number of participants allowed into the room from the lobby at any given time"
-      arg(:room_size, :integer)
+      arg :room_size, :integer
       @desc "The id of the scene to associate with the room"
-      arg(:scene_id, :string)
+      arg :scene_id, :string
       @desc "The url of the scene to associate with the room"
-      arg(:scene_url, :string)
+      arg :scene_url, :string
       @desc "The permissions non-admin participants should have in the room"
-      arg(:member_permissions, :input_member_permissions)
+      arg :member_permissions, :input_member_permissions
       @desc "Arbitrary json data associated with this room"
-      arg(:user_data, :json)
+      arg :user_data, :json
 
-      resolve(&Resolvers.RoomResolver.create_room/3)
+      resolve &Resolvers.RoomResolver.create_room/3
     end
 
     @desc "Update properties of the room specified by the given id"
     field :update_room, :room do
       @desc "The id of the room to update"
-      arg(:id, non_null(:string))
+      arg :id, non_null(:string)
       @desc "The room name"
-      arg(:name, :string)
+      arg :name, :string
       @desc "A description of the room"
-      arg(:description, :string)
+      arg :description, :string
       @desc "The number of participants allowed into the room from the lobby at any given time"
-      arg(:room_size, :integer)
+      arg :room_size, :integer
       @desc "The id of the scene to associate with the room"
-      arg(:scene_id, :string)
+      arg :scene_id, :string
       @desc "The url of the scene to associate with the room"
-      arg(:scene_url, :string)
+      arg :scene_url, :string
       @desc "The permissions non-admin participants should have in the room"
-      arg(:member_permissions, :input_member_permissions)
+      arg :member_permissions, :input_member_permissions
       @desc "Arbitrary json data associated with this room"
-      arg(:user_data, :json)
+      arg :user_data, :json
 
       # TODO: add/remove owner
 
-      resolve(&Resolvers.RoomResolver.update_room/3)
+      resolve &Resolvers.RoomResolver.update_room/3
     end
   end
 
   object :room_subscriptions do
-    field(:room_created, :room)
+    field :room_created, :room
   end
 end

--- a/lib/ret_web/schema/scene_types.ex
+++ b/lib/ret_web/schema/scene_types.ex
@@ -4,28 +4,28 @@ defmodule RetWeb.Schema.SceneTypes do
 
   @desc "A scene or a scene listing"
   union :scene_or_scene_listing do
-    types([:scene, :scene_listing])
+    types [:scene, :scene_listing]
 
-    resolve_type(fn
+    resolve_type fn
       %Scene{}, _ -> :scene
       %SceneListing{}, _ -> :scene_listing
       _, _ -> nil
-    end)
+    end
   end
 
   @desc "A scene"
   object :scene do
     @desc "The scene id"
-    field(:scene_sid, :id, name: "id")
+    field :scene_sid, :id, name: "id"
     @desc "The scene name"
-    field(:name, :string)
+    field :name, :string
   end
 
   @desc "A scene listing (which allows the creator to change the underlying scene assets)"
   object :scene_listing do
     @desc "The scene listing id"
-    field(:scene_listing_sid, :id, name: "id")
+    field :scene_listing_sid, :id, name: "id"
     @desc "The scene listing name"
-    field(:name, :string)
+    field :name, :string
   end
 end

--- a/lib/ret_web/schema/types/custom/json.ex
+++ b/lib/ret_web/schema/types/custom/json.ex
@@ -7,14 +7,14 @@ defmodule RetWeb.Schema.Types.Custom.JSON do
   use Absinthe.Schema.Notation
 
   scalar :json, name: "Json" do
-    description("""
+    description """
     The `Json` scalar type represents arbitrary json string data, represented as UTF-8
     character sequences. The Json type is most often used to represent a free-form
     human-readable json string.
-    """)
+    """
 
-    serialize(&encode/1)
-    parse(&decode/1)
+    serialize &encode/1
+    parse &decode/1
   end
 
   @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error

--- a/lib/ret_web/views/api/v1/account_view.ex
+++ b/lib/ret_web/views/api/v1/account_view.ex
@@ -3,7 +3,10 @@ defmodule RetWeb.Api.V1.AccountView do
 
   alias Ret.{Account, Identity}
 
-  def render("create.json", %{account: %Account{identity: %Identity{name: name}} = account, email: email}) do
+  def render("create.json", %{
+        account: %Account{identity: %Identity{name: name}} = account,
+        email: email
+      }) do
     %{
       id: "#{account.account_id}",
       login: %{email: email},

--- a/lib/ret_web/views/api/v1/avatar_view.ex
+++ b/lib/ret_web/views/api/v1/avatar_view.ex
@@ -22,10 +22,14 @@ defmodule RetWeb.Api.V1.AvatarView do
       avatar_id: avatar.avatar_sid,
       parent_avatar_id: unless(is_nil(avatar.parent_avatar), do: avatar.parent_avatar.avatar_sid),
       # Only include account id on your own avatars
-      account_id: account && avatar.account_id == account.account_id && avatar.account_id |> Integer.to_string(),
+      account_id:
+        account &&
+          avatar.account_id == account.account_id &&
+          avatar.account_id |> Integer.to_string(),
       allow_remixing: avatar.allow_remixing,
       allow_promotion: avatar.allow_promotion,
-      has_listings: length(avatar.avatar_listings |> Enum.filter(fn l -> l.state == :active end)) > 0
+      has_listings:
+        length(avatar.avatar_listings |> Enum.filter(fn l -> l.state == :active end)) > 0
     })
   end
 
@@ -42,7 +46,8 @@ defmodule RetWeb.Api.V1.AvatarView do
 
   defp common_fields(%t{} = a) when t in [Avatar, AvatarListing] do
     %{
-      parent_avatar_listing_id: unless(is_nil(a.parent_avatar_listing), do: a.parent_avatar_listing.avatar_listing_sid),
+      parent_avatar_listing_id:
+        unless(is_nil(a.parent_avatar_listing), do: a.parent_avatar_listing.avatar_listing_sid),
       name: a.name,
       description: a.description,
       attributions: if(is_nil(a.attributions), do: %{}, else: a.attributions),

--- a/lib/ret_web/views/api/v1/hub_view.ex
+++ b/lib/ret_web/views/api/v1/hub_view.ex
@@ -16,7 +16,10 @@ defmodule RetWeb.Api.V1.HubView do
     hub |> render_with_scene(embeddable)
   end
 
-  def render("show.json", %{hub: %Hub{scene_listing: %SceneListing{}} = hub, embeddable: embeddable}) do
+  def render("show.json", %{
+        hub: %Hub{scene_listing: %SceneListing{}} = hub,
+        embeddable: embeddable
+      }) do
     hub |> render_with_scene(embeddable)
   end
 

--- a/lib/ret_web/views/api/v1/project_view.ex
+++ b/lib/ret_web/views/api/v1/project_view.ex
@@ -9,7 +9,11 @@ defmodule RetWeb.Api.V1.ProjectView do
       project_url: OwnedFile.url_or_nil_for(project.project_owned_file),
       thumbnail_url: OwnedFile.url_or_nil_for(project.thumbnail_owned_file),
       scene: RetWeb.Api.V1.SceneView.render_scene(project.scene, nil),
-      parent_scene: RetWeb.Api.V1.SceneView.render_scene(project.parent_scene_listing || project.parent_scene, nil)
+      parent_scene:
+        RetWeb.Api.V1.SceneView.render_scene(
+          project.parent_scene_listing || project.parent_scene,
+          nil
+        )
     }
   end
 

--- a/lib/ret_web/views/api/v1/scene_view.ex
+++ b/lib/ret_web/views/api/v1/scene_view.ex
@@ -54,7 +54,9 @@ defmodule RetWeb.Api.V1.SceneView do
   defp add_scene_or_listing_fields(map, %Scene{} = scene, account) do
     map
     |> Map.merge(%{
-      account_id: account && scene.account_id == account.account_id && scene.account_id |> Integer.to_string(),
+      account_id:
+        account && scene.account_id == account.account_id &&
+          scene.account_id |> Integer.to_string(),
       parent_scene_id: (scene.parent_scene_listing || scene.parent_scene) |> Scene.to_sid(),
       attribution: scene.attribution,
       allow_remixing: scene.allow_remixing,

--- a/mix.exs
+++ b/mix.exs
@@ -92,7 +92,8 @@ defmodule Ret.Mixfile do
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:ex_json_schema, "~> 0.7.3"},
       {:observer_cli, "~> 1.5"},
-      {:stream_data, "~> 0.5", github: "whatyouhide/stream_data", ref: "c7ef8ef", only: [:dev, :test]}
+      {:stream_data, "~> 0.5",
+       github: "whatyouhide/stream_data", ref: "c7ef8ef", only: [:dev, :test]}
     ]
   end
 

--- a/priv/repo/migrations/20170917234137_create_sharding_ids.exs
+++ b/priv/repo/migrations/20170917234137_create_sharding_ids.exs
@@ -2,10 +2,10 @@ defmodule Ret.Repo.Migrations.CreateShardingIds do
   use Ecto.Migration
 
   def up do
-    execute("create schema if not exists ret0")
-    execute("create sequence ret0.table_id_seq")
+    execute "create schema if not exists ret0"
+    execute "create sequence ret0.table_id_seq"
 
-    execute("""
+    execute """
     CREATE OR REPLACE FUNCTION ret0.next_id(OUT result bigint) AS $$
     DECLARE
     our_epoch bigint := 1505706041000;
@@ -21,10 +21,10 @@ defmodule Ret.Repo.Migrations.CreateShardingIds do
     result := result | (seq_id);
     END;
     $$ LANGUAGE PLPGSQL;
-    """)
+    """
   end
 
   def down do
-    execute("DROP SCHEMA ret0 CASCADE")
+    execute "DROP SCHEMA ret0 CASCADE"
   end
 end

--- a/priv/repo/migrations/20170917234138_create_users.exs
+++ b/priv/repo/migrations/20170917234138_create_users.exs
@@ -3,17 +3,17 @@ defmodule Ret.Repo.Migrations.CreateUsers do
 
   def change do
     create table(:users, primary_key: false) do
-      add(:user_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:email, :string, null: false)
-      add(:auth_provider, :string, null: false)
-      add(:name, :string)
-      add(:first_name, :string)
-      add(:last_name, :string)
-      add(:image, :string)
+      add :user_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :email, :string, null: false
+      add :auth_provider, :string, null: false
+      add :name, :string
+      add :first_name, :string
+      add :last_name, :string
+      add :image, :string
 
       timestamps()
     end
 
-    create(index(:users, [:email], unique: true))
+    create unique_index(:users, [:email])
   end
 end

--- a/priv/repo/migrations/20180322000442_drop_users_table.exs
+++ b/priv/repo/migrations/20180322000442_drop_users_table.exs
@@ -2,6 +2,6 @@ defmodule Ret.Repo.Migrations.DropUsersTable do
   use Ecto.Migration
 
   def change do
-    drop(table(:users))
+    drop table(:users)
   end
 end

--- a/priv/repo/migrations/20180322000712_create_hubs_table.exs
+++ b/priv/repo/migrations/20180322000712_create_hubs_table.exs
@@ -3,15 +3,15 @@ defmodule Ret.Repo.Migrations.CreateHubsTable do
 
   def change do
     create table(:hubs, primary_key: false) do
-      add(:hub_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:hub_sid, :string)
-      add(:slug, :string, null: false)
-      add(:name, :string, null: false)
-      add(:default_environment_gltf_bundle_url, :string, null: false)
+      add :hub_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :hub_sid, :string
+      add :slug, :string, null: false
+      add :name, :string, null: false
+      add :default_environment_gltf_bundle_url, :string, null: false
 
       timestamps()
     end
 
-    create(index(:hubs, [:hub_sid], unique: true))
+    create unique_index(:hubs, [:hub_sid])
   end
 end

--- a/priv/repo/migrations/20180408231444_create_session_stats_table.exs
+++ b/priv/repo/migrations/20180408231444_create_session_stats_table.exs
@@ -20,8 +20,10 @@ defmodule Ret.Repo.Migrations.CreateSessionStatsTable do
         month <- 0..11 do
       with end_month <- rem(month + 1, 12),
            end_year <- if(month == 11, do: year + 1, else: year) do
-        execute("create table ret0.session_stats_y#{year}_m#{month + 1} partition of ret0.session_stats
-                 for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')")
+        execute(
+          "create table ret0.session_stats_y#{year}_m#{month + 1} partition of ret0.session_stats
+                 for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')"
+        )
       end
     end
   end

--- a/priv/repo/migrations/20180408231444_create_session_stats_table.exs
+++ b/priv/repo/migrations/20180408231444_create_session_stats_table.exs
@@ -9,21 +9,19 @@ defmodule Ret.Repo.Migrations.CreateSessionStatsTable do
              primary_key: false,
              options: "partition by range (started_at)"
            ) do
-      add(:session_id, :uuid, null: false)
-      add(:started_at, :utc_datetime, null: false)
-      add(:ended_at, :utc_datetime)
-      add(:entered_event_payload, :jsonb)
-      add(:entered_event_received_at, :utc_datetime)
+      add :session_id, :uuid, null: false
+      add :started_at, :utc_datetime, null: false
+      add :ended_at, :utc_datetime
+      add :entered_event_payload, :jsonb
+      add :entered_event_received_at, :utc_datetime
     end
 
     for year <- 2018..@max_year,
         month <- 0..11 do
       with end_month <- rem(month + 1, 12),
            end_year <- if(month == 11, do: year + 1, else: year) do
-        execute(
-          "create table ret0.session_stats_y#{year}_m#{month + 1} partition of ret0.session_stats
+        execute "create table ret0.session_stats_y#{year}_m#{month + 1} partition of ret0.session_stats
                  for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')"
-        )
       end
     end
   end
@@ -31,9 +29,9 @@ defmodule Ret.Repo.Migrations.CreateSessionStatsTable do
   def down do
     for year <- 2018..@max_year,
         month <- 0..11 do
-      execute("drop table ret0.session_stats_y#{year}_m#{month + 1}")
+      execute "drop table ret0.session_stats_y#{year}_m#{month + 1}"
     end
 
-    drop(table(:session_stats))
+    drop table(:session_stats)
   end
 end

--- a/priv/repo/migrations/20180409012805_add_max_occupants_to_hub.exs
+++ b/priv/repo/migrations/20180409012805_add_max_occupants_to_hub.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddMaxOccupantsToHub do
 
   def change do
     alter table("hubs") do
-      add(:max_occupant_count, :integer, null: false, default: 0)
+      add :max_occupant_count, :integer, null: false, default: 0
     end
   end
 end

--- a/priv/repo/migrations/20180412225707_create_node_stats_table.exs
+++ b/priv/repo/migrations/20180412225707_create_node_stats_table.exs
@@ -19,8 +19,10 @@ defmodule Ret.Repo.Migrations.NodeStatsTable do
         month <- 0..11 do
       with end_month <- rem(month + 1, 12),
            end_year <- if(month == 11, do: year + 1, else: year) do
-        execute("create table ret0.node_stats_y#{year}_m#{month + 1} partition of ret0.node_stats
-                 for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')")
+        execute(
+          "create table ret0.node_stats_y#{year}_m#{month + 1} partition of ret0.node_stats
+                 for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')"
+        )
       end
     end
   end

--- a/priv/repo/migrations/20180412225707_create_node_stats_table.exs
+++ b/priv/repo/migrations/20180412225707_create_node_stats_table.exs
@@ -9,20 +9,18 @@ defmodule Ret.Repo.Migrations.NodeStatsTable do
              primary_key: false,
              options: "partition by range (measured_at)"
            ) do
-      add(:node_id, :string, null: false)
-      add(:measured_at, :utc_datetime, null: false)
-      add(:present_sessions, :integer)
-      add(:present_rooms, :integer)
+      add :node_id, :string, null: false
+      add :measured_at, :utc_datetime, null: false
+      add :present_sessions, :integer
+      add :present_rooms, :integer
     end
 
     for year <- 2018..@max_year,
         month <- 0..11 do
       with end_month <- rem(month + 1, 12),
            end_year <- if(month == 11, do: year + 1, else: year) do
-        execute(
-          "create table ret0.node_stats_y#{year}_m#{month + 1} partition of ret0.node_stats
+        execute "create table ret0.node_stats_y#{year}_m#{month + 1} partition of ret0.node_stats
                  for values from ('#{year}-#{month + 1}-01') to ('#{end_year}-#{end_month + 1}-01')"
-        )
       end
     end
   end
@@ -30,9 +28,9 @@ defmodule Ret.Repo.Migrations.NodeStatsTable do
   def down do
     for year <- 2018..@max_year,
         month <- 0..11 do
-      execute("drop table ret0.node_stats_y#{year}_m#{month + 1}")
+      execute "drop table ret0.node_stats_y#{year}_m#{month + 1}"
     end
 
-    drop(table(:node_stats))
+    drop table(:node_stats)
   end
 end

--- a/priv/repo/migrations/20180416203936_add_entry_mode_to_hub.exs
+++ b/priv/repo/migrations/20180416203936_add_entry_mode_to_hub.exs
@@ -5,13 +5,13 @@ defmodule Ret.Repo.Migrations.AddEntryModeToHub do
     Ret.Hub.EntryMode.create_type()
 
     alter table("hubs") do
-      add(:entry_mode, :hub_entry_mode, null: false, default: "allow")
+      add :entry_mode, :hub_entry_mode, null: false, default: "allow"
     end
   end
 
   def down do
     alter table("hubs") do
-      remove(:entry_mode)
+      remove :entry_mode
     end
 
     Ret.Hub.EntryMode.drop_type()

--- a/priv/repo/migrations/20180802004115_extend_scene_column.exs
+++ b/priv/repo/migrations/20180802004115_extend_scene_column.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.ExtendSceneColumn do
 
   def change do
     alter table("hubs") do
-      modify(:default_environment_gltf_bundle_url, :string, null: false, size: 2048)
+      modify :default_environment_gltf_bundle_url, :string, null: false, size: 2048
     end
   end
 end

--- a/priv/repo/migrations/20180808191456_add_has_media_objects_bit.exs
+++ b/priv/repo/migrations/20180808191456_add_has_media_objects_bit.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddHasMediaObjectsBit do
 
   def change do
     alter table("hubs") do
-      add(:spawned_object_types, :int, null: false, default: 0)
+      add :spawned_object_types, :int, null: false, default: 0
     end
   end
 end

--- a/priv/repo/migrations/20180830224453_create_account.exs
+++ b/priv/repo/migrations/20180830224453_create_account.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.CreateAccount do
 
   def change do
     create table(:accounts, primary_key: false) do
-      add(:account_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+      add :account_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
 
       timestamps()
     end

--- a/priv/repo/migrations/20180830224557_create_login.exs
+++ b/priv/repo/migrations/20180830224557_create_login.exs
@@ -3,14 +3,14 @@ defmodule Ret.Repo.Migrations.CreateLogin do
 
   def change do
     create table(:logins, primary_key: false) do
-      add(:login_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:identifier_hash, :string, null: false)
-      add(:account_id, references(:accounts, column: :account_id, on_delete: :delete_all))
+      add :login_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :identifier_hash, :string, null: false
+      add :account_id, references(:accounts, column: :account_id, on_delete: :delete_all)
 
       timestamps()
     end
 
-    create(index(:logins, [:identifier_hash], unique: true))
-    create(index(:logins, [:account_id], unique: true))
+    create unique_index(:logins, [:identifier_hash])
+    create unique_index(:logins, [:account_id])
   end
 end

--- a/priv/repo/migrations/20180831012904_create_login_tokens.exs
+++ b/priv/repo/migrations/20180831012904_create_login_tokens.exs
@@ -3,13 +3,13 @@ defmodule Ret.Repo.Migrations.CreateLoginTokens do
 
   def change do
     create table(:login_tokens, primary_key: false) do
-      add(:login_token_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:token, :string)
-      add(:identifier_hash, :string)
+      add :login_token_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :token, :string
+      add :identifier_hash, :string
 
       timestamps()
     end
 
-    create(index(:login_tokens, [:token], unique: true))
+    create unique_index(:login_tokens, [:token])
   end
 end

--- a/priv/repo/migrations/20180904221223_create_owned_files_table.exs
+++ b/priv/repo/migrations/20180904221223_create_owned_files_table.exs
@@ -3,18 +3,18 @@ defmodule Ret.Repo.Migrations.CreateFilesTable do
 
   def change do
     create table(:owned_files, primary_key: false) do
-      add(:owned_file_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:owned_file_uuid, :string, null: false)
-      add(:key, :string, null: false)
-      add(:account_id, :bigint, null: false)
-      add(:content_type, :string, null: false)
-      add(:content_length, :bigint, null: false)
-      add(:state, :owned_file_state, null: false, default: "active")
+      add :owned_file_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :owned_file_uuid, :string, null: false
+      add :key, :string, null: false
+      add :account_id, :bigint, null: false
+      add :content_type, :string, null: false
+      add :content_length, :bigint, null: false
+      add :state, :owned_file_state, null: false, default: "active"
 
       timestamps()
     end
 
-    create(index(:owned_files, [:owned_file_uuid], unique: true))
-    create(index(:owned_files, [:account_id]))
+    create unique_index(:owned_files, [:owned_file_uuid])
+    create index(:owned_files, [:account_id])
   end
 end

--- a/priv/repo/migrations/20180904222223_create_scenes_table.exs
+++ b/priv/repo/migrations/20180904222223_create_scenes_table.exs
@@ -3,20 +3,20 @@ defmodule Ret.Repo.Migrations.CreateScenesTable do
 
   def change do
     create table(:scenes, primary_key: false) do
-      add(:scene_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:scene_sid, :string)
-      add(:slug, :string, null: false)
-      add(:name, :string, null: false)
-      add(:description, :string)
-      add(:account_id, :bigint, null: false)
-      add(:model_owned_file_id, :bigint, null: false)
-      add(:screenshot_owned_file_id, :bigint, null: false)
-      add(:state, :scene_state, null: false, default: "active")
+      add :scene_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :scene_sid, :string
+      add :slug, :string, null: false
+      add :name, :string, null: false
+      add :description, :string
+      add :account_id, :bigint, null: false
+      add :model_owned_file_id, :bigint, null: false
+      add :screenshot_owned_file_id, :bigint, null: false
+      add :state, :scene_state, null: false, default: "active"
 
       timestamps()
     end
 
-    create(index(:scenes, [:scene_sid], unique: true))
-    create(index(:scenes, [:account_id]))
+    create unique_index(:scenes, [:scene_sid])
+    create index(:scenes, [:account_id])
   end
 end

--- a/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
+++ b/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
@@ -3,7 +3,11 @@ defmodule Ret.Repo.Migrations.AddSupportSubscriptionsTable do
 
   def change do
     create table(:support_subscriptions, primary_key: false) do
-      add(:support_subscription_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+      add(:support_subscription_id, :bigint,
+        default: fragment("ret0.next_id()"),
+        primary_key: true
+      )
+
       add(:channel, :string, null: false)
       add(:identifier, :string, null: false)
 

--- a/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
+++ b/priv/repo/migrations/20180910200029_add_support_subscriptions_table.exs
@@ -3,17 +3,16 @@ defmodule Ret.Repo.Migrations.AddSupportSubscriptionsTable do
 
   def change do
     create table(:support_subscriptions, primary_key: false) do
-      add(:support_subscription_id, :bigint,
+      add :support_subscription_id, :bigint,
         default: fragment("ret0.next_id()"),
         primary_key: true
-      )
 
-      add(:channel, :string, null: false)
-      add(:identifier, :string, null: false)
+      add :channel, :string, null: false
+      add :identifier, :string, null: false
 
       timestamps()
     end
 
-    create(index(:support_subscriptions, [:channel, :identifier], unique: true))
+    create unique_index(:support_subscriptions, [:channel, :identifier])
   end
 end

--- a/priv/repo/migrations/20180919002949_add_attribution_to_scene.exs
+++ b/priv/repo/migrations/20180919002949_add_attribution_to_scene.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddAttributionToScene do
 
   def change do
     alter table("scenes") do
-      add(:attribution, :string)
+      add :attribution, :string
     end
   end
 end

--- a/priv/repo/migrations/20180919235959_add_licensing_columns_to_scenes.exs
+++ b/priv/repo/migrations/20180919235959_add_licensing_columns_to_scenes.exs
@@ -3,9 +3,9 @@ defmodule Ret.Repo.Migrations.AddLicensingColumnsToScenes do
 
   def change do
     alter table("scenes") do
-      add(:allow_remixing, :boolean, null: false, default: false)
-      add(:allow_promotion, :boolean, null: false, default: false)
-      add(:scene_owned_file_id, references(:owned_files, column: :owned_file_id))
+      add :allow_remixing, :boolean, null: false, default: false
+      add :allow_promotion, :boolean, null: false, default: false
+      add :scene_owned_file_id, references(:owned_files, column: :owned_file_id)
     end
   end
 end

--- a/priv/repo/migrations/20180920000254_add_scene_to_hubs.exs
+++ b/priv/repo/migrations/20180920000254_add_scene_to_hubs.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddSceneToHubs do
 
   def change do
     alter table("hubs") do
-      add(:scene_id, references(:scenes, column: :scene_id))
+      add :scene_id, references(:scenes, column: :scene_id)
     end
   end
 end

--- a/priv/repo/migrations/20180920032008_drop_null_constraint_on_gltf_bundle_url.exs
+++ b/priv/repo/migrations/20180920032008_drop_null_constraint_on_gltf_bundle_url.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.DropNullConstraintOnGltfBundleUrl do
 
   def change do
     alter table("hubs") do
-      modify(:default_environment_gltf_bundle_url, :string, null: true)
+      modify :default_environment_gltf_bundle_url, :string, null: true
     end
   end
 end

--- a/priv/repo/migrations/20180920222237_extend_attribution_column.exs
+++ b/priv/repo/migrations/20180920222237_extend_attribution_column.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.ExtendAttributionColumn do
 
   def change do
     alter table("scenes") do
-      modify(:attribution, :string, size: 2048)
+      modify :attribution, :string, size: 2048
     end
   end
 end

--- a/priv/repo/migrations/20180924005229_add_entry_codes_to_hubs.exs
+++ b/priv/repo/migrations/20180924005229_add_entry_codes_to_hubs.exs
@@ -3,10 +3,10 @@ defmodule Ret.Repo.Migrations.AddEntryCodesToHubs do
 
   def change do
     alter table("hubs") do
-      add(:entry_code, :integer, null: true)
-      add(:entry_code_expires_at, :utc_datetime, null: true)
+      add :entry_code, :integer, null: true
+      add :entry_code_expires_at, :utc_datetime, null: true
     end
 
-    create(index(:hubs, [:entry_code], unique: true))
+    create unique_index(:hubs, [:entry_code])
   end
 end

--- a/priv/repo/migrations/20181015020416_add_web_push_subscriptions.exs
+++ b/priv/repo/migrations/20181015020416_add_web_push_subscriptions.exs
@@ -3,21 +3,20 @@ defmodule Ret.Repo.Migrations.AddWebPushSubscriptions do
 
   def change do
     create table(:web_push_subscriptions, primary_key: false) do
-      add(:web_push_subscription_id, :bigint,
+      add :web_push_subscription_id, :bigint,
         default: fragment("ret0.next_id()"),
         primary_key: true
-      )
 
-      add(:p256dh, :string, null: false)
-      add(:endpoint, :string, null: false)
-      add(:auth, :binary, null: false)
-      add(:hub_id, :bigint, null: false)
-      add(:last_notified_at, :utc_datetime, null: true)
+      add :p256dh, :string, null: false
+      add :endpoint, :string, null: false
+      add :auth, :binary, null: false
+      add :hub_id, :bigint, null: false
+      add :last_notified_at, :utc_datetime, null: true
 
       timestamps()
     end
 
-    create(index(:web_push_subscriptions, [:hub_id, :endpoint], unique: true))
-    create(index(:web_push_subscriptions, [:endpoint]))
+    create unique_index(:web_push_subscriptions, [:hub_id, :endpoint])
+    create index(:web_push_subscriptions, [:endpoint])
   end
 end

--- a/priv/repo/migrations/20181015020416_add_web_push_subscriptions.exs
+++ b/priv/repo/migrations/20181015020416_add_web_push_subscriptions.exs
@@ -3,7 +3,11 @@ defmodule Ret.Repo.Migrations.AddWebPushSubscriptions do
 
   def change do
     create table(:web_push_subscriptions, primary_key: false) do
-      add(:web_push_subscription_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+      add(:web_push_subscription_id, :bigint,
+        default: fragment("ret0.next_id()"),
+        primary_key: true
+      )
+
       add(:p256dh, :string, null: false)
       add(:endpoint, :string, null: false)
       add(:auth, :binary, null: false)

--- a/priv/repo/migrations/20181024050853_add_room_objects.exs
+++ b/priv/repo/migrations/20181024050853_add_room_objects.exs
@@ -3,15 +3,15 @@ defmodule Ret.Repo.Migrations.CreateRoomObjectsTable do
 
   def change do
     create table(:room_objects, primary_key: false) do
-      add(:room_object_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:object_id, :string, null: false)
-      add(:hub_id, references(:hubs, column: :hub_id), null: false)
-      add(:gltf_node, :binary, null: false)
+      add :room_object_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :object_id, :string, null: false
+      add :hub_id, references(:hubs, column: :hub_id), null: false
+      add :gltf_node, :binary, null: false
 
       timestamps()
     end
 
-    create(index(:room_objects, [:object_id, :hub_id], unique: true))
-    create(index(:room_objects, [:hub_id]))
+    create unique_index(:room_objects, [:object_id, :hub_id])
+    create index(:room_objects, [:hub_id])
   end
 end

--- a/priv/repo/migrations/20181102010842_add_attributions_to_scene.exs
+++ b/priv/repo/migrations/20181102010842_add_attributions_to_scene.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddAttributionsToScene do
 
   def change do
     alter table("scenes") do
-      add(:attributions, :jsonb)
+      add :attributions, :jsonb
     end
   end
 end

--- a/priv/repo/migrations/20181102011004_migrate_attributions.exs
+++ b/priv/repo/migrations/20181102011004_migrate_attributions.exs
@@ -2,9 +2,7 @@ defmodule Ret.Repo.Migrations.MigrateAttributions do
   use Ecto.Migration
 
   def up do
-    execute(
-      "update ret0.scenes set attributions = json_build_object('extras', scenes.attribution)"
-    )
+    execute "update ret0.scenes set attributions = json_build_object('extras', scenes.attribution)"
   end
 
   def down do

--- a/priv/repo/migrations/20181102011004_migrate_attributions.exs
+++ b/priv/repo/migrations/20181102011004_migrate_attributions.exs
@@ -2,7 +2,9 @@ defmodule Ret.Repo.Migrations.MigrateAttributions do
   use Ecto.Migration
 
   def up do
-    execute("update ret0.scenes set attributions = json_build_object('extras', scenes.attribution)")
+    execute(
+      "update ret0.scenes set attributions = json_build_object('extras', scenes.attribution)"
+    )
   end
 
   def down do

--- a/priv/repo/migrations/20181113033726_add_account_to_room_objects.exs
+++ b/priv/repo/migrations/20181113033726_add_account_to_room_objects.exs
@@ -3,16 +3,14 @@ defmodule Ret.Repo.Migrations.AddAccountToRoomObjects do
 
   def change do
     alter table("room_objects") do
-      add(:account_id, references(:accounts, column: :account_id))
+      add :account_id, references(:accounts, column: :account_id)
     end
 
-    create(
-      constraint(
-        "room_objects",
-        "room_object_is_legacy_or_has_account",
-        check:
-          "inserted_at < '#{DateTime.utc_now() |> DateTime.to_iso8601()}' or account_id is not null"
-      )
-    )
+    create constraint(
+             "room_objects",
+             "room_object_is_legacy_or_has_account",
+             check:
+               "inserted_at < '#{DateTime.utc_now() |> DateTime.to_iso8601()}' or account_id is not null"
+           )
   end
 end

--- a/priv/repo/migrations/20181113033726_add_account_to_room_objects.exs
+++ b/priv/repo/migrations/20181113033726_add_account_to_room_objects.exs
@@ -10,7 +10,8 @@ defmodule Ret.Repo.Migrations.AddAccountToRoomObjects do
       constraint(
         "room_objects",
         "room_object_is_legacy_or_has_account",
-        check: "inserted_at < '#{DateTime.utc_now() |> DateTime.to_iso8601()}' or account_id is not null"
+        check:
+          "inserted_at < '#{DateTime.utc_now() |> DateTime.to_iso8601()}' or account_id is not null"
       )
     )
   end

--- a/priv/repo/migrations/20181127021310_add_inactive_to_owned_file_state_enum.exs
+++ b/priv/repo/migrations/20181127021310_add_inactive_to_owned_file_state_enum.exs
@@ -3,6 +3,6 @@ defmodule Ret.Repo.Migrations.AddInactiveToOwnedFileStateEnum do
   @disable_ddl_transaction true
 
   def change do
-    Ecto.Migration.execute("ALTER TYPE ret0.owned_file_state ADD VALUE IF NOT EXISTS 'inactive'")
+    execute "ALTER TYPE ret0.owned_file_state ADD VALUE IF NOT EXISTS 'inactive'"
   end
 end

--- a/priv/repo/migrations/20181128022000_add_min_token_issued_at_to_account.exs
+++ b/priv/repo/migrations/20181128022000_add_min_token_issued_at_to_account.exs
@@ -5,7 +5,7 @@ defmodule Ret.Repo.Migrations.AddMinTokenIssuedAtToAccount do
     epoch = DateTime.from_unix!(0, :second) |> DateTime.truncate(:second) |> DateTime.to_iso8601()
 
     alter table("accounts") do
-      add(:min_token_issued_at, :utc_datetime, default: epoch, null: false)
+      add :min_token_issued_at, :utc_datetime, default: epoch, null: false
     end
   end
 end

--- a/priv/repo/migrations/20181227040710_add_host_to_hub.exs
+++ b/priv/repo/migrations/20181227040710_add_host_to_hub.exs
@@ -3,9 +3,9 @@ defmodule Ret.Repo.Migrations.AddHostToHub do
 
   def change do
     alter table("hubs") do
-      add(:host, :string)
+      add :host, :string
     end
 
-    create(index(:hubs, [:host, :inserted_at], where: "host is not null"))
+    create index(:hubs, [:host, :inserted_at], where: "host is not null")
   end
 end

--- a/priv/repo/migrations/20190114122412_add_created_by_to_hubs.exs
+++ b/priv/repo/migrations/20190114122412_add_created_by_to_hubs.exs
@@ -3,9 +3,9 @@ defmodule Ret.Repo.Migrations.AddCreatedByToHubs do
 
   def change do
     alter table("hubs") do
-      add(:created_by_account_id, references(:accounts, column: :account_id))
+      add :created_by_account_id, references(:accounts, column: :account_id)
     end
 
-    create(index(:hubs, [:created_by_account_id]))
+    create index(:hubs, [:created_by_account_id])
   end
 end

--- a/priv/repo/migrations/20190114232257_add_reviewed_at_to_scenes.exs
+++ b/priv/repo/migrations/20190114232257_add_reviewed_at_to_scenes.exs
@@ -6,6 +6,8 @@ defmodule Ret.Repo.Migrations.AddReviewedAtToScenes do
       add(:reviewed_at, :utc_datetime, null: true)
     end
 
-    create(index(:scenes, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at"))
+    create(
+      index(:scenes, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at")
+    )
   end
 end

--- a/priv/repo/migrations/20190114232257_add_reviewed_at_to_scenes.exs
+++ b/priv/repo/migrations/20190114232257_add_reviewed_at_to_scenes.exs
@@ -3,11 +3,9 @@ defmodule Ret.Repo.Migrations.AddReviewedAtToScenes do
 
   def change do
     alter table("scenes") do
-      add(:reviewed_at, :utc_datetime, null: true)
+      add :reviewed_at, :utc_datetime, null: true
     end
 
-    create(
-      index(:scenes, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at")
-    )
+    create index(:scenes, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at")
   end
 end

--- a/priv/repo/migrations/20190115003917_add_scene_listings.exs
+++ b/priv/repo/migrations/20190115003917_add_scene_listings.exs
@@ -5,23 +5,23 @@ defmodule Ret.Repo.Migrations.AddSceneListings do
     Ret.SceneListing.State.create_type()
 
     create table(:scene_listings, primary_key: false) do
-      add(:scene_listing_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:scene_listing_sid, :string)
-      add(:scene_id, :bigint, null: false)
-      add(:slug, :string, null: false)
-      add(:name, :string, null: false)
-      add(:description, :string)
-      add(:attributions, :jsonb)
-      add(:tags, :jsonb)
-      add(:model_owned_file_id, :bigint, null: false)
-      add(:scene_owned_file_id, :bigint, null: false)
-      add(:screenshot_owned_file_id, :bigint, null: false)
-      add(:order, :integer)
-      add(:state, :scene_listing_state, null: false, default: "active")
+      add :scene_listing_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :scene_listing_sid, :string
+      add :scene_id, :bigint, null: false
+      add :slug, :string, null: false
+      add :name, :string, null: false
+      add :description, :string
+      add :attributions, :jsonb
+      add :tags, :jsonb
+      add :model_owned_file_id, :bigint, null: false
+      add :scene_owned_file_id, :bigint, null: false
+      add :screenshot_owned_file_id, :bigint, null: false
+      add :order, :integer
+      add :state, :scene_listing_state, null: false, default: "active"
 
       timestamps()
     end
 
-    create(index(:scene_listings, [:scene_listing_sid], unique: true))
+    create unique_index(:scene_listings, [:scene_listing_sid])
   end
 end

--- a/priv/repo/migrations/20190125190651_alter_object_type_column_to_bigint.exs
+++ b/priv/repo/migrations/20190125190651_alter_object_type_column_to_bigint.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AlterObjectTypeColumnToBigint do
 
   def change do
     alter table("hubs") do
-      modify(:spawned_object_types, :bigint)
+      modify :spawned_object_types, :bigint
     end
   end
 end

--- a/priv/repo/migrations/20190130052213_add_is_admin_column.exs
+++ b/priv/repo/migrations/20190130052213_add_is_admin_column.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddIsAdminColumn do
 
   def change do
     alter table("accounts") do
-      add(:is_admin, :boolean)
+      add :is_admin, :boolean
     end
   end
 end

--- a/priv/repo/migrations/20190131231854_create_avatars.exs
+++ b/priv/repo/migrations/20190131231854_create_avatars.exs
@@ -32,7 +32,8 @@ defmodule Ret.Repo.Migrations.CreateAvatars do
 
     create(
       constraint(:avatars, :gltf_or_parent,
-        check: "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
+        check:
+          "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
       )
     )
 

--- a/priv/repo/migrations/20190131231854_create_avatars.exs
+++ b/priv/repo/migrations/20190131231854_create_avatars.exs
@@ -3,41 +3,33 @@ defmodule Ret.Repo.Migrations.CreateAvatars do
 
   def change do
     create table(:avatars, primary_key: false) do
-      add(:avatar_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:avatar_sid, :string)
-      add(:slug, :string, null: false)
-      add(:parent_avatar_id, references(:avatars, column: :avatar_id))
-
-      add(:name, :string)
-      add(:description, :string)
-      add(:attributions, :jsonb)
-
-      add(:allow_remixing, :boolean, null: false, default: false)
-      add(:allow_promotion, :boolean, null: false, default: false)
-
-      add(:account_id, references(:accounts, column: :account_id), null: false)
-
-      add(:gltf_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:bin_owned_file_id, references(:owned_files, column: :owned_file_id))
-
-      add(:base_map_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:emissive_map_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:normal_map_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:orm_map_owned_file_id, references(:owned_files, column: :owned_file_id))
-
-      add(:state, :scene_state, null: false, default: "active")
+      add :avatar_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :avatar_sid, :string
+      add :slug, :string, null: false
+      add :parent_avatar_id, references(:avatars, column: :avatar_id)
+      add :name, :string
+      add :description, :string
+      add :attributions, :jsonb
+      add :allow_remixing, :boolean, null: false, default: false
+      add :allow_promotion, :boolean, null: false, default: false
+      add :account_id, references(:accounts, column: :account_id), null: false
+      add :gltf_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :bin_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :base_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :emissive_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :normal_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :orm_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :state, :scene_state, null: false, default: "active"
 
       timestamps()
     end
 
-    create(
-      constraint(:avatars, :gltf_or_parent,
-        check:
-          "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
-      )
-    )
+    create constraint(:avatars, :gltf_or_parent,
+             check:
+               "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
+           )
 
-    create(index(:avatars, [:avatar_sid], unique: true))
-    create(index(:avatars, [:account_id]))
+    create unique_index(:avatars, [:avatar_sid])
+    create index(:avatars, [:account_id])
   end
 end

--- a/priv/repo/migrations/20190208014624_add_scene_listing_id_to_hubs.exs
+++ b/priv/repo/migrations/20190208014624_add_scene_listing_id_to_hubs.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddSceneListingIdToHubs do
 
   def change do
     alter table("hubs") do
-      add(:scene_listing_id, references(:scene_listings, column: :scene_listing_id))
+      add :scene_listing_id, references(:scene_listings, column: :scene_listing_id)
     end
   end
 end

--- a/priv/repo/migrations/20190305181357_add_hub_bindings_table.exs
+++ b/priv/repo/migrations/20190305181357_add_hub_bindings_table.exs
@@ -5,15 +5,15 @@ defmodule Ret.Repo.Migrations.AddHubBindingsTable do
     Ret.HubBinding.Type.create_type()
 
     create table(:hub_bindings, primary_key: false) do
-      add(:hub_binding_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:hub_id, :bigint, null: false)
-      add(:type, :hub_binding_type, null: false)
-      add(:community_id, :string, null: false)
-      add(:channel_id, :string, null: false)
+      add :hub_binding_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :hub_id, :bigint, null: false
+      add :type, :hub_binding_type, null: false
+      add :community_id, :string, null: false
+      add :channel_id, :string, null: false
 
       timestamps()
     end
 
-    create(index(:hub_bindings, [:type, :community_id, :channel_id], unique: true))
+    create unique_index(:hub_bindings, [:type, :community_id, :channel_id])
   end
 end

--- a/priv/repo/migrations/20190305190955_add_oauth_providers_table.exs
+++ b/priv/repo/migrations/20190305190955_add_oauth_providers_table.exs
@@ -5,15 +5,15 @@ defmodule Ret.Repo.Migrations.AddOauthProvidersTable do
     Ret.OAuthProvider.Source.create_type()
 
     create table(:oauth_providers, primary_key: false) do
-      add(:oauth_provider_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:account_id, :bigint, null: false)
-      add(:source, :oauth_provider_source, null: false)
-      add(:provider_account_id, :string, null: false)
+      add :oauth_provider_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :account_id, :bigint, null: false
+      add :source, :oauth_provider_source, null: false
+      add :provider_account_id, :string, null: false
 
       timestamps()
     end
 
-    create(index(:oauth_providers, [:source, :account_id], unique: true))
-    create(index(:oauth_providers, [:source, :provider_account_id], unique: true))
+    create unique_index(:oauth_providers, [:source, :account_id])
+    create unique_index(:oauth_providers, [:source, :provider_account_id])
   end
 end

--- a/priv/repo/migrations/20190306032224_create_projects.exs
+++ b/priv/repo/migrations/20190306032224_create_projects.exs
@@ -3,17 +3,17 @@ defmodule Ret.Repo.Migrations.CreateProjects do
 
   def change do
     create table(:projects, primary_key: false) do
-      add(:project_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:project_sid, :string)
-      add(:name, :string, null: false)
-      add(:created_by_account_id, references(:accounts, column: :account_id), null: false)
-      add(:project_owned_file_id, :bigint, null: true)
-      add(:thumbnail_owned_file_id, :bigint, null: true)
+      add :project_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :project_sid, :string
+      add :name, :string, null: false
+      add :created_by_account_id, references(:accounts, column: :account_id), null: false
+      add :project_owned_file_id, :bigint, null: true
+      add :thumbnail_owned_file_id, :bigint, null: true
 
       timestamps()
     end
 
-    create(index(:projects, [:project_sid], unique: true))
-    create(index(:projects, [:created_by_account_id]))
+    create unique_index(:projects, [:project_sid])
+    create index(:projects, [:created_by_account_id])
   end
 end

--- a/priv/repo/migrations/20190312171503_add_removed_state_to_scenes.exs
+++ b/priv/repo/migrations/20190312171503_add_removed_state_to_scenes.exs
@@ -3,6 +3,6 @@ defmodule Ret.Repo.Migrations.AddRemovedStateToScenes do
   @disable_ddl_transaction true
 
   def change do
-    Ecto.Migration.execute("ALTER TYPE ret0.scene_state ADD VALUE IF NOT EXISTS 'removed'")
+    execute "ALTER TYPE ret0.scene_state ADD VALUE IF NOT EXISTS 'removed'"
   end
 end

--- a/priv/repo/migrations/20190322222314_add_cached_files.exs
+++ b/priv/repo/migrations/20190322222314_add_cached_files.exs
@@ -3,15 +3,15 @@ defmodule Ret.Repo.Migrations.AddCachedFiles do
 
   def change do
     create table(:cached_files, primary_key: false) do
-      add(:cached_file_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:cache_key, :string, null: false)
-      add(:file_uuid, :string, null: false)
-      add(:file_key, :string, null: false)
-      add(:file_content_type, :string, null: false)
+      add :cached_file_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :cache_key, :string, null: false
+      add :file_uuid, :string, null: false
+      add :file_key, :string, null: false
+      add :file_content_type, :string, null: false
 
       timestamps()
     end
 
-    create(index(:cached_files, [:cache_key], unique: true))
+    create unique_index(:cached_files, [:cache_key])
   end
 end

--- a/priv/repo/migrations/20190329004026_create_assets_tables.exs
+++ b/priv/repo/migrations/20190329004026_create_assets_tables.exs
@@ -3,41 +3,37 @@ defmodule Ret.Repo.Migrations.CreateAssetsTables do
 
   def change do
     create table(:assets, primary_key: false) do
-      add(:asset_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:asset_sid, :string, null: false)
-      add(:name, :string, null: false)
-      add(:type, :asset_type, null: false)
-      add(:account_id, references(:accounts, column: :account_id), null: false)
-      add(:asset_owned_file_id, :bigint, null: false)
-      add(:thumbnail_owned_file_id, :bigint, null: false)
+      add :asset_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :asset_sid, :string, null: false
+      add :name, :string, null: false
+      add :type, :asset_type, null: false
+      add :account_id, references(:accounts, column: :account_id), null: false
+      add :asset_owned_file_id, :bigint, null: false
+      add :thumbnail_owned_file_id, :bigint, null: false
 
       timestamps()
     end
 
-    create(index(:assets, [:asset_sid], unique: true))
-    create(index(:assets, [:account_id]))
+    create unique_index(:assets, [:asset_sid])
+    create index(:assets, [:account_id])
 
     create table(:project_assets, primary_key: false) do
-      add(:project_asset_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+      add :project_asset_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
 
-      add(:project_id, references(:projects, column: :project_id, on_delete: :delete_all),
+      add :project_id, references(:projects, column: :project_id, on_delete: :delete_all),
         primary_key: true
-      )
 
-      add(:asset_id, references(:assets, column: :asset_id, on_delete: :delete_all),
+      add :asset_id, references(:assets, column: :asset_id, on_delete: :delete_all),
         primary_key: true
-      )
 
       timestamps()
     end
 
-    create(index(:project_assets, [:project_id]))
-    create(index(:project_assets, [:asset_id]))
+    create index(:project_assets, [:project_id])
+    create index(:project_assets, [:asset_id])
 
-    create(
-      unique_index(:project_assets, [:project_id, :asset_id],
-        name: :project_id_asset_id_unique_index
-      )
-    )
+    create unique_index(:project_assets, [:project_id, :asset_id],
+             name: :project_id_asset_id_unique_index
+           )
   end
 end

--- a/priv/repo/migrations/20190329004026_create_assets_tables.exs
+++ b/priv/repo/migrations/20190329004026_create_assets_tables.exs
@@ -19,14 +19,25 @@ defmodule Ret.Repo.Migrations.CreateAssetsTables do
 
     create table(:project_assets, primary_key: false) do
       add(:project_asset_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:project_id, references(:projects, column: :project_id, on_delete: :delete_all), primary_key: true)
-      add(:asset_id, references(:assets, column: :asset_id, on_delete: :delete_all), primary_key: true)
+
+      add(:project_id, references(:projects, column: :project_id, on_delete: :delete_all),
+        primary_key: true
+      )
+
+      add(:asset_id, references(:assets, column: :asset_id, on_delete: :delete_all),
+        primary_key: true
+      )
 
       timestamps()
     end
 
     create(index(:project_assets, [:project_id]))
     create(index(:project_assets, [:asset_id]))
-    create(unique_index(:project_assets, [:project_id, :asset_id], name: :project_id_asset_id_unique_index))
+
+    create(
+      unique_index(:project_assets, [:project_id, :asset_id],
+        name: :project_id_asset_id_unique_index
+      )
+    )
   end
 end

--- a/priv/repo/migrations/20190424010558_add_thumbnail_to_avatar.exs
+++ b/priv/repo/migrations/20190424010558_add_thumbnail_to_avatar.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddThumbnailToAvatar do
 
   def change do
     alter table(:avatars) do
-      add(:thumbnail_owned_file_id, references(:owned_files, column: :owned_file_id))
+      add :thumbnail_owned_file_id, references(:owned_files, column: :owned_file_id)
     end
   end
 end

--- a/priv/repo/migrations/20190501221754_create_avatar_listings.exs
+++ b/priv/repo/migrations/20190501221754_create_avatar_listings.exs
@@ -37,6 +37,8 @@ defmodule Ret.Repo.Migrations.CreateAvatarListings do
       add(:reviewed_at, :utc_datetime, null: true)
     end
 
-    create(index(:avatars, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at"))
+    create(
+      index(:avatars, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at")
+    )
   end
 end

--- a/priv/repo/migrations/20190501221754_create_avatar_listings.exs
+++ b/priv/repo/migrations/20190501221754_create_avatar_listings.exs
@@ -5,40 +5,37 @@ defmodule Ret.Repo.Migrations.CreateAvatarListings do
     Ret.AvatarListing.State.create_type()
 
     create table(:avatar_listings, primary_key: false) do
-      add(:avatar_listing_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:avatar_listing_sid, :string, null: false)
-      add(:slug, :string, null: false)
-      add(:order, :integer)
-      add(:state, :avatar_listing_state, null: false, default: "active")
-      add(:tags, :jsonb)
-      add(:avatar_id, :bigint, null: false)
+      add :avatar_listing_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :avatar_listing_sid, :string, null: false
+      add :slug, :string, null: false
+      add :order, :integer
+      add :state, :avatar_listing_state, null: false, default: "active"
+      add :tags, :jsonb
+      add :avatar_id, :bigint, null: false
+      add :name, :string, null: false
+      add :description, :string
+      add :attributions, :jsonb
+      add :parent_avatar_listing_id, references(:avatar_listings, column: :avatar_listing_id)
+      add :gltf_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :bin_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :thumbnail_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :base_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :emissive_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :normal_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+      add :orm_map_owned_file_id, references(:owned_files, column: :owned_file_id)
+
       timestamps()
-
-      add(:name, :string, null: false)
-      add(:description, :string)
-      add(:attributions, :jsonb)
-
-      add(:parent_avatar_listing_id, references(:avatar_listings, column: :avatar_listing_id))
-
-      add(:gltf_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:bin_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:thumbnail_owned_file_id, references(:owned_files, column: :owned_file_id))
-
-      add(:base_map_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:emissive_map_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:normal_map_owned_file_id, references(:owned_files, column: :owned_file_id))
-      add(:orm_map_owned_file_id, references(:owned_files, column: :owned_file_id))
     end
 
-    create(index(:avatar_listings, [:avatar_listing_sid], unique: true))
+    create unique_index(:avatar_listings, [:avatar_listing_sid])
 
     alter table(:avatars) do
-      add(:parent_avatar_listing_id, references(:avatar_listings, column: :avatar_listing_id))
-      add(:reviewed_at, :utc_datetime, null: true)
+      add :parent_avatar_listing_id, references(:avatar_listings, column: :avatar_listing_id)
+      add :reviewed_at, :utc_datetime, null: true
     end
 
-    create(
-      index(:avatars, [:reviewed_at], where: "reviewed_at is null or reviewed_at < updated_at")
-    )
+    create index(:avatars, [:reviewed_at],
+             where: "reviewed_at is null or reviewed_at < updated_at"
+           )
   end
 end

--- a/priv/repo/migrations/20190503170158_add_creator_assignment_token.exs
+++ b/priv/repo/migrations/20190503170158_add_creator_assignment_token.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddCreatorAssignmentToken do
 
   def change do
     alter table("hubs") do
-      add(:creator_assignment_token, :string)
+      add :creator_assignment_token, :string
     end
   end
 end

--- a/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
+++ b/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
@@ -2,24 +2,20 @@ defmodule Ret.Repo.Migrations.UpdateAvatarConstraints do
   use Ecto.Migration
 
   def up do
-    drop(constraint(:avatars, :gltf_or_parent))
+    drop constraint(:avatars, :gltf_or_parent)
 
-    create(
-      constraint(:avatars, :gltf_or_parent_or_parent_listing,
-        check:
-          "parent_avatar_id is not null or parent_avatar_listing_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
-      )
-    )
+    create constraint(:avatars, :gltf_or_parent_or_parent_listing,
+             check:
+               "parent_avatar_id is not null or parent_avatar_listing_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
+           )
   end
 
   def down do
-    drop(constraint(:avatars, :gltf_or_parent_or_parent_listing))
+    drop constraint(:avatars, :gltf_or_parent_or_parent_listing)
 
-    create(
-      constraint(:avatars, :gltf_or_parent,
-        check:
-          "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
-      )
-    )
+    create constraint(:avatars, :gltf_or_parent,
+             check:
+               "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
+           )
   end
 end

--- a/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
+++ b/priv/repo/migrations/20190508021811_update_avatar_constraints.exs
@@ -17,7 +17,8 @@ defmodule Ret.Repo.Migrations.UpdateAvatarConstraints do
 
     create(
       constraint(:avatars, :gltf_or_parent,
-        check: "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
+        check:
+          "parent_avatar_id is not null or (gltf_owned_file_id is not null and bin_owned_file_id is not null)"
       )
     )
   end

--- a/priv/repo/migrations/20190514175300_add_last_active_at.exs
+++ b/priv/repo/migrations/20190514175300_add_last_active_at.exs
@@ -3,9 +3,9 @@ defmodule Ret.Repo.Migrations.AddLastActiveAt do
 
   def change do
     alter table("hubs") do
-      add(:last_active_at, :utc_datetime, null: true)
+      add :last_active_at, :utc_datetime, null: true
     end
 
-    create(index(:hubs, [:last_active_at]))
+    create index(:hubs, [:last_active_at])
   end
 end

--- a/priv/repo/migrations/20190605002622_add_embed_token_to_hubs.exs
+++ b/priv/repo/migrations/20190605002622_add_embed_token_to_hubs.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddEmbedTokenToHubs do
 
   def change do
     alter table("hubs") do
-      add(:embed_token, :string)
+      add :embed_token, :string
     end
   end
 end

--- a/priv/repo/migrations/20190605213019_add_embedded_flag_to_hubs.exs
+++ b/priv/repo/migrations/20190605213019_add_embedded_flag_to_hubs.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddEmbeddedFlagToHubs do
 
   def change do
     alter table("hubs") do
-      add(:embedded, :boolean, default: false)
+      add :embedded, :boolean, default: false
     end
   end
 end

--- a/priv/repo/migrations/20190606012330_add_account_hub_favorites.exs
+++ b/priv/repo/migrations/20190606012330_add_account_hub_favorites.exs
@@ -3,16 +3,16 @@ defmodule Ret.Repo.Migrations.AddAccountHubFavorites do
 
   def change do
     create table(:account_favorites, primary_key: false) do
-      add(:account_favorite_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:account_id, references(:accounts, column: :account_id), null: false)
-      add(:hub_id, references(:hubs, column: :hub_id))
-      add(:last_activated_at, :utc_datetime)
+      add :account_favorite_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :account_id, references(:accounts, column: :account_id), null: false
+      add :hub_id, references(:hubs, column: :hub_id)
+      add :last_activated_at, :utc_datetime
 
       timestamps()
     end
 
     # Do not create inverted index on hubs, because that will lead to bad access
     # patterns if/when we need to shard this table.
-    create(index(:account_favorites, [:account_id, :hub_id], unique: true))
+    create unique_index(:account_favorites, [:account_id, :hub_id])
   end
 end

--- a/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
+++ b/priv/repo/migrations/20190613223618_add_permissions_to_hubs.exs
@@ -4,16 +4,14 @@ defmodule Ret.Repo.Migrations.AddPermissionsToHubs do
 
   def change do
     alter table("hubs") do
-      add(:member_permissions, :integer,
+      add :member_permissions, :integer,
         default:
-          %{
+          Ret.Hub.member_permissions_to_int(%{
             spawn_and_move_media: true,
             spawn_camera: true,
             spawn_drawing: true,
             pin_objects: true
-          }
-          |> Ret.Hub.member_permissions_to_int()
-      )
+          })
     end
   end
 end

--- a/priv/repo/migrations/20190614211950_add_twitter_to_oauth_type.exs
+++ b/priv/repo/migrations/20190614211950_add_twitter_to_oauth_type.exs
@@ -3,8 +3,6 @@ defmodule Ret.Repo.Migrations.AddTwitterToOauthType do
   @disable_ddl_transaction true
 
   def change do
-    Ecto.Migration.execute(
-      "ALTER TYPE ret0.oauth_provider_source ADD VALUE IF NOT EXISTS 'twitter'"
-    )
+    execute "ALTER TYPE ret0.oauth_provider_source ADD VALUE IF NOT EXISTS 'twitter'"
   end
 end

--- a/priv/repo/migrations/20190614211950_add_twitter_to_oauth_type.exs
+++ b/priv/repo/migrations/20190614211950_add_twitter_to_oauth_type.exs
@@ -3,6 +3,8 @@ defmodule Ret.Repo.Migrations.AddTwitterToOauthType do
   @disable_ddl_transaction true
 
   def change do
-    Ecto.Migration.execute("ALTER TYPE ret0.oauth_provider_source ADD VALUE IF NOT EXISTS 'twitter'")
+    Ecto.Migration.execute(
+      "ALTER TYPE ret0.oauth_provider_source ADD VALUE IF NOT EXISTS 'twitter'"
+    )
   end
 end

--- a/priv/repo/migrations/20190615010958_add_provider_access_tokens.exs
+++ b/priv/repo/migrations/20190615010958_add_provider_access_tokens.exs
@@ -3,8 +3,8 @@ defmodule Ret.Repo.Migrations.AddProviderAccessTokens do
 
   def change do
     alter table("oauth_providers") do
-      add(:provider_access_token, :binary)
-      add(:provider_access_token_secret, :binary)
+      add :provider_access_token, :binary
+      add :provider_access_token_secret, :binary
     end
   end
 end

--- a/priv/repo/migrations/20190703224946_add_login_token_payload_keys.exs
+++ b/priv/repo/migrations/20190703224946_add_login_token_payload_keys.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddLoginTokenPayloadKeys do
 
   def change do
     alter table("login_tokens") do
-      add(:payload_key, :string)
+      add :payload_key, :string
     end
   end
 end

--- a/priv/repo/migrations/20190717173132_create_hub_role_memberships.exs
+++ b/priv/repo/migrations/20190717173132_create_hub_role_memberships.exs
@@ -4,6 +4,7 @@ defmodule Ret.Repo.Migrations.CreateHubRoleMemberships do
   def change do
     create table(:hub_role_memberships, primary_key: false) do
       add(:hub_role_membership_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
+
       add(:hub_id, references(:hubs, column: :hub_id))
       add(:account_id, references(:accounts, column: :account_id), null: false)
 

--- a/priv/repo/migrations/20190717173132_create_hub_role_memberships.exs
+++ b/priv/repo/migrations/20190717173132_create_hub_role_memberships.exs
@@ -3,16 +3,15 @@ defmodule Ret.Repo.Migrations.CreateHubRoleMemberships do
 
   def change do
     create table(:hub_role_memberships, primary_key: false) do
-      add(:hub_role_membership_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-
-      add(:hub_id, references(:hubs, column: :hub_id))
-      add(:account_id, references(:accounts, column: :account_id), null: false)
+      add :hub_role_membership_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :hub_id, references(:hubs, column: :hub_id)
+      add :account_id, references(:accounts, column: :account_id), null: false
 
       # Right now role membership is implicit to be the single role of "owners", no db state for now in accordance with YAGNI
 
       timestamps()
     end
 
-    create(index(:hub_role_memberships, [:hub_id, :account_id], unique: true))
+    create unique_index(:hub_role_memberships, [:hub_id, :account_id])
   end
 end

--- a/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
+++ b/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
@@ -19,12 +19,13 @@ defmodule Ret.Repo.Migrations.AddAvatarListingsAccount do
 
     flush()
 
-    from(l in "avatar_listings",
-      join: a in Avatar,
-      on: a.avatar_id == l.avatar_id,
-      update: [set: [account_id: a.account_id]]
-    )
-    |> repo().update_all([])
+    query =
+      from l in "avatar_listings",
+        join: a in Avatar,
+        on: a.avatar_id == l.avatar_id,
+        update: [set: [account_id: a.account_id]]
+
+    repo().update_all(query, [])
   end
 
   def down do

--- a/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
+++ b/priv/repo/migrations/20190812211919_add_avatar_listings_account.exs
@@ -6,16 +6,14 @@ defmodule Ret.Repo.Migrations.AddAvatarListingsAccount do
 
   def up do
     alter table(:avatar_listings) do
-      add(:account_id, references(:accounts, column: :account_id, null: false))
+      add :account_id, references(:accounts, column: :account_id, null: false)
     end
 
-    execute("ALTER TABLE ret0.avatar_listings ALTER COLUMN avatar_id DROP NOT NULL")
+    execute "ALTER TABLE ret0.avatar_listings ALTER COLUMN avatar_id DROP NOT NULL"
 
-    create(
-      constraint(:avatar_listings, :avatar_required_for_listed,
-        check: "avatar_id is not null or (avatar_id is null and state = 'delisted')"
-      )
-    )
+    create constraint(:avatar_listings, :avatar_required_for_listed,
+             check: "avatar_id is not null or (avatar_id is null and state = 'delisted')"
+           )
 
     flush()
 
@@ -30,10 +28,11 @@ defmodule Ret.Repo.Migrations.AddAvatarListingsAccount do
 
   def down do
     alter table(:avatar_listings) do
-      remove(:account_id)
+      remove :account_id
     end
 
-    drop(constraint(:avatar_listings, :avatar_required_for_listed))
-    execute("ALTER TABLE ret0.avatar_listings ALTER COLUMN avatar_id SET NOT NULL")
+    drop constraint(:avatar_listings, :avatar_required_for_listed)
+
+    execute "ALTER TABLE ret0.avatar_listings ALTER COLUMN avatar_id SET NOT NULL"
   end
 end

--- a/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
+++ b/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
@@ -6,9 +6,7 @@ defmodule Ret.Repo.Migrations.AddAvatarListingsRemovedState do
   @disable_ddl_transaction true
 
   def up do
-    Ecto.Migration.execute(
-      "ALTER TYPE ret0.avatar_listing_state ADD VALUE IF NOT EXISTS 'removed'"
-    )
+    execute "ALTER TYPE ret0.avatar_listing_state ADD VALUE IF NOT EXISTS 'removed'"
 
     flush()
 

--- a/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
+++ b/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
@@ -6,7 +6,9 @@ defmodule Ret.Repo.Migrations.AddAvatarListingsRemovedState do
   @disable_ddl_transaction true
 
   def up do
-    Ecto.Migration.execute("ALTER TYPE ret0.avatar_listing_state ADD VALUE IF NOT EXISTS 'removed'")
+    Ecto.Migration.execute(
+      "ALTER TYPE ret0.avatar_listing_state ADD VALUE IF NOT EXISTS 'removed'"
+    )
 
     flush()
 

--- a/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
+++ b/priv/repo/migrations/20190819204535_add_avatar_listings_removed_state.exs
@@ -12,10 +12,12 @@ defmodule Ret.Repo.Migrations.AddAvatarListingsRemovedState do
 
     flush()
 
-    repo().update_all(
-      from(l in AvatarListing, where: l.state == ^:delisted and not is_nil(l.avatar_id)),
-      set: [state: :removed]
-    )
+    query =
+      from l in AvatarListing,
+        where: l.state == ^:delisted,
+        where: not is_nil(l.avatar_id)
+
+    repo().update_all(query, set: [state: :removed])
   end
 
   def down do

--- a/priv/repo/migrations/20190904000046_admin_schema_init.exs
+++ b/priv/repo/migrations/20190904000046_admin_schema_init.exs
@@ -5,9 +5,9 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
   def up do
     auth_password = Application.get_env(:ret, __MODULE__)[:postgrest_password]
 
-    execute("create schema if not exists ret0_admin;")
+    execute "create schema if not exists ret0_admin"
 
-    execute("""
+    execute """
     DO
     $do$
     BEGIN
@@ -20,9 +20,9 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
        END IF;
     END
     $do$;
-    """)
+    """
 
-    execute("""
+    execute """
     DO
     $do$
     BEGIN
@@ -35,9 +35,9 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
        END IF;
     END
     $do$;
-    """)
+    """
 
-    execute("""
+    execute """
     DO
     $do$
     BEGIN
@@ -50,27 +50,27 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
        END IF;
     END
     $do$;
-    """)
+    """
 
-    execute("grant postgrest_anonymous to postgrest_authenticator;")
-    execute("grant ret_admin to postgrest_authenticator;")
+    execute "grant postgrest_anonymous to postgrest_authenticator"
+    execute "grant ret_admin to postgrest_authenticator"
 
-    execute("""
+    execute """
     do 
     $$ 
     begin
       execute format('grant connect on database %I to postgrest_authenticator', current_database());
     end;
     $$;
-    """)
+    """
 
-    execute("grant usage on schema ret0_admin to ret_admin;")
-    execute("grant usage on schema ret0 to ret_admin;")
-    execute("grant usage on ret0.table_id_seq to ret_admin;")
+    execute "grant usage on schema ret0_admin to ret_admin"
+    execute "grant usage on schema ret0 to ret_admin"
+    execute "grant usage on ret0.table_id_seq to ret_admin"
 
-    execute("grant all privileges on all tables in schema ret0_admin to ret_admin;")
+    execute "grant all privileges on all tables in schema ret0_admin to ret_admin"
 
-    execute("""
+    execute """
       create or replace function ret0_admin.create_or_replace_admin_view(
       name text,
       extra_columns text default '',
@@ -108,30 +108,30 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
     end
 
     $$ language plpgsql;
-    """)
+    """
 
-    execute("select ret0_admin.create_or_replace_admin_view('scenes');")
-    execute("grant select, insert, update on ret0_admin.scenes to ret_admin;")
+    execute "select ret0_admin.create_or_replace_admin_view('scenes')"
+    execute "grant select, insert, update on ret0_admin.scenes to ret_admin"
 
-    execute("select ret0_admin.create_or_replace_admin_view('accounts');")
-    execute("grant select, insert, update on ret0_admin.accounts to ret_admin;")
+    execute "select ret0_admin.create_or_replace_admin_view('accounts')"
+    execute "grant select, insert, update on ret0_admin.accounts to ret_admin"
 
-    execute("select ret0_admin.create_or_replace_admin_view('owned_files');")
-    execute("grant select, insert, update on ret0_admin.owned_files to ret_admin;")
+    execute "select ret0_admin.create_or_replace_admin_view('owned_files')"
+    execute "grant select, insert, update on ret0_admin.owned_files to ret_admin"
 
-    execute("select ret0_admin.create_or_replace_admin_view('scene_listings');")
-    execute("grant select, insert, update on ret0_admin.scene_listings to ret_admin;")
+    execute "select ret0_admin.create_or_replace_admin_view('scene_listings')"
+    execute "grant select, insert, update on ret0_admin.scene_listings to ret_admin"
 
-    execute("select ret0_admin.create_or_replace_admin_view('avatars');")
-    execute("grant select, insert, update on ret0_admin.avatars to ret_admin;")
+    execute "select ret0_admin.create_or_replace_admin_view('avatars')"
+    execute "grant select, insert, update on ret0_admin.avatars to ret_admin"
 
-    execute("select ret0_admin.create_or_replace_admin_view('avatar_listings');")
-    execute("grant select, insert, update on ret0_admin.avatar_listings to ret_admin;")
+    execute "select ret0_admin.create_or_replace_admin_view('avatar_listings')"
+    execute "grant select, insert, update on ret0_admin.avatar_listings to ret_admin"
 
-    execute("select ret0_admin.create_or_replace_admin_view('projects');")
-    execute("grant select, insert, update on ret0_admin.projects to ret_admin;")
+    execute "select ret0_admin.create_or_replace_admin_view('projects')"
+    execute "grant select, insert, update on ret0_admin.projects to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.pending_scenes as (
     		select scenes.id, scene_sid, scenes.slug, scenes.name, scenes.description, scenes.screenshot_owned_file_id, scenes.model_owned_file_id, scenes.scene_owned_file_id, 
     		scenes.attributions, scene_listings.id as scene_listing_id, scenes.updated_at, scenes.allow_remixing as _allow_remixing, scenes.allow_promotion as _allow_promotion
@@ -139,11 +139,11 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
     		left outer join ret0_admin.scene_listings on scene_listings.scene_id = scenes.id
     		where ((scenes.reviewed_at is null or scenes.reviewed_at < scenes.updated_at) and scenes.allow_promotion and scenes.state = 'active')
     );
-    """)
+    """
 
-    execute("grant select on ret0_admin.pending_scenes to ret_admin;")
+    execute "grant select on ret0_admin.pending_scenes to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.featured_scene_listings as (
     select id, scene_listing_sid, slug, name, description, screenshot_owned_file_id, model_owned_file_id, scene_owned_file_id, attributions, scene_listings.order, tags
     from ret0_admin.scene_listings
@@ -152,11 +152,11 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
     tags->'tags' ? 'featured' and
     exists (select id from ret0_admin.scenes s where s.id = scene_listings.scene_id and s.state = 'active' and s.allow_promotion)
     );
-    """)
+    """
 
-    execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+    execute "grant select, update on ret0_admin.featured_scene_listings to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.pending_avatars as (
          select avatars.id, avatar_sid, avatars.slug, avatars.name, avatars.description, avatars.thumbnail_owned_file_id,
          avatars.base_map_owned_file_id, avatars.emissive_map_owned_file_id, avatars.normal_map_owned_file_id, avatars.orm_map_owned_file_id,
@@ -167,11 +167,11 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
          left outer join ret0_admin.avatar_listings on avatar_listings.avatar_id = avatars.id
          where ((avatars.reviewed_at is null or avatars.reviewed_at < avatars.updated_at) and avatars.allow_promotion and avatars.state = 'active')
     );
-    """)
+    """
 
-    execute("grant select on ret0_admin.pending_avatars to ret_admin;")
+    execute "grant select on ret0_admin.pending_avatars to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.featured_avatar_listings as (
        select id, avatar_listing_sid, slug, name, description, thumbnail_owned_file_id,
        base_map_owned_file_id, emissive_map_owned_file_id, normal_map_owned_file_id, orm_map_owned_file_id,
@@ -184,28 +184,28 @@ defmodule Ret.Repo.Migrations.AdminSchemaInit do
        tags->'tags' ? 'featured' and
        exists (select id from ret0_admin.avatars s where s.id = avatar_listings.avatar_id and s.state = 'active' and s.allow_promotion)
     );
-    """)
+    """
 
-    execute("grant select, update on ret0_admin.featured_avatar_listings to ret_admin;")
+    execute "grant select, update on ret0_admin.featured_avatar_listings to ret_admin"
   end
 
   def down do
-    execute("drop schema ret0_admin cascade;")
-    execute("revoke usage on ret0.table_id_seq from ret_admin;")
-    execute("revoke usage on schema ret0 from ret_admin;")
-    execute("drop role ret_admin;")
-    execute("revoke postgrest_anonymous from postgrest_authenticator;")
-    execute("drop role postgrest_anonymous;")
+    execute "drop schema ret0_admin cascade"
+    execute "revoke usage on ret0.table_id_seq from ret_admin"
+    execute "revoke usage on schema ret0 from ret_admin"
+    execute "drop role ret_admin"
+    execute "revoke postgrest_anonymous from postgrest_authenticator"
+    execute "drop role postgrest_anonymous"
 
-    execute("""
+    execute """
     do 
     $$ 
     begin
       execute format('revoke connect on database %I from postgrest_authenticator', current_database());
     end;
     $$;
-    """)
+    """
 
-    execute("drop role postgrest_authenticator;")
+    execute "drop role postgrest_authenticator"
   end
 end

--- a/priv/repo/migrations/20191011184435_create_app_configs_table.exs
+++ b/priv/repo/migrations/20191011184435_create_app_configs_table.exs
@@ -3,14 +3,14 @@ defmodule Ret.Repo.Migrations.CreateAppConfigsTable do
 
   def change do
     create table(:app_configs, primary_key: false) do
-      add(:app_config_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:key, :string, null: false)
-      add(:value, :jsonb)
-      add(:owned_file_id, :bigint)
+      add :app_config_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :key, :string, null: false
+      add :value, :jsonb
+      add :owned_file_id, :bigint
 
       timestamps()
     end
 
-    create(index(:app_configs, [:key], unique: true))
+    create unique_index(:app_configs, [:key])
   end
 end

--- a/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
+++ b/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
@@ -8,7 +8,9 @@ defmodule Ret.Repo.Migrations.AddImportedFromColumns do
       add(:imported_from_sid, :string)
     end
 
-    create(index(:avatars, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true))
+    create(
+      index(:avatars, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true)
+    )
 
     alter table("scenes") do
       add(:imported_from_host, :string)
@@ -16,6 +18,8 @@ defmodule Ret.Repo.Migrations.AddImportedFromColumns do
       add(:imported_from_sid, :string)
     end
 
-    create(index(:scenes, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true))
+    create(
+      index(:scenes, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true)
+    )
   end
 end

--- a/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
+++ b/priv/repo/migrations/20191013002432_add_imported_from_columns.exs
@@ -3,23 +3,19 @@ defmodule Ret.Repo.Migrations.AddImportedFromColumns do
 
   def change do
     alter table("avatars") do
-      add(:imported_from_host, :string)
-      add(:imported_from_port, :integer)
-      add(:imported_from_sid, :string)
+      add :imported_from_host, :string
+      add :imported_from_port, :integer
+      add :imported_from_sid, :string
     end
 
-    create(
-      index(:avatars, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true)
-    )
+    create unique_index(:avatars, [:imported_from_host, :imported_from_port, :imported_from_sid])
 
     alter table("scenes") do
-      add(:imported_from_host, :string)
-      add(:imported_from_port, :integer)
-      add(:imported_from_sid, :string)
+      add :imported_from_host, :string
+      add :imported_from_port, :integer
+      add :imported_from_sid, :string
     end
 
-    create(
-      index(:scenes, [:imported_from_host, :imported_from_port, :imported_from_sid], unique: true)
-    )
+    create unique_index(:scenes, [:imported_from_host, :imported_from_port, :imported_from_sid])
   end
 end

--- a/priv/repo/migrations/20191015184128_add_fk_lookup_on_listings.exs
+++ b/priv/repo/migrations/20191015184128_add_fk_lookup_on_listings.exs
@@ -2,7 +2,7 @@ defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
   use Ecto.Migration
 
   def up do
-    execute("""
+    execute """
       create or replace function ret0_admin.create_or_replace_admin_view(
       name text,
       extra_columns text default '',
@@ -40,18 +40,16 @@ defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
     end
 
     $$ language plpgsql;
-    """)
+    """
 
-    execute("drop view ret0_admin.avatar_listings cascade")
-    execute("drop view ret0_admin.scene_listings cascade")
+    execute "drop view ret0_admin.avatar_listings cascade"
+    execute "drop view ret0_admin.scene_listings cascade"
 
-    execute(
-      "select ret0_admin.create_or_replace_admin_view('avatar_listings', ',cast(avatar_id as varchar) as _avatar_id')"
-    )
+    execute "select ret0_admin.create_or_replace_admin_view('avatar_listings', ',cast(avatar_id as varchar) as _avatar_id')"
 
-    execute("grant select, insert, update on ret0_admin.avatar_listings to ret_admin;")
+    execute "grant select, insert, update on ret0_admin.avatar_listings to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.pending_avatars as (
          select avatars.id, avatar_sid, avatars.slug, avatars.name, avatars.description, avatars.thumbnail_owned_file_id,
          avatars.base_map_owned_file_id, avatars.emissive_map_owned_file_id, avatars.normal_map_owned_file_id, avatars.orm_map_owned_file_id,
@@ -62,11 +60,11 @@ defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
          left outer join ret0_admin.avatar_listings on avatar_listings.avatar_id = avatars.id
          where ((avatars.reviewed_at is null or avatars.reviewed_at < avatars.updated_at) and avatars.allow_promotion and avatars.state = 'active')
     );
-    """)
+    """
 
-    execute("grant select on ret0_admin.pending_avatars to ret_admin;")
+    execute "grant select on ret0_admin.pending_avatars to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.featured_avatar_listings as (
        select id, avatar_listing_sid, slug, name, description, thumbnail_owned_file_id,
        base_map_owned_file_id, emissive_map_owned_file_id, normal_map_owned_file_id, orm_map_owned_file_id,
@@ -79,17 +77,15 @@ defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
        tags->'tags' ? 'featured' and
        exists (select id from ret0_admin.avatars s where s.id = avatar_listings.avatar_id and s.state = 'active' and s.allow_promotion)
     );
-    """)
+    """
 
-    execute("grant select, update on ret0_admin.featured_avatar_listings to ret_admin;")
+    execute "grant select, update on ret0_admin.featured_avatar_listings to ret_admin"
 
-    execute(
-      "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
-    )
+    execute "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
 
-    execute("grant select, insert, update on ret0_admin.scene_listings to ret_admin;")
+    execute "grant select, insert, update on ret0_admin.scene_listings to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.pending_scenes as (
     		select scenes.id, scene_sid, scenes.slug, scenes.name, scenes.description, scenes.screenshot_owned_file_id, scenes.model_owned_file_id, scenes.scene_owned_file_id, 
     		scenes.attributions, scene_listings.id as scene_listing_id, scenes.updated_at, scenes.allow_remixing as _allow_remixing, scenes.allow_promotion as _allow_promotion
@@ -97,11 +93,11 @@ defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
     		left outer join ret0_admin.scene_listings on scene_listings.scene_id = scenes.id
     		where ((scenes.reviewed_at is null or scenes.reviewed_at < scenes.updated_at) and scenes.allow_promotion and scenes.state = 'active')
     );
-    """)
+    """
 
-    execute("grant select on ret0_admin.pending_scenes to ret_admin;")
+    execute "grant select on ret0_admin.pending_scenes to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.featured_scene_listings as (
     select id, scene_listing_sid, slug, name, description, screenshot_owned_file_id, model_owned_file_id, scene_owned_file_id, attributions, scene_listings.order, tags
     from ret0_admin.scene_listings
@@ -110,9 +106,9 @@ defmodule Ret.Repo.Migrations.AddFkLookupOnListings do
     tags->'tags' ? 'featured' and
     exists (select id from ret0_admin.scenes s where s.id = scene_listings.scene_id and s.state = 'active' and s.allow_promotion)
     );
-    """)
+    """
 
-    execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+    execute "grant select, update on ret0_admin.featured_scene_listings to ret_admin"
   end
 
   def down do

--- a/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
+++ b/priv/repo/migrations/20191015190511_allow_null_scene_owned_file.exs
@@ -3,22 +3,20 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
 
   def up do
     # Drops scene listings view and featured, pending scenes view
-    execute("drop view ret0_admin.scene_listings cascade")
+    execute "drop view ret0_admin.scene_listings cascade"
 
     # Hosted spoke won't necessarily fill this file in
 
     alter table("scene_listings") do
-      modify(:scene_owned_file_id, :bigint, null: true)
+      modify :scene_owned_file_id, :bigint, null: true
     end
 
     # Re-create views
-    execute(
-      "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
-    )
+    execute "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
 
-    execute("grant select, insert, update on ret0_admin.scene_listings to ret_admin;")
+    execute "grant select, insert, update on ret0_admin.scene_listings to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.featured_scene_listings as (
     select id, scene_listing_sid, slug, name, description, screenshot_owned_file_id, model_owned_file_id, scene_owned_file_id, attributions, scene_listings.order, tags
     from ret0_admin.scene_listings
@@ -27,11 +25,11 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
     tags->'tags' ? 'featured' and
     exists (select id from ret0_admin.scenes s where s.id = scene_listings.scene_id and s.state = 'active' and s.allow_promotion)
     );
-    """)
+    """
 
-    execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+    execute "grant select, update on ret0_admin.featured_scene_listings to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.pending_scenes as (
     		select scenes.id, scene_sid, scenes.slug, scenes.name, scenes.description, scenes.screenshot_owned_file_id, scenes.model_owned_file_id, scenes.scene_owned_file_id, 
     		scenes.attributions, scene_listings.id as scene_listing_id, scenes.updated_at, scenes.allow_remixing as _allow_remixing, scenes.allow_promotion as _allow_promotion
@@ -39,25 +37,23 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
     		left outer join ret0_admin.scene_listings on scene_listings.scene_id = scenes.id
     		where ((scenes.reviewed_at is null or scenes.reviewed_at < scenes.updated_at) and scenes.allow_promotion and scenes.state = 'active')
     );
-    """)
+    """
 
-    execute("grant select on ret0_admin.pending_scenes to ret_admin;")
+    execute "grant select on ret0_admin.pending_scenes to ret_admin"
   end
 
   def down do
-    execute("drop view ret0_admin.scene_listings cascade")
+    execute "drop view ret0_admin.scene_listings cascade"
 
     alter table("scene_listings") do
-      modify(:scene_owned_file_id, :bigint, null: false)
+      modify :scene_owned_file_id, :bigint, null: false
     end
 
-    execute(
-      "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
-    )
+    execute "select ret0_admin.create_or_replace_admin_view('scene_listings', ',cast(scene_id as varchar) as _scene_id')"
 
-    execute("grant select, insert, update on ret0_admin.scene_listings to ret_admin;")
+    execute "grant select, insert, update on ret0_admin.scene_listings to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.featured_scene_listings as (
     select id, scene_listing_sid, slug, name, description, screenshot_owned_file_id, model_owned_file_id, scene_owned_file_id, attributions, scene_listings.order, tags
     from ret0_admin.scene_listings
@@ -66,11 +62,11 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
     tags->'tags' ? 'featured' and
     exists (select id from ret0_admin.scenes s where s.id = scene_listings.scene_id and s.state = 'active' and s.allow_promotion)
     );
-    """)
+    """
 
-    execute("grant select, update on ret0_admin.featured_scene_listings to ret_admin;")
+    execute "grant select, update on ret0_admin.featured_scene_listings to ret_admin"
 
-    execute("""
+    execute """
     create or replace view ret0_admin.pending_scenes as (
     		select scenes.id, scene_sid, scenes.slug, scenes.name, scenes.description, scenes.screenshot_owned_file_id, scenes.model_owned_file_id, scenes.scene_owned_file_id, 
     		scenes.attributions, scene_listings.id as scene_listing_id, scenes.updated_at, scenes.allow_remixing as _allow_remixing, scenes.allow_promotion as _allow_promotion
@@ -78,8 +74,8 @@ defmodule Ret.Repo.Migrations.AllowNullSceneOwnedFile do
     		left outer join ret0_admin.scene_listings on scene_listings.scene_id = scenes.id
     		where ((scenes.reviewed_at is null or scenes.reviewed_at < scenes.updated_at) and scenes.allow_promotion and scenes.state = 'active')
     );
-    """)
+    """
 
-    execute("grant select on ret0_admin.pending_scenes to ret_admin;")
+    execute "grant select on ret0_admin.pending_scenes to ret_admin"
   end
 end

--- a/priv/repo/migrations/20191111234010_add_parenting_to_scenes.exs
+++ b/priv/repo/migrations/20191111234010_add_parenting_to_scenes.exs
@@ -3,12 +3,12 @@ defmodule Ret.Repo.Migrations.AddParentingToScenes do
 
   def change do
     alter table("scenes") do
-      add(:parent_scene_id, references(:scenes, column: :scene_id))
-      add(:parent_scene_listing_id, references(:scene_listings, column: :scene_listing_id))
+      add :parent_scene_id, references(:scenes, column: :scene_id)
+      add :parent_scene_listing_id, references(:scene_listings, column: :scene_listing_id)
     end
 
     alter table("projects") do
-      add(:scene_id, references(:scenes, column: :scene_id))
+      add :scene_id, references(:scenes, column: :scene_id)
     end
   end
 end

--- a/priv/repo/migrations/20191121222742_add_parent_to_projects.exs
+++ b/priv/repo/migrations/20191121222742_add_parent_to_projects.exs
@@ -3,8 +3,8 @@ defmodule Ret.Repo.Migrations.AddParentToProjects do
 
   def change do
     alter table("projects") do
-      add(:parent_scene_id, references(:scenes, column: :scene_id))
-      add(:parent_scene_listing_id, references(:scene_listings, column: :scene_listing_id))
+      add :parent_scene_id, references(:scenes, column: :scene_id)
+      add :parent_scene_listing_id, references(:scene_listings, column: :scene_listing_id)
     end
   end
 end

--- a/priv/repo/migrations/20200115013245_add_promotion_to_hubs.exs
+++ b/priv/repo/migrations/20200115013245_add_promotion_to_hubs.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddPromotionToHubs do
 
   def change do
     alter table(:hubs) do
-      add(:allow_promotion, :boolean, null: false, default: false)
+      add :allow_promotion, :boolean, null: false, default: false
     end
   end
 end

--- a/priv/repo/migrations/20200206023550_add_audio_asset_type.exs
+++ b/priv/repo/migrations/20200206023550_add_audio_asset_type.exs
@@ -3,6 +3,6 @@ defmodule Ret.Repo.Migrations.AddAudioAssetType do
   @disable_ddl_transaction true
 
   def change do
-    Ecto.Migration.execute("ALTER TYPE ret0.asset_type ADD VALUE IF NOT EXISTS 'audio'")
+    execute "ALTER TYPE ret0.asset_type ADD VALUE IF NOT EXISTS 'audio'"
   end
 end

--- a/priv/repo/migrations/20200206195625_drop_null_constraint_on_asset_thumbnail.exs
+++ b/priv/repo/migrations/20200206195625_drop_null_constraint_on_asset_thumbnail.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.DropNullConstraintOnAssetThumbnail do
 
   def change do
     alter table("assets") do
-      modify(:thumbnail_owned_file_id, :bigint, null: true)
+      modify :thumbnail_owned_file_id, :bigint, null: true
     end
   end
 end

--- a/priv/repo/migrations/20200212011700_create_identities.exs
+++ b/priv/repo/migrations/20200212011700_create_identities.exs
@@ -3,13 +3,13 @@ defmodule Ret.Repo.Migrations.CreateIdentities do
 
   def change do
     create table(:identities, primary_key: false) do
-      add(:identity_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:name, :string, null: false)
-      add(:account_id, references(:accounts, column: :account_id, on_delete: :delete_all))
+      add :identity_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :name, :string, null: false
+      add :account_id, references(:accounts, column: :account_id, on_delete: :delete_all)
 
       timestamps()
     end
 
-    create(index(:identities, [:account_id], unique: true))
+    create unique_index(:identities, [:account_id])
   end
 end

--- a/priv/repo/migrations/20200212174135_create_identities_admin.exs
+++ b/priv/repo/migrations/20200212174135_create_identities_admin.exs
@@ -2,14 +2,12 @@ defmodule Ret.Repo.Migrations.CreateIdentitiesAdmin do
   use Ecto.Migration
 
   def up do
-    execute(
-      "select ret0_admin.create_or_replace_admin_view('identities', ',cast(account_id as varchar) as _account_id')"
-    )
+    execute "select ret0_admin.create_or_replace_admin_view('identities', ',cast(account_id as varchar) as _account_id')"
 
-    execute("grant select, insert, update, delete on ret0_admin.identities to ret_admin;")
+    execute "grant select, insert, update, delete on ret0_admin.identities to ret_admin"
   end
 
   def down do
-    execute("drop view ret0_admin.identities;")
+    execute "drop view ret0_admin.identities"
   end
 end

--- a/priv/repo/migrations/20200212220224_add_description_to_rooms.exs
+++ b/priv/repo/migrations/20200212220224_add_description_to_rooms.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddDescriptionToRooms do
 
   def change do
     alter table("hubs") do
-      add(:description, :string, size: 64_000)
+      add :description, :string, size: 64_000
     end
   end
 end

--- a/priv/repo/migrations/20200220012135_add_cap_to_rooms.exs
+++ b/priv/repo/migrations/20200220012135_add_cap_to_rooms.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddCapToRooms do
 
   def change do
     alter table("hubs") do
-      add(:room_size, :integer, null: true, default: nil)
+      add :room_size, :integer, null: true, default: nil
     end
   end
 end

--- a/priv/repo/migrations/20200303214942_add_user_data_to_hub.exs
+++ b/priv/repo/migrations/20200303214942_add_user_data_to_hub.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddUserDataToHub do
 
   def change do
     alter table("hubs") do
-      add(:user_data, :jsonb)
+      add :user_data, :jsonb
     end
   end
 end

--- a/priv/repo/migrations/20200309203501_add_emoji_permission.exs
+++ b/priv/repo/migrations/20200309203501_add_emoji_permission.exs
@@ -3,20 +3,18 @@ defmodule Ret.Repo.Migrations.AddEmojiPermission do
 
   def up do
     alter table("hubs") do
-      modify(:member_permissions, :integer,
+      modify :member_permissions, :integer,
         default:
-          %{
+          Ret.Hub.member_permissions_to_int(%{
             spawn_and_move_media: true,
             spawn_camera: true,
             spawn_drawing: true,
             pin_objects: true,
             spawn_emoji: true
-          }
-          |> Ret.Hub.member_permissions_to_int()
-      )
+          })
     end
 
-    execute("UPDATE ret0.hubs SET member_permissions = member_permissions | 16;")
+    execute "UPDATE ret0.hubs SET member_permissions = member_permissions | 16"
   end
 
   def down do

--- a/priv/repo/migrations/20200313232157_add_fly_permission.exs
+++ b/priv/repo/migrations/20200313232157_add_fly_permission.exs
@@ -3,21 +3,19 @@ defmodule Ret.Repo.Migrations.AddFlyPermission do
 
   def up do
     alter table("hubs") do
-      modify(:member_permissions, :integer,
+      modify :member_permissions, :integer,
         default:
-          %{
+          Ret.Hub.member_permissions_to_int(%{
             spawn_and_move_media: true,
             spawn_camera: true,
             spawn_drawing: true,
             pin_objects: true,
             spawn_emoji: true,
             fly: true
-          }
-          |> Ret.Hub.member_permissions_to_int()
-      )
+          })
     end
 
-    execute("UPDATE ret0.hubs SET member_permissions = member_permissions | 32;")
+    execute "UPDATE ret0.hubs SET member_permissions = member_permissions | 32"
   end
 
   def down do

--- a/priv/repo/migrations/20200320004303_add_account_state_column.exs
+++ b/priv/repo/migrations/20200320004303_add_account_state_column.exs
@@ -5,9 +5,9 @@ defmodule Ret.Repo.Migrations.AddAccountStateColumn do
     Ret.Account.State.create_type()
 
     alter table("accounts") do
-      add(:state, :account_state, null: false, default: "enabled")
+      add :state, :account_state, null: false, default: "enabled"
     end
 
-    execute("select ret0_admin.create_or_replace_admin_view('accounts');")
+    execute "select ret0_admin.create_or_replace_admin_view('accounts')"
   end
 end

--- a/priv/repo/migrations/20200413202224_add_coturn_schema.exs
+++ b/priv/repo/migrations/20200413202224_add_coturn_schema.exs
@@ -2,22 +2,16 @@ defmodule Ret.Repo.Migrations.AddCoturnSchema do
   use Ecto.Migration
 
   def up do
-    execute("create schema if not exists coturn")
+    execute "create schema if not exists coturn"
 
-    execute(
-      "create table coturn.turn_secret (realm varchar(127), value varchar(256), inserted_at timestamp, updated_at timestamp)"
-    )
+    execute "create table coturn.turn_secret (realm varchar(127), value varchar(256), inserted_at timestamp, updated_at timestamp)"
 
-    execute(
-      "create table coturn.allowed_peer_ip (realm varchar(127), ip_range varchar(256), inserted_at timestamp, updated_at timestamp)"
-    )
+    execute "create table coturn.allowed_peer_ip (realm varchar(127), ip_range varchar(256), inserted_at timestamp, updated_at timestamp)"
 
-    execute(
-      "create table coturn.denied_peer_ip (realm varchar(127), ip_range varchar(256), inserted_at timestamp, updated_at timestamp)"
-    )
+    execute "create table coturn.denied_peer_ip (realm varchar(127), ip_range varchar(256), inserted_at timestamp, updated_at timestamp)"
   end
 
   def down do
-    execute("drop schema coturn cascade")
+    execute "drop schema coturn cascade"
   end
 end

--- a/priv/repo/migrations/20200730155900_add_invite_to_hub_entry_mode_enum.exs
+++ b/priv/repo/migrations/20200730155900_add_invite_to_hub_entry_mode_enum.exs
@@ -3,6 +3,6 @@ defmodule Ret.Repo.Migrations.AddInviteToHubEntryModeEnum do
   @disable_ddl_transaction true
 
   def change do
-    Ecto.Migration.execute("ALTER TYPE ret0.hub_entry_mode ADD VALUE IF NOT EXISTS 'invite'")
+    execute "ALTER TYPE ret0.hub_entry_mode ADD VALUE IF NOT EXISTS 'invite'"
   end
 end

--- a/priv/repo/migrations/20200805190647_create_hub_invites_table.exs
+++ b/priv/repo/migrations/20200805190647_create_hub_invites_table.exs
@@ -5,14 +5,14 @@ defmodule Ret.Repo.Migrations.CreateHubInvitesTable do
     Ret.HubInvite.State.create_type()
 
     create table(:hub_invites, primary_key: false) do
-      add(:hub_invite_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:hub_invite_sid, :string, null: false)
-      add(:hub_id, :bigint, null: false)
-      add(:state, :hub_invite_state, null: false, default: "active")
+      add :hub_invite_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :hub_invite_sid, :string, null: false
+      add :hub_id, :bigint, null: false
+      add :state, :hub_invite_state, null: false, default: "active"
 
       timestamps()
     end
 
-    create(index(:hub_invites, [:hub_invite_sid], unique: true))
+    create unique_index(:hub_invites, [:hub_invite_sid])
   end
 end

--- a/priv/repo/migrations/20201027202054_add_api_credentials_table.exs
+++ b/priv/repo/migrations/20201027202054_add_api_credentials_table.exs
@@ -6,18 +6,19 @@ defmodule Ret.Repo.Migrations.AddApiCredentialsTable do
     Ret.Api.ScopeType.create_type()
 
     create table(:api_credentials, primary_key: false) do
-      add(:api_credentials_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true)
-      add(:token_hash, :string, null: false)
-      add(:api_credentials_sid, :string, null: false)
-      add(:is_revoked, :boolean, null: false)
-      add(:scopes, {:array, :api_scope_type}, null: false)
-      add(:subject_type, :api_token_subject_type, null: false)
-      add(:account_id, references(:accounts, column: :account_id))
+      add :api_credentials_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :token_hash, :string, null: false
+      add :api_credentials_sid, :string, null: false
+      add :is_revoked, :boolean, null: false
+      add :scopes, {:array, :api_scope_type}, null: false
+      add :subject_type, :api_token_subject_type, null: false
+      add :account_id, references(:accounts, column: :account_id)
+
       timestamps()
     end
 
-    create(index(:api_credentials, [:token_hash], unique: true))
-    create(index(:api_credentials, [:api_credentials_sid], unique: true))
-    create(index(:api_credentials, [:account_id]))
+    create unique_index(:api_credentials, [:token_hash])
+    create unique_index(:api_credentials, [:api_credentials_sid])
+    create index(:api_credentials, [:account_id])
   end
 end

--- a/priv/repo/migrations/20210304010625_add_accessed_at_to_cached_files.exs
+++ b/priv/repo/migrations/20210304010625_add_accessed_at_to_cached_files.exs
@@ -3,7 +3,7 @@ defmodule Ret.Repo.Migrations.AddAccessedAtToCachedFiles do
 
   def change do
     alter table(:cached_files) do
-      add(:accessed_at, :naive_datetime, null: false, default: fragment("now()"))
+      add :accessed_at, :naive_datetime, null: false, default: fragment("now()")
     end
   end
 end

--- a/priv/repo/migrations/20210420191647_add_session_stats_index.exs
+++ b/priv/repo/migrations/20210420191647_add_session_stats_index.exs
@@ -6,17 +6,17 @@ defmodule Ret.Repo.Migrations.AddSessionStatsIndex do
   def up do
     for year <- 2018..@max_year,
         month <- 0..11 do
-      execute("
+      execute """
         create index session_stats_y#{year}_m#{month + 1}_session_id 
           on ret0.session_stats_y#{year}_m#{month + 1} (session_id)
-      ")
+      """
     end
   end
 
   def down do
     for year <- 2018..@max_year,
         month <- 0..11 do
-      execute("drop index session_stats_y#{year}_m#{month + 1}_session_id")
+      execute "drop index session_stats_y#{year}_m#{month + 1}_session_id"
     end
   end
 end

--- a/priv/repo/migrations/20220218024638_drop_entry_code_from_hubs.exs
+++ b/priv/repo/migrations/20220218024638_drop_entry_code_from_hubs.exs
@@ -2,11 +2,11 @@ defmodule Ret.Repo.Migrations.DropEntryCodeFromHubs do
   use Ecto.Migration
 
   def change do
-    drop(index(:hubs, [:entry_code]))
+    drop index(:hubs, [:entry_code])
 
     alter table("hubs") do
-      remove(:entry_code)
-      remove(:entry_code_expires_at)
+      remove :entry_code
+      remove :entry_code_expires_at
     end
   end
 end

--- a/priv/repo/migrations/20220304230943_add_hubs_public_rooms_index.exs
+++ b/priv/repo/migrations/20220304230943_add_hubs_public_rooms_index.exs
@@ -2,6 +2,6 @@ defmodule Ret.Repo.Migrations.AddHubsPublicRoomsIndex do
   use Ecto.Migration
 
   def change do
-    create(index(:hubs, [:allow_promotion]))
+    create index(:hubs, [:allow_promotion])
   end
 end

--- a/priv/repo/migrations/20220820164826_delete_orphaned_data_from_tables_missing_references.exs
+++ b/priv/repo/migrations/20220820164826_delete_orphaned_data_from_tables_missing_references.exs
@@ -14,13 +14,13 @@ defmodule Ret.Repo.Migrations.DeleteOrphanedDataFromTablesMissingReferences do
           {:oauth_providers, :account_id, :accounts},
           {:web_push_subscriptions, :hub_id, :hubs}
         ] do
-      execute("""
+      execute """
       DELETE FROM #{table}
       WHERE NOT EXISTS
         (SELECT *
            FROM "#{foreign_table}"
           WHERE "#{table}"."#{column}" = "#{foreign_table}"."#{column}")
-      """)
+      """
     end
   end
 

--- a/priv/repo/migrations/20220908132321_add_voice_text_chat.exs
+++ b/priv/repo/migrations/20220908132321_add_voice_text_chat.exs
@@ -3,9 +3,9 @@ defmodule Ret.Repo.Migrations.AddVoiceChatPermission do
 
   def up do
     alter table("hubs") do
-      modify(:member_permissions, :integer,
+      modify :member_permissions, :integer,
         default:
-          %{
+          Ret.Hub.member_permissions_to_int(%{
             spawn_and_move_media: true,
             spawn_camera: true,
             spawn_drawing: true,
@@ -14,30 +14,26 @@ defmodule Ret.Repo.Migrations.AddVoiceChatPermission do
             fly: true,
             voice_chat: true,
             text_chat: true
-          }
-          |> Ret.Hub.member_permissions_to_int()
-      )
+          })
     end
 
-    execute("UPDATE ret0.hubs SET member_permissions = member_permissions | 192;")
+    execute "UPDATE ret0.hubs SET member_permissions = member_permissions | 192"
   end
 
   def down do
     alter table("hubs") do
-      modify(:member_permissions, :integer,
+      modify :member_permissions, :integer,
         default:
-          %{
+          Ret.Hub.member_permissions_to_int(%{
             spawn_and_move_media: true,
             spawn_camera: true,
             spawn_drawing: true,
             pin_objects: true,
             spawn_emoji: true,
             fly: true
-          }
-          |> Ret.Hub.member_permissions_to_int()
-      )
+          })
     end
 
-    execute("UPDATE ret0.hubs SET member_permissions = member_permissions & ~192;")
+    execute "UPDATE ret0.hubs SET member_permissions = member_permissions & ~192"
   end
 end

--- a/priv/repo/migrations/20220915094102_add_foreign_references_and_delete_behaviors_to_tables.exs
+++ b/priv/repo/migrations/20220915094102_add_foreign_references_and_delete_behaviors_to_tables.exs
@@ -24,7 +24,7 @@ defmodule Ret.Repo.Migrations.AddForeignReferencesAndDeleteBehaviorToTables do
   def up do
     for {table, column, foreign_table} <- @missing_reference do
       alter table(table) do
-        modify(column, references(foreign_table, column: column, on_delete: :delete_all))
+        modify column, references(foreign_table, column: column, on_delete: :delete_all)
       end
     end
 
@@ -32,7 +32,7 @@ defmodule Ret.Repo.Migrations.AddForeignReferencesAndDeleteBehaviorToTables do
       drop_foreign_constraint(table, column)
 
       alter table(table) do
-        modify(column, references(foreign_table, column: foreign_column, on_delete: :delete_all))
+        modify column, references(foreign_table, column: foreign_column, on_delete: :delete_all)
       end
     end
   end
@@ -46,12 +46,13 @@ defmodule Ret.Repo.Migrations.AddForeignReferencesAndDeleteBehaviorToTables do
       drop_foreign_constraint(table, column)
 
       alter table(table) do
-        modify(column, references(foreign_table, column: foreign_column, on_delete: :nothing))
+        modify column, references(foreign_table, column: foreign_column, on_delete: :nothing)
       end
     end
   end
 
   @spec drop_foreign_constraint(String.t(), String.t()) :: :ok
-  defp drop_foreign_constraint(table, column) when is_atom(table) and is_atom(column),
-    do: execute("ALTER TABLE #{table} DROP CONSTRAINT #{table}_#{column}_fkey")
+  defp drop_foreign_constraint(table, column) when is_atom(table) and is_atom(column) do
+    execute "ALTER TABLE #{table} DROP CONSTRAINT #{table}_#{column}_fkey"
+  end
 end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -27,24 +27,24 @@ environment :dev do
   # It is recommended that you build with MIX_ENV=prod and pass
   # the --env flag to Distillery explicitly if you want to use
   # dev mode.
-  set(dev_mode: true)
-  set(include_erts: false)
-  set(cookie: :"=!x&pbYZ[lT[2XdWU)=JWm9vC~,ym5U<6sUOAinLIIGF@!t1J/UY:es{Pok_0(Y@")
-  set(no_dot_erlang: true)
+  set dev_mode: true
+  set include_erts: false
+  set cookie: :"=!x&pbYZ[lT[2XdWU)=JWm9vC~,ym5U<6sUOAinLIIGF@!t1J/UY:es{Pok_0(Y@"
+  set no_dot_erlang: true
 end
 
 environment :prod do
-  set(include_erts: true)
-  set(include_src: false)
-  set(no_dot_erlang: true)
-  set(vm_args: "rel/prod.vm_args")
+  set include_erts: true
+  set include_src: false
+  set no_dot_erlang: true
+  set vm_args: "rel/prod.vm_args"
 end
 
 environment :turkey do
-  set(include_erts: true)
-  set(include_src: false)
-  set(no_dot_erlang: true)
-  set(vm_args: "rel/prod.vm_args")
+  set include_erts: true
+  set include_src: false
+  set no_dot_erlang: true
+  set vm_args: "rel/prod.vm_args"
 end
 
 # You may define one or more releases in this file.
@@ -53,19 +53,15 @@ end
 # will be used by default
 
 release :ret do
-  set(version: System.get_env("RELEASE_VERSION") || current_version(:ret))
+  set version: System.get_env("RELEASE_VERSION") || current_version(:ret)
 
-  set(
-    applications: [
-      :runtime_tools
-    ]
-  )
+  set applications: [
+        :runtime_tools
+      ]
 
-  set(commands: [])
+  set commands: []
 
-  set(
-    config_providers: [
-      {Toml.Provider, [path: "${RELEASE_CONFIG_DIR}/config.toml"]}
-    ]
-  )
+  set config_providers: [
+        {Toml.Provider, [path: "${RELEASE_CONFIG_DIR}/config.toml"]}
+      ]
 end

--- a/test/api/v2/room_query_test.exs
+++ b/test/api/v2/room_query_test.exs
@@ -73,7 +73,11 @@ defmodule RoomQueryTest do
     assert hd(res["errors"])["type"] === "api_access_token_not_found"
   end
 
-  test "Can query public rooms with app token", %{conn: conn, public_hub: public_hub, app_token: app_token} do
+  test "Can query public rooms with app token", %{
+    conn: conn,
+    public_hub: public_hub,
+    app_token: app_token
+  } do
     res =
       conn
       |> put_auth_header_for_token(app_token)
@@ -116,7 +120,12 @@ defmodule RoomQueryTest do
     assert List.first(rooms)["id"] == hub.hub_sid
   end
 
-  test "my rooms only returns my own rooms", %{conn: conn, account2: account2, hub: hub, token: token} do
+  test "my rooms only returns my own rooms", %{
+    conn: conn,
+    account2: account2,
+    hub: hub,
+    token: token
+  } do
     assign_creator(hub, account2)
 
     auth_res =
@@ -144,7 +153,8 @@ defmodule RoomQueryTest do
       |> put_auth_header_for_token(token)
       |> do_graphql_action(@query_my_rooms)
 
-    assert length(response["data"]["myRooms"]["entries"]) === response["data"]["myRooms"]["page_size"]
+    assert length(response["data"]["myRooms"]["entries"]) ===
+             response["data"]["myRooms"]["page_size"]
   end
 
   test "The room query api paginates results 2", %{
@@ -166,7 +176,11 @@ defmodule RoomQueryTest do
     assert length(response["data"]["myRooms"]["entries"]) === 2
   end
 
-  test "Public API Access has to be enabled on the server", %{conn: conn, public_hub: public_hub, app_token: app_token} do
+  test "Public API Access has to be enabled on the server", %{
+    conn: conn,
+    public_hub: public_hub,
+    app_token: app_token
+  } do
     AppConfig.set_config_value("features|public_api_access", false)
 
     conn

--- a/test/ret/api_token_test.exs
+++ b/test/ret/api_token_test.exs
@@ -26,7 +26,9 @@ defmodule Ret.ApiTokenTest do
 
     Ret.Api.Token.revoke(token)
 
-    {:ok, %Credentials{is_revoked: is_revoked_2}} = Guardian.decode_and_verify(Ret.Api.Token, token)
+    {:ok, %Credentials{is_revoked: is_revoked_2}} =
+      Guardian.decode_and_verify(Ret.Api.Token, token)
+
     assert is_revoked_2 == true
   end
 

--- a/test/ret/avatar_listing_test.exs
+++ b/test/ret/avatar_listing_test.exs
@@ -31,7 +31,10 @@ defmodule Ret.AvatarListingTest do
     }
   end
 
-  test "can create an avatar listing", %{account_1_avatar_1: avatar, account_1_avatar_1_listing_1: listing} do
+  test "can create an avatar listing", %{
+    account_1_avatar_1: avatar,
+    account_1_avatar_1_listing_1: listing
+  } do
     assert listing.name == avatar.name
     assert listing.description == avatar.description
     assert listing.avatar_id == avatar.avatar_id

--- a/test/ret/cached_file_test.exs
+++ b/test/ret/cached_file_test.exs
@@ -183,7 +183,7 @@ defmodule Ret.CachedFileTest do
   end
 
   defp cached_file(cache_key) do
-    CachedFile |> where(cache_key: ^cache_key) |> Repo.one()
+    Repo.one(from CachedFile, where: [cache_key: ^cache_key])
   end
 
   defp changeset(struct, params) do

--- a/test/ret/cached_file_test.exs
+++ b/test/ret/cached_file_test.exs
@@ -57,8 +57,12 @@ defmodule Ret.CachedFileTest do
       assert %CachedFile{cache_key: "ccc"} = cached_file("ccc")
 
       # The underlying asset has been vacuumed
-      assert {:error, :not_found} = Storage.fetch(aaa.file_uuid, aaa.file_key, Storage.cached_file_path())
-      assert {:error, :not_found} = Storage.fetch(bbb.file_uuid, bbb.file_key, Storage.cached_file_path())
+      assert {:error, :not_found} =
+               Storage.fetch(aaa.file_uuid, aaa.file_key, Storage.cached_file_path())
+
+      assert {:error, :not_found} =
+               Storage.fetch(bbb.file_uuid, bbb.file_key, Storage.cached_file_path())
+
       assert {:ok, _meta, _stream} = Storage.fetch(ccc)
     end
   end
@@ -66,7 +70,8 @@ defmodule Ret.CachedFileTest do
   test "CachedFiles are migrated from expiring storage to cached storage" do
     cache_key = "abc"
 
-    %CachedFile{file_uuid: file_uuid, file_key: file_key} = cached_file = put_file_in_expiring_storage(cache_key, "abc")
+    %CachedFile{file_uuid: file_uuid, file_key: file_key} =
+      cached_file = put_file_in_expiring_storage(cache_key, "abc")
 
     # This line ensures the file is stored in the expiring_file_path
     {:ok, _meta, _stream} = Storage.fetch(file_uuid, file_key, Storage.expiring_file_path())
@@ -81,7 +86,8 @@ defmodule Ret.CachedFileTest do
   test "CachedFiles are migrated from expiring storage to cached storage only once" do
     cache_key = "foobarbaz"
 
-    %CachedFile{file_uuid: file_uuid, file_key: file_key} = cached_file = put_file_in_expiring_storage(cache_key, "abc")
+    %CachedFile{file_uuid: file_uuid, file_key: file_key} =
+      cached_file = put_file_in_expiring_storage(cache_key, "abc")
 
     # This line ensures the file is stored in the expiring_file_path
     {:ok, _meta, _stream} = Storage.fetch(file_uuid, file_key, Storage.expiring_file_path())
@@ -128,14 +134,20 @@ defmodule Ret.CachedFileTest do
       assert %CachedFile{cache_key: "ccc"} = cached_file("ccc")
 
       # The underlying asset has been vacuumed
-      assert {:error, :not_found} = Storage.fetch(aaa.file_uuid, aaa.file_key, Storage.cached_file_path())
-      assert {:error, :not_found} = Storage.fetch(bbb.file_uuid, bbb.file_key, Storage.cached_file_path())
-      assert {:error, :not_found} = Storage.fetch(expiring.file_uuid, expiring.file_key, Storage.cached_file_path())
+      assert {:error, :not_found} =
+               Storage.fetch(aaa.file_uuid, aaa.file_key, Storage.cached_file_path())
+
+      assert {:error, :not_found} =
+               Storage.fetch(bbb.file_uuid, bbb.file_key, Storage.cached_file_path())
+
+      assert {:error, :not_found} =
+               Storage.fetch(expiring.file_uuid, expiring.file_key, Storage.cached_file_path())
 
       assert {:ok, _meta, _stream} = Storage.fetch(ccc)
 
       # The expiring file will exist until vacuumed independently
-      assert {:ok, _meta, _stream} = Storage.fetch(expiring.file_uuid, expiring.file_key, Storage.expiring_file_path())
+      assert {:ok, _meta, _stream} =
+               Storage.fetch(expiring.file_uuid, expiring.file_key, Storage.expiring_file_path())
     end
   end
 
@@ -143,7 +155,10 @@ defmodule Ret.CachedFileTest do
     {:ok, path} = Temp.path()
     file_key = SecureRandom.hex()
     {:ok, %{content_type: content_type}} = write_large_file_to_path(contents).(path)
-    {:ok, file_uuid} = Storage.store(path, content_type, file_key, nil, Storage.expiring_file_path())
+
+    {:ok, file_uuid} =
+      Storage.store(path, content_type, file_key, nil, Storage.expiring_file_path())
+
     File.rm_rf(path)
 
     {:ok, cached_file} =
@@ -161,7 +176,10 @@ defmodule Ret.CachedFileTest do
   end
 
   defp shift(%{now: now, shift_options: shift_options}) do
-    now |> Timex.shift(shift_options) |> Timex.to_naive_datetime() |> NaiveDateTime.truncate(:second)
+    now
+    |> Timex.shift(shift_options)
+    |> Timex.to_naive_datetime()
+    |> NaiveDateTime.truncate(:second)
   end
 
   defp cached_file(cache_key) do

--- a/test/ret/change_email_for_login_test.exs
+++ b/test/ret/change_email_for_login_test.exs
@@ -27,11 +27,13 @@ defmodule Ret.ChangeEmailForLoginTest do
       Account.find_or_create_account_for_email(@alpha)
       Account.find_or_create_account_for_email(@bravo)
 
-      {:error, :new_email_already_in_use} = Ret.change_email_for_login(%{new_email: @bravo, old_email: @alpha})
+      {:error, :new_email_already_in_use} =
+        Ret.change_email_for_login(%{new_email: @bravo, old_email: @alpha})
     end
 
     test "validates that the old email is in use" do
-      {:error, :no_account_for_old_email} = Ret.change_email_for_login(%{new_email: @bravo, old_email: @alpha})
+      {:error, :no_account_for_old_email} =
+        Ret.change_email_for_login(%{new_email: @bravo, old_email: @alpha})
     end
   end
 end

--- a/test/ret/discord_client_test.exs
+++ b/test/ret/discord_client_test.exs
@@ -33,9 +33,17 @@ defmodule Ret.DiscordClientTest do
       %{"id" => @moderator_role, "permissions" => @view_channel}
     ])
 
-    Cachex.put(:discord_api, "/guilds/#{@community_id}/members/#{@moderator_user_id}", %{"roles" => [@moderator_role]})
-    Cachex.put(:discord_api, "/guilds/#{@community_id}/members/#{@owner_user_id}", %{"roles" => []})
-    Cachex.put(:discord_api, "/guilds/#{@community_id}/members/#{@regular_user_id}", %{"roles" => []})
+    Cachex.put(:discord_api, "/guilds/#{@community_id}/members/#{@moderator_user_id}", %{
+      "roles" => [@moderator_role]
+    })
+
+    Cachex.put(:discord_api, "/guilds/#{@community_id}/members/#{@owner_user_id}", %{
+      "roles" => []
+    })
+
+    Cachex.put(:discord_api, "/guilds/#{@community_id}/members/#{@regular_user_id}", %{
+      "roles" => []
+    })
 
     Cachex.put(:discord_api, "/channels/#{@general_channel_id}", %{"permission_overwrites" => []})
 
@@ -51,18 +59,22 @@ defmodule Ret.DiscordClientTest do
   end
 
   test "regular member should be able to view general channel" do
-    assert @regular_user_id |> DiscordClient.has_permission?(@general_channel_binding, :view_channel)
+    assert @regular_user_id
+           |> DiscordClient.has_permission?(@general_channel_binding, :view_channel)
   end
 
   test "regular member should not be able to view restricted channel" do
-    refute @regular_user_id |> DiscordClient.has_permission?(@restricted_channel_binding, :view_channel)
+    refute @regular_user_id
+           |> DiscordClient.has_permission?(@restricted_channel_binding, :view_channel)
   end
 
   test "owner should be able to view restricted channel" do
-    assert @owner_user_id |> DiscordClient.has_permission?(@restricted_channel_binding, :view_channel)
+    assert @owner_user_id
+           |> DiscordClient.has_permission?(@restricted_channel_binding, :view_channel)
   end
 
   test "moderator should be able to view restricted channel" do
-    assert @moderator_user_id |> DiscordClient.has_permission?(@restricted_channel_binding, :view_channel)
+    assert @moderator_user_id
+           |> DiscordClient.has_permission?(@restricted_channel_binding, :view_channel)
   end
 end

--- a/test/ret/gltf_utils_test.exs
+++ b/test/ret/gltf_utils_test.exs
@@ -158,7 +158,10 @@ defmodule Ret.GLTFUtilsTest do
 
   test "replace only base texture", %{temp_owned_file: temp_owned_file} do
     input_gltf = @sample_gltf
-    output_gltf = input_gltf |> GLTFUtils.with_default_material_override(%{base_map_owned_file: temp_owned_file})
+
+    output_gltf =
+      input_gltf
+      |> GLTFUtils.with_default_material_override(%{base_map_owned_file: temp_owned_file})
 
     img_url = temp_owned_file |> OwnedFile.uri_for() |> URI.to_string()
     assert img_url == output_gltf |> get_in(["images", Access.at(2), "uri"])
@@ -170,7 +173,10 @@ defmodule Ret.GLTFUtilsTest do
 
   test "replace ORM texture", %{temp_owned_file: temp_owned_file} do
     input_gltf = @sample_gltf
-    output_gltf = input_gltf |> GLTFUtils.with_default_material_override(%{orm_map_owned_file: temp_owned_file})
+
+    output_gltf =
+      input_gltf
+      |> GLTFUtils.with_default_material_override(%{orm_map_owned_file: temp_owned_file})
 
     img_url = temp_owned_file |> OwnedFile.uri_for() |> URI.to_string()
     assert img_url == output_gltf |> get_in(["images", Access.at(1), "uri"])
@@ -182,7 +188,10 @@ defmodule Ret.GLTFUtilsTest do
 
   test "replace multiple ORM texture", %{temp_owned_file: temp_owned_file} do
     input_gltf = @multi_orm_gltf
-    output_gltf = input_gltf |> GLTFUtils.with_default_material_override(%{orm_map_owned_file: temp_owned_file})
+
+    output_gltf =
+      input_gltf
+      |> GLTFUtils.with_default_material_override(%{orm_map_owned_file: temp_owned_file})
 
     img_url = temp_owned_file |> OwnedFile.uri_for() |> URI.to_string()
     assert img_url == output_gltf |> get_in(["images", Access.at(1), "uri"])

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -200,9 +200,7 @@ defmodule Ret.HubTest do
 
     hub = hub |> Hub.add_owner!(account)
 
-    assert HubRoleMembership
-           |> where(hub_id: ^hub.hub_id)
-           |> Repo.aggregate(:count, :hub_role_membership_id) === 0
+    refute Repo.exists?(from HubRoleMembership, where: [hub_id: ^hub.hub_id])
   end
 
   test "double adding the same account doesn't fail", %{
@@ -220,8 +218,6 @@ defmodule Ret.HubTest do
     hub = hub |> Hub.add_owner!(account2)
     hub = hub |> Hub.add_owner!(account2)
 
-    assert HubRoleMembership
-           |> where(hub_id: ^hub.hub_id)
-           |> Repo.aggregate(:count, :hub_role_membership_id) === 1
+    assert Repo.one(from HubRoleMembership, where: [hub_id: ^hub.hub_id])
   end
 end

--- a/test/ret/hub_test.exs
+++ b/test/ret/hub_test.exs
@@ -10,16 +10,26 @@ defmodule Ret.HubTest do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
     hub = hub |> Repo.preload([:hub_bindings, :hub_role_memberships])
 
-    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false, amplify_audio: false} =
-      hub |> Hub.perms_for_account(Ret.Account.account_for_email("non-creator@mozilla.com"))
+    %{
+      join_hub: true,
+      update_hub: false,
+      close_hub: false,
+      mute_users: false,
+      amplify_audio: false
+    } = hub |> Hub.perms_for_account(Ret.Account.account_for_email("non-creator@mozilla.com"))
   end
 
   test "should deny permissions for anon", %{scene: scene} do
     {:ok, hub} = %Hub{} |> Hub.changeset(scene, %{name: "Test Hub"}) |> Repo.insert()
     hub = hub |> Repo.preload([:hub_bindings])
 
-    %{join_hub: true, update_hub: false, close_hub: false, mute_users: false, amplify_audio: false} =
-      hub |> Hub.perms_for_account(nil)
+    %{
+      join_hub: true,
+      update_hub: false,
+      close_hub: false,
+      mute_users: false,
+      amplify_audio: false
+    } = hub |> Hub.perms_for_account(nil)
   end
 
   test "should deny entry for closed hub, allow entry for re-opened hub", %{scene: scene} do
@@ -114,7 +124,10 @@ defmodule Ret.HubTest do
     assert hub.created_by_account_id == account.account_id
   end
 
-  test "should not have creator assignment token if account assigned", %{account: account, scene: scene} do
+  test "should not have creator assignment token if account assigned", %{
+    account: account,
+    scene: scene
+  } do
     {:ok, hub} =
       %Hub{}
       |> Hub.changeset(scene, %{name: "Test Hub"})
@@ -186,7 +199,10 @@ defmodule Ret.HubTest do
       |> Repo.insert()
 
     hub = hub |> Hub.add_owner!(account)
-    assert HubRoleMembership |> where(hub_id: ^hub.hub_id) |> Repo.aggregate(:count, :hub_role_membership_id) === 0
+
+    assert HubRoleMembership
+           |> where(hub_id: ^hub.hub_id)
+           |> Repo.aggregate(:count, :hub_role_membership_id) === 0
   end
 
   test "double adding the same account doesn't fail", %{
@@ -204,6 +220,8 @@ defmodule Ret.HubTest do
     hub = hub |> Hub.add_owner!(account2)
     hub = hub |> Hub.add_owner!(account2)
 
-    assert HubRoleMembership |> where(hub_id: ^hub.hub_id) |> Repo.aggregate(:count, :hub_role_membership_id) === 1
+    assert HubRoleMembership
+           |> where(hub_id: ^hub.hub_id)
+           |> Repo.aggregate(:count, :hub_role_membership_id) === 1
   end
 end

--- a/test/ret/login_token_test.exs
+++ b/test/ret/login_token_test.exs
@@ -10,7 +10,9 @@ defmodule Ret.LoginTokenTest do
 
   test "should generate a valid token" do
     %LoginToken{token: token} = LoginToken.new_login_token_for_email("test@mozilla.com")
-    assert LoginToken.lookup_by_token(token).identifier_hash == Ret.Crypto.hash("test@mozilla.com")
+
+    assert LoginToken.lookup_by_token(token).identifier_hash ==
+             Ret.Crypto.hash("test@mozilla.com")
   end
 
   test "should allow expiring a token" do

--- a/test/ret/media_resolver_test.exs
+++ b/test/ret/media_resolver_test.exs
@@ -2,15 +2,23 @@ defmodule Ret.MediaResolverTest do
   use Ret.DataCase
 
   test "media resolver forbids requesting internal hosts" do
-    :forbidden = Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "http://127.0.0.1:3000/foo"})
+    :forbidden =
+      Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "http://127.0.0.1:3000/foo"})
+
     :forbidden = Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "http://0.0.0.0"})
-    :forbidden = Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "https://192.168.0.1/foo"})
-    :forbidden = Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "http://127.0.0.1.sslip.io"})
+
+    :forbidden =
+      Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "https://192.168.0.1/foo"})
+
+    :forbidden =
+      Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "http://127.0.0.1.sslip.io"})
   end
 
   test "media resolver errors when requesting non-existent hosts, or hosts without a public dns" do
     :error = Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "http://hubs.local:3000/foo"})
     :error = Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "http://localhost:4000/foo"})
-    :error = Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "https://missing.example.com/"})
+
+    :error =
+      Ret.MediaResolver.resolve(%Ret.MediaResolverQuery{url: "https://missing.example.com/"})
   end
 end

--- a/test/ret/node_stat_test.exs
+++ b/test/ret/node_stat_test.exs
@@ -63,7 +63,10 @@ defmodule Ret.NodeStatTest do
     {:ok, time} = Time.new(0, 0, 0, 0)
 
     %{
-      today: %{start_time: today_date |> date_to_date_time(time), end_time: tomorrow_date |> date_to_date_time(time)},
+      today: %{
+        start_time: today_date |> date_to_date_time(time),
+        end_time: tomorrow_date |> date_to_date_time(time)
+      },
       yesterday: %{
         start_time: yesterday_date |> date_to_date_time(time),
         end_time: today_date |> date_to_date_time(time)

--- a/test/ret/project_test.exs
+++ b/test/ret/project_test.exs
@@ -41,7 +41,9 @@ defmodule Ret.ProjectTest do
       Repo.get!(OwnedFile, project.project_owned_file_id)
       Repo.get!(OwnedFile, project.thumbnail_owned_file_id)
 
-      [_path, old_meta_file_path, old_blob_file_path] = Storage.paths_for_owned_file(project.project_owned_file)
+      [_path, old_meta_file_path, old_blob_file_path] =
+        Storage.paths_for_owned_file(project.project_owned_file)
+
       true = File.exists?(old_meta_file_path)
       true = File.exists?(old_blob_file_path)
 
@@ -60,7 +62,9 @@ defmodule Ret.ProjectTest do
     thumbnail_owned_file = generate_temp_owned_file(account)
 
     %Project{}
-    |> Project.changeset(account, project_owned_file, thumbnail_owned_file, %{name: DummyData.project_name()})
+    |> Project.changeset(account, project_owned_file, thumbnail_owned_file, %{
+      name: DummyData.project_name()
+    })
     |> Repo.insert!()
     |> Repo.preload([:project_owned_file])
   end

--- a/test/ret/scene_test.exs
+++ b/test/ret/scene_test.exs
@@ -43,7 +43,9 @@ defmodule Ret.SceneTest do
       Repo.get!(OwnedFile, scene.screenshot_owned_file_id)
       Repo.get!(OwnedFile, scene.model_owned_file_id)
 
-      [_path, old_meta_file_path, old_blob_file_path] = Storage.paths_for_owned_file(scene.scene_owned_file)
+      [_path, old_meta_file_path, old_blob_file_path] =
+        Storage.paths_for_owned_file(scene.scene_owned_file)
+
       true = File.exists?(old_meta_file_path)
       true = File.exists?(old_blob_file_path)
 

--- a/test/ret/sketchfab_test.exs
+++ b/test/ret/sketchfab_test.exs
@@ -61,7 +61,7 @@ defmodule Ret.SketchfabTest do
       )
 
     %CachedFile{file_uuid: file_uuid, file_content_type: file_content_type, file_key: file_key} =
-      CachedFile |> where(cache_key: ^cache_key) |> Repo.one()
+      Repo.one(from CachedFile, where: [cache_key: ^cache_key])
 
     assert uri === Storage.uri_for(file_uuid, file_content_type, file_key)
   end

--- a/test/ret/storage_test.exs
+++ b/test/ret/storage_test.exs
@@ -39,10 +39,14 @@ defmodule Ret.StorageTest do
     assert_fetch_result(result, "text/plain", "test")
   end
 
-  test "should not be able to promote a file with an invalid promotion token", %{temp_file: temp_file} do
+  test "should not be able to promote a file with an invalid promotion token", %{
+    temp_file: temp_file
+  } do
     account = Ret.Repo.insert!(%Ret.Account{})
 
-    {:ok, uuid} = Storage.store(%Plug.Upload{path: temp_file}, "text/plain", "secret", "promotion_secret")
+    {:ok, uuid} =
+      Storage.store(%Plug.Upload{path: temp_file}, "text/plain", "secret", "promotion_secret")
+
     {:error, :not_allowed} = Storage.promote(uuid, "secret", "invalid_promotion_secret", account)
   end
 
@@ -55,7 +59,8 @@ defmodule Ret.StorageTest do
 
     owned_file_id = owned_file.owned_file_id
 
-    {:ok, %OwnedFile{owned_file_id: ^owned_file_id}} = Storage.promote(uuid, "secret", nil, account)
+    {:ok, %OwnedFile{owned_file_id: ^owned_file_id}} =
+      Storage.promote(uuid, "secret", nil, account)
   end
 
   test "should be able to promote multiple files", %{

--- a/test/ret/support_subscription_test.exs
+++ b/test/ret/support_subscription_test.exs
@@ -6,7 +6,9 @@ defmodule Ret.SupportSubscriptionTest do
   test "support availability" do
     assert Support.available?() == false
 
-    %SupportSubscription{} |> SupportSubscription.changeset(%{identifier: "csr"}) |> Ret.Repo.insert!()
+    %SupportSubscription{}
+    |> SupportSubscription.changeset(%{identifier: "csr"})
+    |> Ret.Repo.insert!()
 
     assert Support.available?() == true
   end

--- a/test/ret_test.exs
+++ b/test/ret_test.exs
@@ -2,7 +2,9 @@ defmodule RetTest do
   use Ret.DataCase
 
   import Ret.Schema, only: [is_schema: 1]
-  import Ret.TestHelpers, only: [create_admin_account: 1, create_account: 1, generate_temp_owned_file: 1]
+
+  import Ret.TestHelpers,
+    only: [create_admin_account: 1, create_account: 1, generate_temp_owned_file: 1]
 
   alias Ret.{
     Account,
@@ -43,7 +45,10 @@ defmodule RetTest do
       refute repo_reload(account_to_delete)
     end
 
-    test "deletes account owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes account owned files", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       owned_file = generate_temp_owned_file(account_to_delete)
 
       %OwnedFile{} = repo_reload(owned_file)
@@ -54,7 +59,10 @@ defmodule RetTest do
       refute file_on_disk?(owned_file)
     end
 
-    test "deletes account favorites", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes account favorites", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       own_hub = create_hub(account_to_delete)
       member_hub = create_hub()
       favorite1 = Repo.insert!(%AccountFavorite{account: account_to_delete, hub: own_hub})
@@ -65,7 +73,10 @@ defmodule RetTest do
       refute repo_reload(favorite2)
     end
 
-    test "deletes API credentials", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes API credentials", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       Api.TokenUtils.gen_token_for_account(account_to_delete)
       credentials = Repo.get_by(Api.Credentials, account_id: account_to_delete.account_id)
 
@@ -82,7 +93,10 @@ defmodule RetTest do
       refute repo_reload(asset)
     end
 
-    test "deletes asset owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes asset owned files", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       asset = create_asset(account_to_delete)
       owned_files = owned_files(asset, [:asset_owned_file, :thumbnail_owned_file])
 
@@ -108,7 +122,10 @@ defmodule RetTest do
       refute repo_reload(avatar)
     end
 
-    test "deletes avatar owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes avatar owned files", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       avatar = create_avatar(account_to_delete)
       owned_files = avatar_owned_files(avatar)
 
@@ -125,7 +142,10 @@ defmodule RetTest do
       end
     end
 
-    test "reassigns parent avatars to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "reassigns parent avatars to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       account_to_delete_id = account_to_delete.account_id
       avatar = create_avatar(account_to_delete)
       create_child_avatar(avatar)
@@ -159,7 +179,10 @@ defmodule RetTest do
       end
     end
 
-    test "reassigns listed avatars to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "reassigns listed avatars to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       account_to_delete_id = account_to_delete.account_id
       avatar = create_avatar(account_to_delete)
       create_avatar_listing(avatar)
@@ -202,7 +225,10 @@ defmodule RetTest do
       refute repo_reload(hub)
     end
 
-    test "deletes hub account favorites", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes hub account favorites", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       hub = create_hub(account_to_delete)
       other_account = create_account("other account")
       favorite = Repo.insert!(%AccountFavorite{account: other_account, hub: hub})
@@ -211,7 +237,10 @@ defmodule RetTest do
       refute repo_reload(favorite)
     end
 
-    test "deletes hub bindings", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes hub bindings", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       hub = create_hub(account_to_delete)
 
       binding =
@@ -226,7 +255,10 @@ defmodule RetTest do
       refute repo_reload(binding)
     end
 
-    test "deletes hub invites", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes hub invites", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       hub = create_hub(account_to_delete)
       invite = Repo.insert!(%HubInvite{hub: hub, hub_invite_sid: "dummy sid"})
 
@@ -234,7 +266,10 @@ defmodule RetTest do
       refute repo_reload(invite)
     end
 
-    test "deletes hub hub-role memberships", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes hub hub-role memberships", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       hub = create_hub(account_to_delete)
       other_account = create_account("other account")
       membership = Repo.insert!(%HubRoleMembership{account: other_account, hub: hub})
@@ -243,7 +278,10 @@ defmodule RetTest do
       refute repo_reload(membership)
     end
 
-    test "deletes hub room objects", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes hub room objects", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       hub = create_hub(account_to_delete)
       other_account = create_account("other account")
       object = create_room_object(hub, other_account)
@@ -254,17 +292,28 @@ defmodule RetTest do
       refute repo_reload(object)
     end
 
-    test "deletes hub web push subscriptions", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes hub web push subscriptions", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       hub = create_hub(account_to_delete)
 
       subscription =
-        Repo.insert!(%WebPushSubscription{auth: "fake auth", endpoint: "fake endpoint", hub: hub, p256dh: "fake key"})
+        Repo.insert!(%WebPushSubscription{
+          auth: "fake auth",
+          endpoint: "fake endpoint",
+          hub: hub,
+          p256dh: "fake key"
+        })
 
       assert :ok === Ret.delete_account(account_to_delete.account_id, current_user)
       refute repo_reload(subscription)
     end
 
-    test "deletes hub-role memberships", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes hub-role memberships", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       own_hub = create_hub(account_to_delete)
       member_hub = create_hub()
       membership1 = Repo.insert!(%HubRoleMembership{account: account_to_delete, hub: own_hub})
@@ -291,7 +340,10 @@ defmodule RetTest do
       refute repo_reload(login)
     end
 
-    test "deletes OAuth providers", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes OAuth providers", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       provider =
         Repo.insert!(%OAuthProvider{
           account: account_to_delete,
@@ -312,7 +364,10 @@ defmodule RetTest do
       refute repo_reload(project)
     end
 
-    test "deletes project owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes project owned files", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       project = create_project(account_to_delete)
       owned_files = owned_files(project, [:project_owned_file, :thumbnail_owned_file])
 
@@ -329,7 +384,10 @@ defmodule RetTest do
       end
     end
 
-    test "deletes project assets", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes project assets", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       %{project_id: project_id} = create_project(account_to_delete)
       %{asset_id: asset_id} = create_asset(account_to_delete)
       project_asset = Repo.insert!(%ProjectAsset{asset_id: asset_id, project_id: project_id})
@@ -338,7 +396,10 @@ defmodule RetTest do
       refute repo_reload(project_asset)
     end
 
-    test "deletes room objects", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes room objects", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       own_hub = create_hub(account_to_delete)
       member_hub = create_hub()
       object1 = create_room_object(own_hub, account_to_delete)
@@ -361,7 +422,10 @@ defmodule RetTest do
       refute repo_reload(scene)
     end
 
-    test "deletes scene owned files", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "deletes scene owned files", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       scene = create_scene(account_to_delete)
       owned_files = scene_owned_files(scene)
 
@@ -378,7 +442,10 @@ defmodule RetTest do
       end
     end
 
-    test "rassigns parent scenes to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "rassigns parent scenes to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       account_to_delete_id = account_to_delete.account_id
       scene = create_scene(account_to_delete)
       create_child_scene(scene)
@@ -412,7 +479,10 @@ defmodule RetTest do
       end
     end
 
-    test "reassigns listed scenes to current user", %{account_to_delete: account_to_delete, current_user: current_user} do
+    test "reassigns listed scenes to current user", %{
+      account_to_delete: account_to_delete,
+      current_user: current_user
+    } do
       account_to_delete_id = account_to_delete.account_id
       scene = create_scene(account_to_delete)
       create_scene_listing(scene)
@@ -449,14 +519,18 @@ defmodule RetTest do
     test "with a non-admin user", %{account_to_delete: account_to_delete} do
       current_user = create_account("non-admin")
 
-      assert {:error, :forbidden} === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert {:error, :forbidden} ===
+               Ret.delete_account(account_to_delete.account_id, current_user)
+
       assert repo_reload(account_to_delete)
     end
 
     test "with an admin account to delete", %{current_user: current_user} do
       {:ok, admin_account: account_to_delete} = create_admin_account("admin account")
 
-      assert {:error, :forbidden} === Ret.delete_account(account_to_delete.account_id, current_user)
+      assert {:error, :forbidden} ===
+               Ret.delete_account(account_to_delete.account_id, current_user)
+
       assert repo_reload(account_to_delete)
     end
 
@@ -587,7 +661,12 @@ defmodule RetTest do
   @spec create_hub(Account.t()) :: Hub.t()
   defp create_hub(%Account{} = account),
     do:
-      Repo.insert!(%Hub{created_by_account: account, name: "test hub", scene: create_scene(account), slug: "dummy-slug"})
+      Repo.insert!(%Hub{
+        created_by_account: account,
+        name: "test hub",
+        scene: create_scene(account),
+        slug: "dummy-slug"
+      })
 
   @spec create_project(Account.t()) :: Project.t()
   defp create_project(%Account{} = account) do
@@ -606,7 +685,13 @@ defmodule RetTest do
 
   @spec create_room_object(Hub.t(), Account.t()) :: RoomObject.t()
   defp create_room_object(%Hub{} = hub, %Account{} = account),
-    do: Repo.insert!(%RoomObject{account: account, gltf_node: "fake node", hub: hub, object_id: "fake id"})
+    do:
+      Repo.insert!(%RoomObject{
+        account: account,
+        gltf_node: "fake node",
+        hub: hub,
+        object_id: "fake id"
+      })
 
   @spec create_scene(Account.t()) :: Scene.t()
   defp create_scene(%Account{} = account) do

--- a/test/ret_web/channels/auth_channel_test.exs
+++ b/test/ret_web/channels/auth_channel_test.exs
@@ -56,9 +56,6 @@ defmodule RetWeb.AuthChannelTest do
 
   defp login_token_for_email_exists?(email) do
     email_hash = Account.identifier_hash_for_email(email)
-
-    Ret.LoginToken
-    |> where([t], t.identifier_hash == ^email_hash)
-    |> Repo.exists?()
+    Repo.exists?(from t in Ret.LoginToken, where: t.identifier_hash == ^email_hash)
   end
 end

--- a/test/ret_web/channels/hub_channel_test.exs
+++ b/test/ret_web/channels/hub_channel_test.exs
@@ -32,13 +32,19 @@ defmodule RetWeb.HubChannelTest do
       disabled_account |> Ecto.Changeset.change(state: :disabled) |> Ret.Repo.update!()
 
       {:error, %{reason: "join_denied"}} =
-        subscribe_and_join(socket, "hub:#{hub.hub_sid}", join_params_for_account(disabled_account))
+        subscribe_and_join(
+          socket,
+          "hub:#{hub.hub_sid}",
+          join_params_for_account(disabled_account)
+        )
     end
   end
 
   describe "presence" do
     test "joining hub registers in presence", %{socket: socket, hub: hub} do
-      {:ok, %{session_id: session_id}, socket} = subscribe_and_join(socket, "hub:#{hub.hub_sid}", @default_join_params)
+      {:ok, %{session_id: session_id}, socket} =
+        subscribe_and_join(socket, "hub:#{hub.hub_sid}", @default_join_params)
+
       :timer.sleep(100)
       presence = socket |> Presence.list()
       assert presence[session_id]
@@ -71,7 +77,8 @@ defmodule RetWeb.HubChannelTest do
     test "join is denied when joining with an invalid invite", %{socket: socket} do
       %{hub: hub} = create_invite_only_hub()
 
-      {:error, %{reason: "join_denied"}} = join_hub(socket, hub, join_params_for_hub_invite_id("invalid_invite_id"))
+      {:error, %{reason: "join_denied"}} =
+        join_hub(socket, hub, join_params_for_hub_invite_id("invalid_invite_id"))
     end
 
     test "join is denied when joining with a revoked invite", %{socket: socket} do
@@ -79,7 +86,8 @@ defmodule RetWeb.HubChannelTest do
 
       Ret.HubInvite.revoke_invite(hub, hub_invite.hub_invite_sid)
 
-      {:error, %{reason: "join_denied"}} = join_hub(socket, hub, join_params_for_hub_invite(hub_invite))
+      {:error, %{reason: "join_denied"}} =
+        join_hub(socket, hub, join_params_for_hub_invite(hub_invite))
     end
 
     test "join is denied when joining with a mismatched invite", %{socket: socket} do
@@ -106,7 +114,8 @@ defmodule RetWeb.HubChannelTest do
       |> assert_reply(:ok, %{})
 
       # Join is still denied with invalid invite
-      {:error, %{reason: "join_denied"}} = join_hub(socket, hub, join_params_for_hub_invite_id("invalid_invite_id"))
+      {:error, %{reason: "join_denied"}} =
+        join_hub(socket, hub, join_params_for_hub_invite_id("invalid_invite_id"))
 
       # Join is still allowed with original invite
       {:ok, _context, _socket} = join_hub(socket, hub, join_params_for_hub_invite(hub_invite))
@@ -131,10 +140,12 @@ defmodule RetWeb.HubChannelTest do
       assert response_payload |> Map.keys() |> length === 0
 
       # Joining hub_two is still denied with invalid invite
-      {:error, %{reason: "join_denied"}} = join_hub(socket, hub_two, join_params_for_hub_invite_id("invalid_invite_id"))
+      {:error, %{reason: "join_denied"}} =
+        join_hub(socket, hub_two, join_params_for_hub_invite_id("invalid_invite_id"))
 
       # Joining hub_two still allowed with original invite
-      {:ok, _context, _socket} = join_hub(socket, hub_two, join_params_for_hub_invite(hub_two_invite))
+      {:ok, _context, _socket} =
+        join_hub(socket, hub_two, join_params_for_hub_invite(hub_two_invite))
     end
 
     test "revoke can be performed by hub creator", %{socket: socket} do

--- a/test/ret_web/channels/hub_channel_test.exs
+++ b/test/ret_web/channels/hub_channel_test.exs
@@ -110,8 +110,9 @@ defmodule RetWeb.HubChannelTest do
       {:ok, _context, socket} = join_hub(socket, hub, join_params_for_hub_invite(hub_invite))
 
       # Attempt to revoke invite
-      push(socket, "revoke_invite", %{hub_invite_id: hub_invite.hub_invite_sid})
-      |> assert_reply(:ok, %{})
+      assert_reply push(socket, "revoke_invite", %{hub_invite_id: hub_invite.hub_invite_sid}),
+                   :ok,
+                   %{}
 
       # Join is still denied with invalid invite
       {:error, %{reason: "join_denied"}} =
@@ -133,8 +134,9 @@ defmodule RetWeb.HubChannelTest do
 
       # Attempt to revoke invite associated with hub_two, using channel associated with hub_one
       %{payload: response_payload} =
-        push(socket, "revoke_invite", %{hub_invite_id: hub_two_invite.hub_invite_sid})
-        |> assert_reply(:ok, %{})
+        assert_reply push(socket, "revoke_invite", %{hub_invite_id: hub_two_invite.hub_invite_sid}),
+                     :ok,
+                     %{}
 
       # Response payload should be empty when a revoke is ignored
       assert response_payload |> Map.keys() |> length === 0

--- a/test/ret_web/controllers/api-internal/login_email_controller_test.exs
+++ b/test/ret_web/controllers/api-internal/login_email_controller_test.exs
@@ -8,24 +8,34 @@ defmodule RetWeb.ApiInternal.V1.LoginEmailControllerTest do
   @dashboard_access_key "test-key"
 
   setup_all do
-    merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{dashboard_access_key: @dashboard_access_key})
+    merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{
+      dashboard_access_key: @dashboard_access_key
+    })
 
     on_exit(fn ->
-      merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{dashboard_access_key: nil})
+      merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{
+        dashboard_access_key: nil
+      })
     end)
   end
 
   describe "PUT update" do
     test "validates the new email address", %{conn: conn} do
       Account.find_or_create_account_for_email("alice@reticulum.io")
-      assert %{status: 400} = put_change_email_for_login(conn, "not_an_email_address", "alice@reticulum.io")
+
+      assert %{status: 400} =
+               put_change_email_for_login(conn, "not_an_email_address", "alice@reticulum.io")
+
       refute Account.exists_for_email?("not_an_email_address")
       assert Account.exists_for_email?("alice@reticulum.io")
     end
 
     test "changes the account email", %{conn: conn} do
       Account.find_or_create_account_for_email("alice@reticulum.io")
-      assert %{status: 200} = put_change_email_for_login(conn, "alicia@anotherdomain.com", "alice@reticulum.io")
+
+      assert %{status: 200} =
+               put_change_email_for_login(conn, "alicia@anotherdomain.com", "alice@reticulum.io")
+
       refute Account.exists_for_email?("alice@reticulum.io")
       assert Account.exists_for_email?("alicia@anotherdomain.com")
     end
@@ -33,11 +43,14 @@ defmodule RetWeb.ApiInternal.V1.LoginEmailControllerTest do
     test "validates that the new email cannot already be in use", %{conn: conn} do
       Account.find_or_create_account_for_email("alice@reticulum.io")
       Account.find_or_create_account_for_email("bob@reticulum.io")
-      assert %{status: 409} = put_change_email_for_login(conn, "bob@reticulum.io", "alice@reticulum.io")
+
+      assert %{status: 409} =
+               put_change_email_for_login(conn, "bob@reticulum.io", "alice@reticulum.io")
     end
 
     test "validates that the old email is in use", %{conn: conn} do
-      assert %{status: 404} = put_change_email_for_login(conn, "bob@reticulum.io", "alice@reticulum.io")
+      assert %{status: 404} =
+               put_change_email_for_login(conn, "bob@reticulum.io", "alice@reticulum.io")
     end
 
     test "authenticates the request", %{conn: conn} do
@@ -58,6 +71,9 @@ defmodule RetWeb.ApiInternal.V1.LoginEmailControllerTest do
   defp put_change_email_for_login(conn, new_email, old_email) do
     conn
     |> put_req_header(@dashboard_access_header, @dashboard_access_key)
-    |> put("/api-internal/v1/change_email_for_login", %{"old_email" => old_email, "new_email" => new_email})
+    |> put("/api-internal/v1/change_email_for_login", %{
+      "old_email" => old_email,
+      "new_email" => new_email
+    })
   end
 end

--- a/test/ret_web/controllers/api-internal/rewrite_assets_controller_test.exs
+++ b/test/ret_web/controllers/api-internal/rewrite_assets_controller_test.exs
@@ -6,10 +6,14 @@ defmodule RetWeb.ApiInternal.V1.RewriteAssetsControllerTest do
   @dashboard_access_key "test-key"
 
   setup_all do
-    merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{dashboard_access_key: @dashboard_access_key})
+    merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{
+      dashboard_access_key: @dashboard_access_key
+    })
 
     on_exit(fn ->
-      Ret.TestHelpers.merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{dashboard_access_key: nil})
+      Ret.TestHelpers.merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{
+        dashboard_access_key: nil
+      })
     end)
   end
 
@@ -29,6 +33,9 @@ defmodule RetWeb.ApiInternal.V1.RewriteAssetsControllerTest do
   defp post_rewrite_assets(conn, new_domain, old_domain) do
     conn
     |> put_req_header(@dashboard_access_header, @dashboard_access_key)
-    |> post("/api-internal/v1/rewrite_assets", %{"old_domain" => old_domain, "new_domain" => new_domain})
+    |> post("/api-internal/v1/rewrite_assets", %{
+      "old_domain" => old_domain,
+      "new_domain" => new_domain
+    })
   end
 end

--- a/test/ret_web/controllers/api-internal/storage_controller_test.exs
+++ b/test/ret_web/controllers/api-internal/storage_controller_test.exs
@@ -6,10 +6,14 @@ defmodule RetWeb.ApiInternal.V1.StorageControllerTest do
   @dashboard_access_key "test-key"
 
   setup_all do
-    merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{dashboard_access_key: @dashboard_access_key})
+    merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{
+      dashboard_access_key: @dashboard_access_key
+    })
 
     on_exit(fn ->
-      Ret.TestHelpers.merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{dashboard_access_key: nil})
+      Ret.TestHelpers.merge_module_config(:ret, RetWeb.Plugs.DashboardHeaderAuthorization, %{
+        dashboard_access_key: nil
+      })
     end)
   end
 
@@ -45,7 +49,9 @@ defmodule RetWeb.ApiInternal.V1.StorageControllerTest do
   # Since we mainly care about testing the endpoint here, we use the cache to mock the usage value
   # and ensure that the endpoint returns it as expected.
   defp mock_storage_used(nil), do: Cachex.put(:storage_used, :storage_used, nil)
-  defp mock_storage_used(storage_used_mb), do: Cachex.put(:storage_used, :storage_used, storage_used_mb * 1024)
+
+  defp mock_storage_used(storage_used_mb),
+    do: Cachex.put(:storage_used, :storage_used, storage_used_mb * 1024)
 
   defp request_storage(conn, opts \\ [expected_status: 200]) do
     conn

--- a/test/ret_web/controllers/api/account_controller_test.exs
+++ b/test/ret_web/controllers/api/account_controller_test.exs
@@ -7,7 +7,10 @@ defmodule RetWeb.AccountControllerTest do
   setup %{conn: conn} do
     {:ok, admin_account: admin_account} = create_admin_account("test")
     {:ok, token, _params} = admin_account |> Ret.Guardian.encode_and_sign()
-    {:ok, account: admin_account, conn: conn |> Plug.Conn.put_req_header("authorization", "bearer: " <> token)}
+
+    {:ok,
+     account: admin_account,
+     conn: conn |> Plug.Conn.put_req_header("authorization", "bearer: " <> token)}
   end
 
   test "non-admins cannot create accounts", %{conn: conn} do
@@ -34,7 +37,10 @@ defmodule RetWeb.AccountControllerTest do
   end
 
   test "admins can create accounts with identities", %{conn: conn} do
-    req = conn |> api_v1_account_path(:create, %{data: %{email: "testapi@mozilla.com", name: "Test User"}})
+    req =
+      conn
+      |> api_v1_account_path(:create, %{data: %{email: "testapi@mozilla.com", name: "Test User"}})
+
     res = conn |> post(req) |> response(200) |> Poison.decode!()
 
     account = Account.account_for_email("testapi@mozilla.com")
@@ -73,7 +79,11 @@ defmodule RetWeb.AccountControllerTest do
     req =
       conn
       |> api_v1_account_path(:create, %{
-        data: [%{email: "testapi1@mozilla.com"}, %{email: "testapi2@mozilla.com"}, %{email: "invalidemail"}]
+        data: [
+          %{email: "testapi1@mozilla.com"},
+          %{email: "testapi2@mozilla.com"},
+          %{email: "invalidemail"}
+        ]
       })
 
     res = conn |> post(req) |> response(207) |> Poison.decode!()

--- a/test/ret_web/controllers/api/assets_controller_test.exs
+++ b/test/ret_web/controllers/api/assets_controller_test.exs
@@ -12,13 +12,19 @@ defmodule RetWeb.AssetsControllerTest do
     end)
   end
 
-  test "assets create 401's when not logged in", %{conn: conn, thumbnail_owned_file: thumbnail_owned_file} do
+  test "assets create 401's when not logged in", %{
+    conn: conn,
+    thumbnail_owned_file: thumbnail_owned_file
+  } do
     params = asset_create_params(thumbnail_owned_file, thumbnail_owned_file)
     conn |> post(api_v1_assets_path(conn, :create), params) |> response(401)
   end
 
   @tag :authenticated
-  test "assets create works when logged in", %{conn: conn, thumbnail_owned_file: thumbnail_owned_file} do
+  test "assets create works when logged in", %{
+    conn: conn,
+    thumbnail_owned_file: thumbnail_owned_file
+  } do
     # Asset file needs to be an image, video, or model so use the thumbnail_owned_file for both the asset and thumbnail
     params = asset_create_params(thumbnail_owned_file, thumbnail_owned_file)
 

--- a/test/ret_web/controllers/api/credentials_controller_test.exs
+++ b/test/ret_web/controllers/api/credentials_controller_test.exs
@@ -39,7 +39,10 @@ defmodule RetWeb.CredentialsControllerTest do
   defp create_credentials_for_another_account(conn, creator_account, account) do
     conn
     |> put_auth_header_for_account(creator_account)
-    |> post(credentials_path(conn, :create), params(valid_scopes(), :account) ++ [account_id: account.account_id])
+    |> post(
+      credentials_path(conn, :create),
+      params(valid_scopes(), :account) ++ [account_id: account.account_id]
+    )
   end
 
   test "Accounts must authenticate to access credentials API.", %{
@@ -157,7 +160,10 @@ defmodule RetWeb.CredentialsControllerTest do
     errors =
       conn
       |> put_auth_header_for_account(admin_account)
-      |> post(create, params([:not_a_valid_scope, :another_invalid_scope], :not_a_valid_subject_type))
+      |> post(
+        create,
+        params([:not_a_valid_scope, :another_invalid_scope], :not_a_valid_subject_type)
+      )
       |> json_response(400)
       |> Map.get("errors")
 

--- a/test/ret_web/controllers/api/hub_controller_test.exs
+++ b/test/ret_web/controllers/api/hub_controller_test.exs
@@ -134,7 +134,9 @@ defmodule RetWeb.HubControllerTest do
 
     %{"hubs" => hubs} =
       conn
-      |> update_hub(hub_id, %{member_permissions: %{spawn_and_move_media: true, pin_objects: false}})
+      |> update_hub(hub_id, %{
+        member_permissions: %{spawn_and_move_media: true, pin_objects: false}
+      })
       |> json_response(200)
 
     hub_response = Enum.at(hubs, 0)

--- a/test/ret_web/controllers/api/media_search_controller_test.exs
+++ b/test/ret_web/controllers/api/media_search_controller_test.exs
@@ -184,8 +184,18 @@ defmodule RetWeb.MediaSearchControllerTest do
 
     entries = resp["entries"]
     assert length(entries) == 2
-    assert length(Enum.filter(entries, fn e -> e["id"] == private_hub.hub_sid && e["type"] == "room" end)) == 1
-    assert length(Enum.filter(entries, fn e -> e["id"] == private_hub_2.hub_sid && e["type"] == "room" end)) == 1
+
+    assert length(
+             Enum.filter(entries, fn e ->
+               e["id"] == private_hub.hub_sid && e["type"] == "room"
+             end)
+           ) == 1
+
+    assert length(
+             Enum.filter(entries, fn e ->
+               e["id"] == private_hub_2.hub_sid && e["type"] == "room"
+             end)
+           ) == 1
   end
 
   test "Search for a user's own favorites should not return closed hubs", %{
@@ -220,10 +230,11 @@ defmodule RetWeb.MediaSearchControllerTest do
     assert entry["type"] == "room"
   end
 
-  test "Search for a user's own favorites should return an empty list if they have no favorites", %{
-    conn: conn,
-    account_3: account
-  } do
+  test "Search for a user's own favorites should return an empty list if they have no favorites",
+       %{
+         conn: conn,
+         account_3: account
+       } do
     resp =
       conn
       |> auth_with_account(account)

--- a/test/ret_web/controllers/api/project_assets_controller_test.exs
+++ b/test/ret_web/controllers/api/project_assets_controller_test.exs
@@ -21,12 +21,17 @@ defmodule RetWeb.ProjectAssetsControllerTest do
   end
 
   test "project assets index 401's when not logged in", %{conn: conn, project: project} do
-    conn |> get(api_v1_project_project_assets_path(conn, :index, project.project_sid)) |> response(401)
+    conn
+    |> get(api_v1_project_project_assets_path(conn, :index, project.project_sid))
+    |> response(401)
   end
 
   @tag :authenticated
   test "project assets index shows assets", %{conn: conn, project: project} do
-    response = conn |> get(api_v1_project_project_assets_path(conn, :index, project.project_sid)) |> json_response(200)
+    response =
+      conn
+      |> get(api_v1_project_project_assets_path(conn, :index, project.project_sid))
+      |> json_response(200)
 
     %{
       "assets" => [
@@ -55,7 +60,10 @@ defmodule RetWeb.ProjectAssetsControllerTest do
     thumbnail_owned_file: thumbnail_owned_file
   } do
     params = project_asset_create_or_update_params(thumbnail_owned_file, thumbnail_owned_file)
-    conn |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params) |> response(401)
+
+    conn
+    |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params)
+    |> response(401)
   end
 
   @tag :authenticated
@@ -67,7 +75,9 @@ defmodule RetWeb.ProjectAssetsControllerTest do
     params = %{"asset_id" => asset.asset_sid}
 
     response =
-      conn |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params) |> json_response(200)
+      conn
+      |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params)
+      |> json_response(200)
 
     %{"assets" => [%{"asset_id" => asset_id}]} = response
 
@@ -86,7 +96,9 @@ defmodule RetWeb.ProjectAssetsControllerTest do
     params = project_asset_create_or_update_params(thumbnail_owned_file, thumbnail_owned_file)
 
     response =
-      conn |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params) |> json_response(200)
+      conn
+      |> post(api_v1_project_project_assets_path(conn, :create, project.project_sid), params)
+      |> json_response(200)
 
     %{"assets" => [%{"asset_id" => asset_id}]} = response
 
@@ -95,12 +107,17 @@ defmodule RetWeb.ProjectAssetsControllerTest do
     assert created_asset.name == "Name"
   end
 
-  test "project assets delete 401's when not logged in", %{conn: conn, project_asset: project_asset} do
+  test "project assets delete 401's when not logged in", %{
+    conn: conn,
+    project_asset: project_asset
+  } do
     project = project_asset.project
     asset = project_asset.asset
 
     conn
-    |> delete(api_v1_project_project_assets_path(conn, :delete, project.project_sid, asset.asset_sid))
+    |> delete(
+      api_v1_project_project_assets_path(conn, :delete, project.project_sid, asset.asset_sid)
+    )
     |> response(401)
   end
 
@@ -110,12 +127,16 @@ defmodule RetWeb.ProjectAssetsControllerTest do
     asset = project_asset.asset
 
     conn
-    |> delete(api_v1_project_project_assets_path(conn, :delete, project.project_sid, asset.asset_sid))
+    |> delete(
+      api_v1_project_project_assets_path(conn, :delete, project.project_sid, asset.asset_sid)
+    )
     |> response(200)
 
     deleted_asset = Asset |> Repo.get_by(asset_sid: asset.asset_sid)
     deleted_project = Project |> Repo.get_by(project_sid: project.project_sid)
-    deleted_project_asset = ProjectAsset |> Repo.get_by(project_id: project.project_id, asset_id: asset.asset_id)
+
+    deleted_project_asset =
+      ProjectAsset |> Repo.get_by(project_id: project.project_id, asset_id: asset.asset_id)
 
     assert deleted_asset != nil
     assert deleted_project != nil

--- a/test/ret_web/controllers/api/projects_controller_test.exs
+++ b/test/ret_web/controllers/api/projects_controller_test.exs
@@ -49,7 +49,8 @@ defmodule RetWeb.ProjectsControllerTest do
 
   @tag :authenticated
   test "projects show works when logged in", %{conn: conn, project: project} do
-    response = conn |> get(api_v1_project_path(conn, :show, project.project_sid)) |> json_response(200)
+    response =
+      conn |> get(api_v1_project_path(conn, :show, project.project_sid)) |> json_response(200)
 
     %{
       "thumbnail_url" => thumbnail_url,
@@ -115,7 +116,9 @@ defmodule RetWeb.ProjectsControllerTest do
       }
     }
 
-    conn |> patch(api_v1_project_path(conn, :update, project.project_sid, params)) |> response(401)
+    conn
+    |> patch(api_v1_project_path(conn, :update, project.project_sid, params))
+    |> response(401)
   end
 
   @tag :authenticated
@@ -135,7 +138,10 @@ defmodule RetWeb.ProjectsControllerTest do
       }
     }
 
-    response = conn |> patch(api_v1_project_path(conn, :update, project.project_sid, params)) |> json_response(200)
+    response =
+      conn
+      |> patch(api_v1_project_path(conn, :update, project.project_sid, params))
+      |> json_response(200)
 
     %{
       "thumbnail_url" => thumbnail_url,
@@ -176,11 +182,15 @@ defmodule RetWeb.ProjectsControllerTest do
     assert project.scene == nil
 
     response_project =
-      conn |> post(api_v1_project_project_path(conn, :publish, project.project_sid, params)) |> json_response(200)
+      conn
+      |> post(api_v1_project_project_path(conn, :publish, project.project_sid, params))
+      |> json_response(200)
 
     new_scene_sid = response_project["scene"]["scene_id"]
 
-    updated_project = Project |> Repo.get_by(project_sid: project.project_sid) |> Repo.preload([:scene])
+    updated_project =
+      Project |> Repo.get_by(project_sid: project.project_sid) |> Repo.preload([:scene])
+
     assert updated_project.scene.scene_sid == new_scene_sid
     assert response_project["name"] == "Test Project"
     assert response_project["scene"]["name"] == "Test Publish"
@@ -189,7 +199,9 @@ defmodule RetWeb.ProjectsControllerTest do
     params = params |> put_in([:scene, :name], "Test Republish")
 
     response_project =
-      conn |> post(api_v1_project_project_path(conn, :publish, project.project_sid, params)) |> json_response(200)
+      conn
+      |> post(api_v1_project_project_path(conn, :publish, project.project_sid, params))
+      |> json_response(200)
 
     assert response_project["scene"]["name"] == "Test Republish"
     assert response_project["scene"]["scene_id"] == new_scene_sid

--- a/test/ret_web/controllers/api/scene_controller_test.exs
+++ b/test/ret_web/controllers/api/scene_controller_test.exs
@@ -55,7 +55,11 @@ defmodule RetWeb.SceneControllerTest do
     assert updated_scene.description == "New Description"
   end
 
-  test "scene update disallowed for different user", %{conn: conn, owned_file: owned_file, scene: scene} do
+  test "scene update disallowed for different user", %{
+    conn: conn,
+    owned_file: owned_file,
+    scene: scene
+  } do
     {:ok, token, _claims} =
       "test2@mozilla.com"
       |> Ret.Account.find_or_create_account_for_email()

--- a/test/ret_web/controllers/file_controller_test.exs
+++ b/test/ret_web/controllers/file_controller_test.exs
@@ -4,12 +4,21 @@ defmodule RetWeb.FileControllerTest do
 
   test "Uploaded HTML files are served as plain text", %{conn: conn} do
     uuid = store_file(content: "hello", content_type: "text/html", token: "secret")
-    conn |> assert_file_content_type(expected_content_type: "text/plain", uuid: uuid, token: "secret")
+
+    conn
+    |> assert_file_content_type(expected_content_type: "text/plain", uuid: uuid, token: "secret")
   end
 
   test "Uploaded JavaScript files are served as plain text", %{conn: conn} do
-    uuid = store_file(content: "alert('hello')", content_type: "application/javascript", token: "secret")
-    conn |> assert_file_content_type(expected_content_type: "text/plain", uuid: uuid, token: "secret")
+    uuid =
+      store_file(
+        content: "alert('hello')",
+        content_type: "application/javascript",
+        token: "secret"
+      )
+
+    conn
+    |> assert_file_content_type(expected_content_type: "text/plain", uuid: uuid, token: "secret")
   end
 
   test "Files are served with stricter CSP", %{conn: conn} do
@@ -29,7 +38,11 @@ defmodule RetWeb.FileControllerTest do
     uuid
   end
 
-  defp assert_file_content_type(conn, expected_content_type: expected_content_type, uuid: uuid, token: token) do
+  defp assert_file_content_type(conn,
+         expected_content_type: expected_content_type,
+         uuid: uuid,
+         token: token
+       ) do
     req = conn |> file_path(:show, uuid, token: token)
     storage_host = Application.get_env(:ret, Ret.Storage)[:host]
     resp = conn |> get("#{storage_host}#{req}")

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,5 +1,17 @@
 defmodule Ret.TestHelpers do
-  alias Ret.{Storage, Project, Account, Asset, ProjectAsset, Scene, SceneListing, Repo, Hub, Avatar, AvatarListing}
+  alias Ret.{
+    Account,
+    Asset,
+    Avatar,
+    AvatarListing,
+    Hub,
+    Project,
+    ProjectAsset,
+    Repo,
+    Scene,
+    SceneListing,
+    Storage
+  }
 
   def generate_temp_owned_file(account) do
     temp_file = generate_temp_file("test")
@@ -71,7 +83,9 @@ defmodule Ret.TestHelpers do
   end
 
   def create_scene(%Account{} = account) do
-    {:ok, scene: scene} = create_scene(%{account: account, owned_file: generate_temp_owned_file(account)})
+    {:ok, scene: scene} =
+      create_scene(%{account: account, owned_file: generate_temp_owned_file(account)})
+
     scene
   end
 
@@ -85,7 +99,10 @@ defmodule Ret.TestHelpers do
       })
       |> Repo.insert_or_update()
 
-    scene = scene |> Repo.preload([:model_owned_file, :screenshot_owned_file, :scene_owned_file, :account])
+    scene =
+      scene
+      |> Repo.preload([:model_owned_file, :screenshot_owned_file, :scene_owned_file, :account])
+
     {:ok, scene: scene}
   end
 
@@ -156,7 +173,9 @@ defmodule Ret.TestHelpers do
 
   def create_project_owned_file(%{account: account}) do
     project_file = Path.expand("../fixtures/spoke-project.json", __DIR__)
-    {:ok, project_owned_file: generate_fixture_owned_file(account, project_file, "application/json")}
+
+    {:ok,
+     project_owned_file: generate_fixture_owned_file(account, project_file, "application/json")}
   end
 
   def create_thumbnail_owned_file(%{account: account}) do
@@ -180,7 +199,9 @@ defmodule Ret.TestHelpers do
       })
       |> Repo.insert_or_update()
 
-    project = project |> Repo.preload([:project_owned_file, :thumbnail_owned_file, :created_by_account])
+    project =
+      project |> Repo.preload([:project_owned_file, :thumbnail_owned_file, :created_by_account])
+
     {:ok, project: project}
   end
 

--- a/test/web_push_subscription_test.exs
+++ b/test/web_push_subscription_test.exs
@@ -4,7 +4,10 @@ defmodule Ret.WebPushSubscriptionTest do
 
   alias Ret.{Hub, WebPushSubscription}
 
-  @stub_subscription %{"endpoint" => "endpoint", "keys" => %{"p256dh" => "p256dh", "auth" => "auth"}}
+  @stub_subscription %{
+    "endpoint" => "endpoint",
+    "keys" => %{"p256dh" => "p256dh", "auth" => "auth"}
+  }
 
   setup [:create_account, :create_owned_file, :create_scene, :create_hub]
 
@@ -15,7 +18,8 @@ defmodule Ret.WebPushSubscriptionTest do
 
     assert subscription.web_push_subscription_id != nil
 
-    %WebPushSubscription{endpoint: "endpoint", p256dh: "p256dh", auth: "auth", hub_id: ^hub_id} = subscription
+    %WebPushSubscription{endpoint: "endpoint", p256dh: "p256dh", auth: "auth", hub_id: ^hub_id} =
+      subscription
   end
 
   test "re-use existing subscription", %{hub: hub} do
@@ -29,7 +33,10 @@ defmodule Ret.WebPushSubscriptionTest do
     subscription = WebPushSubscription.subscribe_to_hub(hub, @stub_subscription)
 
     subscription_other =
-      WebPushSubscription.subscribe_to_hub(hub, @stub_subscription |> Map.put("endpoint", "endpoint2"))
+      WebPushSubscription.subscribe_to_hub(
+        hub,
+        @stub_subscription |> Map.put("endpoint", "endpoint2")
+      )
 
     assert subscription.web_push_subscription_id != subscription_other.web_push_subscription_id
 
@@ -37,7 +44,10 @@ defmodule Ret.WebPushSubscriptionTest do
     %WebPushSubscription{endpoint: "endpoint2"} = subscription_other
   end
 
-  test "create a new subscription if hub is varied", %{scene: scene, hub: %Hub{hub_id: hub_id} = hub} do
+  test "create a new subscription if hub is varied", %{
+    scene: scene,
+    hub: %Hub{hub_id: hub_id} = hub
+  } do
     {:ok, hub: hub_other} = create_hub(%{scene: scene})
     %Hub{hub_id: other_hub_id} = hub_other
 

--- a/test/web_push_subscription_test.exs
+++ b/test/web_push_subscription_test.exs
@@ -77,9 +77,11 @@ defmodule Ret.WebPushSubscriptionTest do
     WebPushSubscription.unsubscribe_from_hub(hub, @stub_subscription)
 
     existing =
-      WebPushSubscription
-      |> where([t], t.endpoint == "endpoint" and t.hub_id == ^hub_id)
-      |> Repo.one()
+      Repo.one(
+        from sub in WebPushSubscription,
+          where: sub.endpoint == "endpoint",
+          where: sub.hub_id == ^hub_id
+      )
 
     assert existing == nil
   end


### PR DESCRIPTION
Why
---

When I move between Elixir projects, I shouldn’t have to adjust the line length in my editor.  Though the `:line_length` `mix format` option exists, most projects forgo it for the aforementioned reason.

Ecto provides a DSL for building schemas, queries, and migrations. The formatter doesn’t know about this DSL and thus formats the keywords as ordinary function/macro calls.

What
----

* Use default formatter line-length
* Import Ecto formatter config
* Import Ecto SQL formatter config

Note
----

While there are technically a lot of line changes, the fundamental change is a mere two lines in [`.formatter.exs`](https://github.com/mozilla/reticulum/pull/645/files#diff-aad92a030ac915c80a2e0d0204d240fc952893bc87b372dc1b6d485609f27260).  Everything else is just application of the formatting rules.