### PR TITLE
Remove 'crazy' from the random Hubs room name generation wordlist

### DIFF
--- a/lib/ret/random_room_names.ex
+++ b/lib/ret/random_room_names.ex
@@ -395,7 +395,6 @@ defmodule Ret.RandomRoomNames do
     "courageous",
     "courteous",
     "crafty",
-    "crazy",
     "creamy",
     "creative",
     "crisp",


### PR DESCRIPTION
1/2 of the resolution of https://github.com/mozilla/hubs/issues/6283. Good idea to remove this from the wordlist.

The second half of this issue is resolved with this PR: https://github.com/mozilla/hubs/pull/6284