### PR TITLE
Detects non-referred files

### DIFF
--- a/lib/ret/non_referred_owned_file.ex
+++ b/lib/ret/non_referred_owned_file.ex
@@ -1,0 +1,28 @@
+defmodule Ret.NonReferredOwnedFile do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Ret.{OwnedFile, Account}
+
+  @schema_prefix "ret0"
+  @primary_key {:non_referred_owned_file_id, :id, autogenerate: true}
+  schema "non_referred_owned_files" do
+    field :owned_file_id, :integer
+    field :owned_file_uuid, :string
+    field :key, :string
+    field :content_type, :string
+    field :content_length, :integer
+    field :state, OwnedFile.State
+
+    belongs_to :account, Account, references: :account_id
+
+    timestamps()
+  end
+
+  def changeset(struct, account, params \\ %{}) do
+    struct
+    |> cast(params, [:owned_file_id, :owned_file_uuid, :key, :content_type, :content_length, :state])
+    |> validate_required([:owned_file_id, :owned_file_uuid, :key, :content_type, :content_length])
+    |> unique_constraint(:owned_file_uuid)
+    |> put_assoc(:account, account)
+  end
+end

--- a/priv/repo/migrations/20230719191900_create_non_referred_owned_file.exs
+++ b/priv/repo/migrations/20230719191900_create_non_referred_owned_file.exs
@@ -1,0 +1,22 @@
+defmodule Ret.Repo.Migrations.CreateNonReferredOwnedFileTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:non_referred_owned_files, primary_key: false) do
+      add :non_referred_owned_file_id, :bigint, default: fragment("ret0.next_id()"), primary_key: true
+      add :owned_file_id, :bigint, null: false
+      add :owned_file_uuid, :string, null: false
+      add :key, :string, null: false
+      add :account_id, :bigint, null: false
+      add :content_type, :string, null: false
+      add :content_length, :bigint, null: false
+      add :state, :owned_file_state, null: false, default: "inactive"
+
+      timestamps()
+    end
+
+    create unique_index(:non_referred_owned_files, [:owned_file_uuid])
+    create index(:non_referred_owned_files, [:account_id])
+  end
+end
+

