### PR TITLE
Fix 301 responses

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,7 @@ config :ret, Ret.SessionLockRepo,
 
 config :ret, RetWeb.Plugs.RateLimit, throttle?: true
 
-config :ret, RetWeb.Router, secure?: false
+config :ret, RetWeb.Router, canonicalize?: false
 
 config :peerage, log_results: false
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -161,4 +161,4 @@ config :ret, Ret.StatsJob, node_stats_enabled: false, node_gauges_enabled: false
 # Default repo check and page check to off so for polycosm hosts database + s3 hits can go idle
 config :ret, RetWeb.HealthController, check_repo: false
 
-config :ret, RetWeb.Router, secure?: true
+config :ret, RetWeb.Router, canonicalize?: true


### PR DESCRIPTION
Why
---

Reticulum is not hosted behind TLS in production, yet we are doing an SSL rewrite using X-Forwarded-Proto header

What
----
Remove SSL rewrite