### PR TITLE
update is_cors_proxy_url check to enable cors_proxy when hosted behind proxy

### DIFF
--- a/lib/ret_web/controllers/api/v1/media_controller.ex
+++ b/lib/ret_web/controllers/api/v1/media_controller.ex
@@ -2,7 +2,6 @@ defmodule RetWeb.Api.V1.MediaController do
   use RetWeb, :controller
   use Retry
   alias Ret.Statix
-  require Logger
 
   def create(conn, %{"media" => %{"url" => url, "quality" => quality}, "version" => version}),
     do: resolve_and_render(conn, url, version, String.to_atom(quality))
@@ -205,7 +204,6 @@ defmodule RetWeb.Api.V1.MediaController do
   # This is an unexpected error response from Cachex
   defp render_resolved_media_or_error(conn, {:error, _reason}) do
     Statix.increment("ret.media_resolver.unknown_cachex_error")
-    Logger.warning(Process.info(self(), :current_stacktrace) |> elem(1))
     send_resp(conn, 500, "An unexpected (Cachex)error occurred during media resolution.")
   end
 
@@ -213,7 +211,6 @@ defmodule RetWeb.Api.V1.MediaController do
   defp render_resolved_media_or_error(conn, _) do
     # We do not expect this code to run, so if it happens, something went wrong
     Statix.increment("ret.media_resolver.unknown_error")
-    Logger.warning(Process.info(self(), :current_stacktrace) |> elem(1))
     send_resp(conn, 500, "An unexpected error occurred during media resolution.")
   end
 

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -674,6 +674,8 @@ defmodule RetWeb.PageController do
     resolved_ip = HttpUtils.resolve_ip(host)
 
     if HttpUtils.internal_ip?(resolved_ip) do
+      IO.inspect(resolved_ip)
+      IO.inspect(conn)
       conn |> send_resp(401, "Bad request.")
     else
       # We want to ensure that the URL we request hits the same IP that we verified above,
@@ -691,6 +693,7 @@ defmodule RetWeb.PageController do
           cors_port == conn.port
         
       IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
+      IO.inspect(conn)
           
       if is_cors_proxy_url do
         allowed_origins =

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -428,7 +428,13 @@ defmodule RetWeb.PageController do
   end
 
   def render_hub_content(conn, nil, _) do
-    conn |> send_resp(200, "Hub is not configured properly. (Homepage Room ID not valid.) Please contact your Hub administrator.")
+    user_agent = get_req_header(conn, "user-agent")
+    IO.puts("user_agent#{user_agent}")
+    if contains?(user_agent, "kube-probe") do
+      send_resp(conn, 200, "")
+    else
+      send_resp(conn, 404, "bad Room ID")
+    end
   end
 
   def render_hub_content(conn, hub, "objects.gltf") do

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -674,8 +674,6 @@ defmodule RetWeb.PageController do
     resolved_ip = HttpUtils.resolve_ip(host)
 
     if HttpUtils.internal_ip?(resolved_ip) do
-      IO.inspect(resolved_ip)
-      IO.inspect(conn)
       conn |> send_resp(401, "Bad request.")
     else
       # We want to ensure that the URL we request hits the same IP that we verified above,
@@ -693,7 +691,8 @@ defmodule RetWeb.PageController do
           cors_port == conn.port
         
       IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
-      IO.puts("conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")
+      IO.puts("conn.scheme: #{conn.scheme}, conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")
+      IO.puts(IO.inspect(conn))
       
       if is_cors_proxy_url do
         allowed_origins =

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -687,12 +687,11 @@ defmodule RetWeb.PageController do
         [:scheme, :port, :host] |> Enum.map(&Keyword.get(cors_proxy_url, &1))
 
       is_cors_proxy_url =
-        cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host &&
-          cors_port == conn.port
-        
-      IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
-      IO.puts("conn.scheme: #{conn.scheme}, conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")
-      IO.puts(IO.inspect(conn))
+        if System.get_env("TURKEY_MODE") do
+          cors_host == conn.host && cors_scheme == get_req_header(conn, "x-forwarded-proto")
+        else
+          cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host && cors_port == conn.port
+        end
       
       if is_cors_proxy_url do
         allowed_origins =

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -691,7 +691,6 @@ defmodule RetWeb.PageController do
           cors_port == conn.port
         
       IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
