### PR TITLE
Broadcast host_changed events when hub.host changes

### DIFF
--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -668,6 +668,18 @@ defmodule Ret.Hub do
     end
   end
 
+  def test_change_host(hub) do
+    host = RoomAssigner.get_available_host(hub.host)
+
+    hub |> changeset_for_new_host(host) |> Repo.update!()
+
+    RetWeb.Endpoint.broadcast("hub:" <> hub.hub_sid, "host_changed", %{
+      host: host,
+      port: Hub.janus_port(),
+      turn: Hub.generate_turn_info()
+    })
+  end
+
   # Remove the host entry from any rooms that are older than a day old and have no presence
   def vacuum_hosts do
     Ret.Locking.exec_if_lockable(:hub_vacuum_hosts, fn ->

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -656,6 +656,12 @@ defmodule Ret.Hub do
 
       if host && host != hub.host do
         hub |> changeset_for_new_host(host) |> Repo.update!()
+
+        RetWeb.Endpoint.broadcast("hub:" <> hub.hub_sid, "host_changed", %{
+          host: host,
+          port: Hub.janus_port(),
+          turn: Hub.generate_turn_info()
+        })
       else
         hub
       end

--- a/lib/ret/hub.ex
+++ b/lib/ret/hub.ex
@@ -668,18 +668,6 @@ defmodule Ret.Hub do
     end
   end
 
-  def test_change_host(hub) do
-    host = RoomAssigner.get_available_host(hub.host)
-
-    hub |> changeset_for_new_host(host) |> Repo.update!()
-
-    RetWeb.Endpoint.broadcast("hub:" <> hub.hub_sid, "host_changed", %{
-      host: host,
-      port: Hub.janus_port(),
-      turn: Hub.generate_turn_info()
-    })
-  end
-
   # Remove the host entry from any rooms that are older than a day old and have no presence
   def vacuum_hosts do
     Ret.Locking.exec_if_lockable(:hub_vacuum_hosts, fn ->

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -712,11 +712,6 @@ defmodule RetWeb.HubChannel do
     end
   end
 
-  def handle_in("test_change_host", _payload, socket) do
-    Hub.test_change_host(hub_for_socket(socket))
-    {:noreply, socket}
-  end
-
   def handle_in(_message, _payload, socket) do
     {:noreply, socket}
   end

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -834,6 +834,11 @@ defmodule RetWeb.HubChannel do
     {:noreply, socket}
   end
 
+  def handle_out("host_changed" = event, payload, socket) do
+    push(socket, event, payload)
+    {:noreply, socket}
+  end
+
   defp maybe_push_naf(
          socket,
          event,

--- a/lib/ret_web/channels/hub_channel.ex
+++ b/lib/ret_web/channels/hub_channel.ex
@@ -712,6 +712,11 @@ defmodule RetWeb.HubChannel do
     end
   end
 
+  def handle_in("test_change_host", _payload, socket) do
+    Hub.test_change_host(hub_for_socket(socket))
+    {:noreply, socket}
+  end
+
   def handle_in(_message, _payload, socket) do
     {:noreply, socket}
   end


### PR DESCRIPTION
If a client causes a room's `host` to change, broadcast the change so that other clients in the room are notified of this change and can migrate their connections to the new dialog host.

https://github.com/mozilla/hubs/pull/5975