### PR TITLE
Adding new workflow to move branch pointers for post release chore. 

### DIFF
--- a/.github/workflows/hc-pkgcaller.yml
+++ b/.github/workflows/hc-pkgcaller.yml
@@ -1,0 +1,11 @@
+name: hc-pkg
+on:
+  workflow_dispatch: 
+    
+jobs:
+  hcpkgrelease:
+    uses: mozilla/hubs-ops/.github/workflows/HcPkgPreReleaseGitops.yaml@master
+    with:
+      main: master
+      releasing: polycosm
+      qaTestBranch: qa-test


### PR DESCRIPTION
This adds a workflow to move the branch pointer and tag the new releases. 