-      IO.puts("conn.scheme: #{Atom.to_string(conn.scheme)}, conn.host: #{conn.host}, conn.port: #{onn.port}")
           
       if is_cors_proxy_url do
         allowed_origins =

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -688,14 +688,14 @@ defmodule RetWeb.PageController do
 
       is_cors_proxy_url =
         if System.get_env("TURKEY_MODE") do
-          cors_host == conn.host && cors_scheme == get_req_header(conn, "x-forwarded-proto")
+          IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
+          IO.puts("conn.scheme: #{get_req_header(conn, "x-forwarded-proto")}, conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")            
+          conn_scheme = get_req_header(conn, "x-forwarded-proto") |> Enum.at(0)
+          cors_host == conn.host && cors_scheme == conn_scheme
         else
           cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host && cors_port == conn.port
         end
       
-      IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
-      IO.puts("conn.scheme: #{get_req_header(conn, "x-forwarded-proto")}, conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")
-        
         
       if is_cors_proxy_url do
         allowed_origins =

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -693,6 +693,10 @@ defmodule RetWeb.PageController do
           cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host && cors_port == conn.port
         end
       
+      IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
+      IO.puts("conn.scheme: #{get_req_header(conn, "x-forwarded-proto")}, conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")
+        
+        
       if is_cors_proxy_url do
         allowed_origins =
           Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -689,13 +689,14 @@ defmodule RetWeb.PageController do
       is_cors_proxy_url =
         if System.get_env("TURKEY_MODE") do
           IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
-          IO.puts("conn.scheme: #{get_req_header(conn, "x-forwarded-proto")}, conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")            
+          IO.puts("conn.scheme: #{get_req_header(conn, "x-forwarded-proto")}, conn.host: #{conn.host}, conn.port: #{conn.port}")            
           conn_scheme = get_req_header(conn, "x-forwarded-proto") |> Enum.at(0)
           cors_host == conn.host && cors_scheme == conn_scheme
         else
           cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host && cors_port == conn.port
         end
-      
+      IO.puts("is_cors_proxy_url: #{is_cors_proxy_url}")            
+
         
       if is_cors_proxy_url do
         allowed_origins =

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -689,7 +689,10 @@ defmodule RetWeb.PageController do
       is_cors_proxy_url =
         cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host &&
           cors_port == conn.port
-
+        
+      IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
+      IO.puts("conn.scheme: #{Atom.to_string(conn.scheme)}, conn.host: #{conn.host}, conn.port: #{onn.port}")
+          
       if is_cors_proxy_url do
         allowed_origins =
           Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -693,8 +693,8 @@ defmodule RetWeb.PageController do
           cors_port == conn.port
         
       IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
-      IO.inspect(conn)
-          
+      IO.puts("conn.host: #{conn.host}, conn.port: #{conn.port}, is_cors_proxy_url: #{is_cors_proxy_url}")
+      
       if is_cors_proxy_url do
         allowed_origins =
           Application.get_env(:ret, RetWeb.Endpoint)[:allowed_origins] |> String.split(",")

--- a/lib/ret_web/controllers/page_controller.ex
+++ b/lib/ret_web/controllers/page_controller.ex
@@ -687,11 +687,8 @@ defmodule RetWeb.PageController do
         [:scheme, :port, :host] |> Enum.map(&Keyword.get(cors_proxy_url, &1))
 
       is_cors_proxy_url =
-        if System.get_env("TURKEY_MODE") do
-          IO.puts("cors_scheme: #{cors_scheme}, cors_host: #{cors_host}, cors_port: #{cors_port}")
-          IO.puts("conn.scheme: #{get_req_header(conn, "x-forwarded-proto")}, conn.host: #{conn.host}, conn.port: #{conn.port}")            
-          conn_scheme = get_req_header(conn, "x-forwarded-proto") |> Enum.at(0)
-          cors_host == conn.host && cors_scheme == conn_scheme
+        if System.get_env("TURKEY_MODE") do          
+          cors_host == conn.host && cors_scheme == get_req_header(conn, "x-forwarded-proto") |> Enum.at(0)
         else
           cors_scheme == Atom.to_string(conn.scheme) && cors_host == conn.host && cors_port == conn.port
         end


### PR DESCRIPTION
problem:
in turkey arch, reticulum is hosted behind ingress controller.
the ingress controller terminates TLS connection for reticulum, so the connection observed by reticulum is http instead of https, this will fail the is_cors_proxy_url check

solution:
- TURKEY_MODE switch
- uses the "de-facto standard" x-forwarded-proto header set at ingress to determine
- no change on host name check
- skip port# check