### PR TITLE
Reduce number of ytdl retries and expire faster

### DIFF
--- a/lib/ret/media_resolver.ex
+++ b/lib/ret/media_resolver.ex
@@ -232,6 +232,9 @@ defmodule Ret.MediaResolver do
       %HTTPoison.Response{body: body} ->
         {:error, body}
 
+      :timeout ->
+        {:error, "Failed to resolve via youtube-dl: timeout"}
+
       :error ->
         {:error, "Failed to resolve via youtube-dl"}
     end
@@ -590,7 +593,7 @@ defmodule Ret.MediaResolver do
   #
   # https://youtube-dl-api-server.readthedocs.io/en/latest/api.html#api-methods
   defp retry_get_until_valid_ytdl_response(url) do
-    retry with: exponential_backoff() |> randomize |> cap(1_000) |> expiry(10_000) do
+    retry with: constant_backoff(1_000) |> randomize() |> expiry(3_500) do
       Statix.increment("ret.media_resolver.ytdl.requests")
 
       case HTTPoison.get(url) do
@@ -598,6 +601,11 @@ defmodule Ret.MediaResolver do
         when status_code in @ytdl_valid_status_codes ->
           Statix.increment("ret.media_resolver.ytdl.ok")
           resp
+
+        {:error, %HTTPoison.Error{reason: :timeout, id: _}} ->
+          Statix.increment("ret.media_resolver.ytdl.errors")
+          # Return a different atom so that we do not retry
+          :timeout
 
         _ ->
           Statix.increment("ret.media_resolver.ytdl.errors")


### PR DESCRIPTION
Reduce the number of attempts to fetch a URL from ytdl, and expire the retry loop faster.

If ytdl is returning some unexpected error that causes us to retry, then we might be making more requests than is necessary. This protects against that case.

**edit**
I'm not sure that this PR meaningfully improves the situation. I need to measure whether resolving media causes many retries or not. If what's _actually_ happening is that media resolution hangs until the 7 or 15 second timeout, then this change is not helpful or necessary.

