### PR TITLE
Deletes commented out cases from elixir test and lint

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -57,20 +57,6 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-#          - elixir: '1.14'
-#            otp: '24.2'
-#          - elixir: '1.14'
-#            otp: '24.3'
-#          - elixir: '1.14'
-#            otp: '25.3'
-#
-#          - elixir: '1.15'
-#            otp: '24.3'
-#          - elixir: '1.15'
-#            otp: '25.3'
-#          - elixir: '1.15'
-#            otp: '26.2'
-
           - elixir: '1.16'
             otp: '24.3'
           - elixir: '1.16'
@@ -98,11 +84,6 @@ jobs:
           - versions:   # current versions; already tested above
               elixir: '1.16'
               otp: '25.3'
-
-#          - versions:   # not supported
-#              elixir: '1.14'
-#              otp: '24.2'
-#            os: 'ubuntu-24.04'
           - versions:   # not supported
               elixir: '1.16'
               otp: '24.3'
@@ -152,17 +133,8 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-#          - elixir: '1.14'
-#            otp: '24.3'
-#
-#          - elixir: '1.15'
-#            otp: '24.3'
-
           - elixir: '1.16'
             otp: '24.3'
-
-#          - elixir: '1.16'
-#            otp: '25.1'
 
           - elixir: '1.17'
             otp: '25.3'


### PR DESCRIPTION
## What?
Deletes commented out cases from elixir test and lint


## Why?
They are old versions we won't be going back to


## How to test
1. Navigate to the Actions tab for this repository
2. Observe that the test-current and pseudo-lint jobs succeeed



## Documentation of functionality
No change in functionality


## Limitations
There's still many warnings when compiled