--- a/test/ret/cleanup_nonreferred_files_test.exs
+++ b/test/ret/cleanup_nonreferred_files_test.exs
@@ -1,0 +1,330 @@
+defmodule Ret.CleanupNonreferredFilesTest do
+  use Ret.DataCase
+  import Ret.TestHelpers
+
+  alias Ret.{
+    AppConfig,
+    Avatar,
+    AvatarListing,
+    DummyData,
+    NonReferredOwnedFile,
+    OwnedFile,
+    Repo,
+    RoomObject,
+    Scene,
+    Storage
+  }
+
+  setup do
+    on_exit(fn ->
+      clear_all_stored_files()
+    end)
+  end
+
+  # Make an account and two owned files
+  setup _context do
+    account = DummyData.account_prefix() |> create_account()
+
+    %{
+      account: account,
+      file1: generate_fixture_owned_file(account, generate_temp_file("file"), "image/png"),
+      file2: generate_fixture_owned_file(account, generate_temp_file("file2"), "image/png")
+    }
+  end
+
+  test "delete if no row in other related tables", %{} do
+    assert 2 == OwnedFile |> Repo.aggregate(:count)
+
+    Storage.cleanup_nonreferred_files()
+
+    assert 0 == OwnedFile |> Repo.aggregate(:count)
+  end
+
+  # TODO: Ideally should be tested with all the {
+  #   RoomObject,
+  #   Avatar(gltf_owned_file, bin_owned_file, :thumbnail_owned_file, ...),
+  #   Asset(asset_owned_file, thumbnail_owned_file),
+  #   ...
+  # } combination
+  # TODO: Test multiple rows deletion and remain
+
+  test "not delete if OwnedFile is referred by AppConfig", %{
+    file1: file,
+    file2: non_referred_file
+  } do
+    %AppConfig{key: "foo", owned_file: file}
+      |> Repo.insert!()
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "not delete if OwnedFile is referred by Asset", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    create_asset(%{
+      account: account,
+      thumbnail_owned_file: file
+    })
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "not delete if OwnedFile is referred by Avatar", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    %Avatar{}
+      |> Avatar.changeset(
+        account,
+        %{
+          gltf_owned_file: file,
+          bin_owned_file: file
+        },
+        nil,
+        nil,
+        %{
+          name: "Test Avatar"
+        }
+      )
+      |> Repo.insert!()
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "not delete if OwnedFile is referred by AvatarListing", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    avatar = %Avatar{}
+      |> Avatar.changeset(
+        account,
+        %{
+          gltf_owned_file: file,
+          bin_owned_file: file
+        },
+        nil,
+        nil,
+        %{
+          name: "Test Avatar"
+        }
+      )
+      |> Repo.insert!()
+
+    %AvatarListing{}
+      |> AvatarListing.changeset_for_listing_for_avatar(
+           avatar,
+           %{}
+         )
+      |> Repo.insert!()
+
+    # The Avatar refers to file so delete it for
+    # AvatarListing test
+    Repo.delete_all(Avatar)
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "not delete if OwnedFile is referred by Project", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    create_project(%{
+      account: account,
+      project_owned_file: file,
+      thumbnail_owned_file: file
+    })
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "not delete if OwnedFile is referred by Scene", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    create_scene(%{account: account, owned_file: file})
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "not delete if OwnedFile is referred by SceneListing", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    {:ok, scene: scene} = create_scene(%{account: account, owned_file: file})
+    create_scene_listing(%{scene: scene})
+
+    # The Scene refers to file so delete it for
+    # SceneListing test
+    Repo.delete_all(Scene)
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "not delete if OwnedFile is referred by RoomObject", %{
+    account: account,
+    file1: file1,
+    file2: file2
+  } do
+    # Make the third owned file that is not referred
+    non_referred_file = generate_temp_owned_file(account)
+
+    {:ok, scene: scene} = create_scene(%{account: account, owned_file: file1})
+    {:ok, hub: hub} = create_hub(%{scene: scene})
+
+    %RoomObject{
+      account: account,
+      gltf_node: create_gltf_node_with_media("https://hubs.local:4000/files/#{file2.owned_file_uuid}.glb?token=xxx"),
+      hub: hub,
+      object_id: "fake id"
+    }
+      |> Repo.insert!()
+
+    # file1 is referred by Scene and file2 is referred by RoomObject so
+    # they will be remained. The third owned file is not referred and
+    # it will be deleted.
+
+    referred_query = from(
+      f in OwnedFile,
+      where: f.owned_file_uuid in [^file1.owned_file_uuid, ^file2.owned_file_uuid]
+    )
+
+    non_referred_query = from(
+      f in OwnedFile,
+      where: f.owned_file_uuid == ^non_referred_file.owned_file_uuid
+    )
+
+    non_referred_owned_file_query = from(
+      f in NonReferredOwnedFile,
+      where: f.owned_file_uuid == ^non_referred_file.owned_file_uuid
+    )
+
+    assert 3 == Repo.aggregate(OwnedFile, :count)
+    assert 2 == Repo.aggregate(referred_query, :count)
+    assert 1 == Repo.aggregate(non_referred_query, :count)
+    assert 0 == Repo.aggregate(NonReferredOwnedFile, :count)
+    assert 0 == Repo.aggregate(non_referred_owned_file_query, :count)
+
+    Storage.cleanup_nonreferred_files()
+
+    assert 2 == Repo.aggregate(OwnedFile, :count)
+    assert 2 == Repo.aggregate(referred_query, :count)
+    assert 0 == Repo.aggregate(non_referred_query, :count)
+    assert 1 == Repo.aggregate(NonReferredOwnedFile, :count)
+    assert 1 == Repo.aggregate(non_referred_owned_file_query, :count)
+  end
+
+  test "no fail with no HUBS_components in RoomObject.gltf_node", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    {:ok, scene: scene} = create_scene(%{account: account, owned_file: file})
+    {:ok, hub: hub} = create_hub(%{scene: scene})
+
+    %RoomObject{
+      account: account,
+      gltf_node: %{extensions: %{}} |> Jason.encode!(),
+      hub: hub,
+      object_id: "fake id"
+    }
+      |> Repo.insert!()
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  test "no fail with public resource url in media.src", %{
+    account: account,
+    file1: file,
+    file2: non_referred_file
+  } do
+    {:ok, scene: scene} = create_scene(%{account: account, owned_file: file})
+    {:ok, hub: hub} = create_hub(%{scene: scene})
+
+    %RoomObject{
+      account: account,
+      gltf_node: create_gltf_node_with_media("https://www.example.com/some_image.png"),
+      hub: hub,
+      object_id: "fake id"
+    }
+      |> Repo.insert!()
+
+    cleanup_and_check(file, non_referred_file)
+  end
+
+  defp create_gltf_node_with_media(src) do
+    %{
+      extensions: %{
+        HUBS_components: %{
+          media: %{
+            src: src
+          }
+        }
+      }
+    }
+      |> Jason.encode!()
+  end
+
+  defp cleanup_and_check(referred_file, non_referred_file) do
+    # Assume only two owned files are made and one (the first argument)
+    # of them is referred by somewhere in the related tables while
+    # the other one (the second argument) is not.
+    # Test cases that don't match this assumption should use custom
+    # run and check.
+
+    referred_query = from(
+      f in OwnedFile,
+      where: f.owned_file_uuid == ^referred_file.owned_file_uuid
+    )
+
+    non_referred_query = from(
+      f in OwnedFile,
+      where: f.owned_file_uuid == ^non_referred_file.owned_file_uuid
+    )
+
+    non_referred_owned_file_query = from(
+      f in NonReferredOwnedFile,
+      where: f.owned_file_uuid == ^non_referred_file.owned_file_uuid
+    )
+
+    assert 2 == Repo.aggregate(OwnedFile, :count)
+    assert 1 == Repo.aggregate(referred_query, :count)
+    assert 1 == Repo.aggregate(non_referred_query, :count)
+    assert 0 == Repo.aggregate(NonReferredOwnedFile, :count)
+
+    Storage.cleanup_nonreferred_files()
+
+    # An OwnedFile that is not referred should be deleted so total
+    # OwnedFile count should be one.
+
+    assert 1 == Repo.aggregate(OwnedFile, :count)
+
+    # A referred OwnedFile should be remained.
+
+    assert 1 == Repo.aggregate(referred_query, :count)
+
+    # A non-referred OwnedFile should be moved from OwnedFile to
+    # NonReferredOwnedFile table.
+
+    assert 1 == Repo.aggregate(NonReferredOwnedFile, :count)
+    assert 1 == Repo.aggregate(non_referred_owned_file_query, :count)
+    assert 0 == Repo.aggregate(non_referred_query, :count)
+
+    # Check if the moved row keeps the same value
+    read_data = Repo.one!(non_referred_owned_file_query)
+
+    # Question: Any more elegant way to check?
+    assert non_referred_file.owned_file_id == read_data.owned_file_id
+    assert non_referred_file.owned_file_uuid == read_data.owned_file_uuid
+    assert non_referred_file.key == read_data.key
+    assert non_referred_file.content_type == read_data.content_type
+    assert non_referred_file.content_length == read_data.content_length
+    assert non_referred_file.account_id == read_data.account_id
+  end
+end


