### PR TITLE
Prefer stale dialog pod data to invalid results

### DIFF
--- a/lib/ret/load_balancing/janus_load_status.ex
+++ b/lib/ret/load_balancing/janus_load_status.ex
@@ -10,15 +10,14 @@ defmodule Ret.JanusLoadStatus do
       if module_config(:janus_service_name) == "" do
         {:ok, [{:host_to_ccu, [{module_config(:default_janus_host), 0}]}]}
       else
-        with pods when pods != [] <- get_dialog_pods() do
+        pods = get_dialog_pods()
+
+        if length(pods) > 0 do
           {:ok, [{:host_to_ccu, pods}]}
         else
-          _ ->
-            Logger.warning(
-              "falling back to default_janus_host because get_dialog_pods() returned []"
-            )
-
-            {:ok, [{:host_to_ccu, [{module_config(:default_janus_host), 0}]}]}
+          # get_dialog_pods/0 can fail to find hosts for reasons we don't fully understand
+          # If this happens, don't update the cache.
+          :ignore
         end
       end
     else


### PR DESCRIPTION
We have observed get_dialog_pods/0 fail to discover dialog nodes within the cluster for reasons we don't yet fully understand. In the meantime, the simplest "fix" is to prefer stale cache data instead of overwrite it.

The :ignore atom is meant to tell Cachex not to update the cache.

Since this warmer runs every 15 seconds, we think an occasional intermittent failure will not cause major issues.