### PR TITLE
Add missing case for failed resolution from youtube-dl

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -233,6 +233,7 @@ defmodule Ret.MediaResolver do
         {:error, body}
 
       :error ->
+        IO.inspect("Failed to resolve via youtube-dl")
         {:error, "Failed to resolve via youtube-dl"}
     end
   end

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -231,6 +231,9 @@ defmodule Ret.MediaResolver do
 
       %HTTPoison.Response{body: body} ->
         {:error, body}
+
+      :error ->
+        {:error, "Failed to resolve via youtube-dl"}
     end
   end
 

--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -233,7 +233,6 @@ defmodule Ret.MediaResolver do
         {:error, body}
 
       :error ->
-        IO.inspect("Failed to resolve via youtube-dl")
         {:error, "Failed to resolve via youtube-dl"}
     end
   end


### PR DESCRIPTION
If `retry_get_until_valid_ytdl_response` fails, it seems to return `:error`. This adds a case clause to catch this possibility so that execution can continue normally after `fetch_ytdl_response`.