### PR DESCRIPTION
**Problem**

Due to a bug in Reticulum and/or Hubs Client, `OwnedFiles` that are not referred from anywhere can be remained as active in the database then the associated files are not removed. This problem causes a high disk volume usage pressure.

**Solution**

This commit addresses the problem by adding a function that finds and deletes such non-referred files. The function might be removed when the root issue will be resolved.

Non-referred OwnedFile detection algorithm

1. Mark all `OwnedFiles` as inactive
2. Mark the `OwnedFiles` as active that are referred by `RoomObjects`
3. Mark the `OwnedFiles` as active that are referred by `AppConfig`, `Asset`, `Avatar`, `AvatarListing`, `Project`, `Scene`, or `SceneListing`
4. Delete the inactive `OwnedFiles`

Note that in this commit we don't delete the non-referred `OwnedFiles` and associated files. Instead until we are confident for this operation we move the non-referred `OwnedFile` rows to another new table and keep the associated files. Even if this operation has a bug and wrongly detects non-referred owned files we can restore. And users will notice the wrong detection problem by their contents that won't appear because they are moved from `OwnedFile` table.

After we test this operation much enough we will update the code to actually delete the non-referred files in another commit.

**Changes**

- Add a new table that holds non-referred `OwnedFile` rows
- Add a function that detects non-referred `OwnedFiles` and moves them to the new table
- Add unit tests for them

**TODO in the future**

- Test this operation much enough
- Update the function to actually delete non-referred files

**Tasks**
- [x] Implementation
- [ ] Optimization and error handling if needed
- [x] Unit Test
- [ ] Decide how the function should be invoked (eg: Periodically with crontab or manually)
- [ ] Test on instance