### PR TITLE
Fix admin project deletion

### DIFF
--- a/priv/repo/migrations/20230104213552_grant_admin_delete_on_projects.exs
+++ b/priv/repo/migrations/20230104213552_grant_admin_delete_on_projects.exs
@@ -1,0 +1,8 @@
+defmodule Ret.Repo.Migrations.GrantAdminDeleteOnProjects do
+  use Ecto.Migration
+
+  def change do
+    execute "GRANT DELETE ON ret0_admin.projects TO ret_admin",
+            "REVOKE DELETE ON ret0_admin.projects TO ret_admin"
+  end
+end


### PR DESCRIPTION
Why
---
When I attempt to delete a project from the admin panel, a 403 status is returned, the project remains, and I am redirected to the login page

What
----
Create a database migration to grant admin permissions to `ret_admin` to delete records from the `ret0_admin.projects` view