### PR TITLE
Fix missing stats partitions

### DIFF
--- a/lib/ret/repo/migration_helpers.ex
+++ b/lib/ret/repo/migration_helpers.ex
@@ -1,0 +1,11 @@
+defmodule Ret.Repo.MigrationHelpers do
+  @type month_int :: 1..12
+  @type year_int :: non_neg_integer
+
+  @spec next_month(year_int, month_int) :: %{y: year_int, m: month_int}
+  def next_month(y, 12) when y >= 0,
+    do: %{y: y + 1, m: 1}
+
+  def next_month(y, m) when y >= 0 and m in 1..11,
+    do: %{y: y, m: m + 1}
+end

--- a/priv/repo/migrations/20230105144400_create_node_stats_partitions_through_2030.exs
+++ b/priv/repo/migrations/20230105144400_create_node_stats_partitions_through_2030.exs
@@ -1,0 +1,28 @@
+defmodule Ret.Repo.Migrations.CreateNodeStatsPartitionsThrough2030 do
+  use Ecto.Migration
+
+  import Ret.Repo.MigrationHelpers, only: [next_month: 2]
+
+  @max_year 2030
+
+  def up do
+    for y <- 2023..@max_year,
+        m <- 1..12 do
+      next_month = next_month(y, m)
+
+      execute """
+      CREATE TABLE IF NOT EXISTS ret0.node_stats_y#{y}_m#{m} PARTITION OF ret0.node_stats
+        FOR VALUES FROM ('#{y}-#{m}-01') TO ('#{next_month.y}-#{next_month.m}-01')
+      """
+    end
+  end
+
+  def down do
+    for y <- 2023..@max_year,
+        m <- 1..12 do
+      execute """
+      DROP TABLE ret0.node_stats_y#{y}_m#{m}
+      """
+    end
+  end
+end

--- a/priv/repo/migrations/20230105144433_create_session_stats_partitions_through_2030.exs
+++ b/priv/repo/migrations/20230105144433_create_session_stats_partitions_through_2030.exs
@@ -1,0 +1,28 @@
+defmodule Ret.Repo.Migrations.CreateSessionStatsPartitionsThrough2030 do
+  use Ecto.Migration
+
+  import Ret.Repo.MigrationHelpers, only: [next_month: 2]
+
+  @max_year 2030
+
+  def up do
+    for y <- 2023..@max_year,
+        m <- 1..12 do
+      next_month = next_month(y, m)
+
+      execute """
+      CREATE TABLE IF NOT EXISTS ret0.session_stats_y#{y}_m#{m} PARTITION OF ret0.session_stats
+        FOR VALUES FROM ('#{y}-#{m}-01') TO ('#{next_month.y}-#{next_month.m}-01')
+      """
+    end
+  end
+
+  def down do
+    for y <- 2023..@max_year,
+        m <- 1..12 do
+      execute """
+      DROP TABLE ret0.session_stats_y#{y}_m#{m}
+      """
+    end
+  end
+end

--- a/test/ret/repo/migration_helpers_test.exs
+++ b/test/ret/repo/migration_helpers_test.exs
@@ -1,0 +1,25 @@
+defmodule Ret.Repo.MigrationHelpersTest do
+  use ExUnit.Case, async: true
+
+  import Ret.Repo.MigrationHelpers
+
+  describe "next_month/2" do
+    setup do
+      %{y: 1234}
+    end
+
+    test "when the month is December", %{y: y} do
+      result = next_month(y, 12)
+      assert y + 1 === result.y
+      assert 1 === result.m
+    end
+
+    test "when the month is not December", %{y: y} do
+      for m <- 1..11 do
+        result = next_month(y, m)
+        assert y === result.y
+        assert m + 1 === result.m
+      end
+    end
+  end
+end

--- a/test/ret/schema_test.exs
+++ b/test/ret/schema_test.exs
@@ -16,7 +16,7 @@ defmodule Ret.SchemaTest do
 
     property "with a non-struct map" do
       check all map <-
-                  string(:printable, max_length: 3)
+                  string(:printable, max_length: 4)
                   |> map(&String.to_atom/1)
                   |> map_of(nil) do
         assert false === Schema.is_schema(map)


### PR DESCRIPTION
Why
---
The `node_stats` table was only partitioned through 2022.  While the `session_stats` table was partitioned through 2030, an earlier released version of the migration only partitioned the table through 2022.

What
----
* Create migration to create `node_stats` partitions through 2030
* Create migration to create `session_stats` partitions through 2030
* Fix `StreamData.TooManyDuplicatesError` intermittent test failure

Note
----
If any partitions have already been created, they will be skipped during partition creation