### PR TITLE
Fix UndefinedFunctionError on clustered instances

### DIFF
--- a/TurkeyDockerfile
+++ b/TurkeyDockerfile
@@ -1,18 +1,22 @@
-FROM elixir:1.14-alpine as builder
+ARG ALPINE_VERSION=3.16.2
+ARG ELIXIR_VERSION=1.14.3
+ARG ERLANG_VERSION=23.3.4.18
+
+FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-alpine-${ALPINE_VERSION} AS builder
 RUN apk add --no-cache nodejs yarn git build-base
-copy . .
+COPY . .
 RUN mix local.hex --force && mix local.rebar --force && mix deps.get
-run MIX_ENV=turkey mix release
+RUN MIX_ENV=turkey mix release
 
-from alpine/openssl as certr
-workdir certs
-run openssl req -x509 -newkey rsa:2048 -sha256 -days 36500 -nodes -keyout key.pem -out cert.pem -subj '/CN=ret' && cp cert.pem cacert.pem
+FROM alpine/openssl AS certr
+WORKDIR certs
+RUN openssl req -x509 -newkey rsa:2048 -sha256 -days 36500 -nodes -keyout key.pem -out cert.pem -subj '/CN=ret' && cp cert.pem cacert.pem
 
-FROM alpine:3.16
-run mkdir -p /storage && chmod 777 /storage
-workdir ret
-copy --from=builder /_build/turkey/rel/ret/ .
-copy --from=certr /certs .
+FROM alpine:${ALPINE_VERSION}
+RUN mkdir -p /storage && chmod 777 /storage
+WORKDIR ret
+COPY --from=builder /_build/turkey/rel/ret/ .
+COPY --from=certr /certs .
 RUN apk update && apk add --no-cache bash openssl-dev=1.1.1s-r0 openssl=1.1.1s-r0 jq libstdc++ coreutils
-copy scripts/docker/run.sh /run.sh
-cmd bash /run.sh
+COPY scripts/docker/run.sh /run.sh
+CMD bash /run.sh

--- a/TurkeyDockerfile
+++ b/TurkeyDockerfile
@@ -17,6 +17,6 @@ RUN mkdir -p /storage && chmod 777 /storage
 WORKDIR ret
 COPY --from=builder /_build/turkey/rel/ret/ .
 COPY --from=certr /certs .
-RUN apk update && apk add --no-cache bash openssl-dev=1.1.1s-r0 openssl=1.1.1s-r0 jq libstdc++ coreutils
+RUN apk update && apk add --no-cache bash openssl-dev openssl jq libstdc++ coreutils
 COPY scripts/docker/run.sh /run.sh
 CMD bash /run.sh


### PR DESCRIPTION
Why
---

The Elixir upgrade was only meant to upgrade the Elixir version and not the Erlang version.  When the Elixir version was bumped for clustered instances, the Erlang version was implicitly bumped.  This led to `UndefinedFunctionError` exceptions being raised for functions that were fully deprecated in OTP 24.

What
----
* Declare the Erlang version
* Declare the Alpine version
* Declare the precise Elixir version