### PR TITLE
Health probe failures log useful message

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Run the following commands at the root of the reticulum directory:
 
 Run `scripts/run.sh` if you have the hubs secret repo cloned. Otherwise `iex -S mix phx.server`
 
+## Development Aids
+
+### Environment Variables [INCOMPLETE]
+
+* STACKTRACE
+   * For errors logged using `log_our_code_location/3`, controls output verbosity.
+   * Valid values:
+      * `FULL`: prints a full stack trace in addition to the location in project code
+      * undefined or any other value: prints only the location in project code
+
+
 ## Run Hubs Against a Local Reticulum Instance
 
 ### 1. Setup the `hubs.local` hostname

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,7 +11,7 @@ config :ret, RetWeb.Endpoint,
   server: false
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :warning
 
 config :ret, Ret.AppConfig, caching?: false
 

--- a/lib/ret_web/controllers/controller_helpers.ex
+++ b/lib/ret_web/controllers/controller_helpers.ex
@@ -64,10 +64,16 @@ defmodule RetWeb.ControllerHelpers do
 
     Logger.error("#{description} at #{filename}:#{line} calling #{function}: #{inspect(error)}")
 
-    if System.get_env("STACKTRACE") === "FULL" or filename === "<unknown>" do
-      Logger.error(
-        "Stack trace (most recent call first):\n" <> Exception.format_stacktrace(stacktrace)
-      )
+    if System.get_env("STACKTRACE") === "FULL" or filename === "<unknown>" or
+         filename === "<malformed stacktrace>" do
+      try do
+        Logger.error(
+          "Stack trace (most recent call first):\n" <> Exception.format_stacktrace(stacktrace)
+        )
+      rescue
+        _ ->
+          Logger.error("Stack trace (nonstandard):\n" <> inspect(stacktrace))
+      end
     else
       Logger.info("For full stacktraces, set the environment variable STACKTRACE to FULL.")
     end

--- a/lib/ret_web/controllers/controller_helpers.ex
+++ b/lib/ret_web/controllers/controller_helpers.ex
@@ -62,6 +62,12 @@ defmodule RetWeb.ControllerHelpers do
 
     Logger.error("#{description} at #{filename}:#{line} calling #{function}: #{inspect(error)}")
 
+    if System.get_env("STACKTRACE") === "FULL" do
+      Logger.error(Exception.format_stacktrace(stacktrace))
+    else
+      Logger.debug("For full stacktraces, set the environment variable STACKTRACE to FULL.")
+    end
+
     {filename, line, function}
   end
 end

--- a/lib/ret_web/controllers/controller_helpers.ex
+++ b/lib/ret_web/controllers/controller_helpers.ex
@@ -24,8 +24,8 @@ defmodule RetWeb.ControllerHelpers do
 
   def extract_our_code_location(stacktrace) do
     try do
-      entry =
-        Enum.find(stacktrace, fn
+      ind =
+        Enum.find_index(stacktrace, fn
           {module, _function, _arity, [file: filepath, line: _line]} ->
             filepath = List.to_string(filepath)
 
@@ -39,12 +39,20 @@ defmodule RetWeb.ControllerHelpers do
           _ ->
             false
             # if no matching entry found, returns first entry
-        end) || hd(stacktrace)
+        end) || 0
 
-      {_module, _function, _arity, [file: filepath, line: line]} = entry
+      {_module, _function, _arity, [file: filepath, line: line]} = Enum.at(stacktrace, ind)
       filename = Path.basename(List.to_string(filepath))
 
-      {filename, line}
+      function =
+        if ind > 0 do
+          {_m, function, _a, [_f, _l]} = Enum.at(stacktrace, ind - 1)
+          function
+        else
+          :unknown
+        end
+
+      {filename, line, function}
     rescue
       _coding_error ->
         {"<unknown>", 0}

--- a/lib/ret_web/controllers/controller_helpers.ex
+++ b/lib/ret_web/controllers/controller_helpers.ex
@@ -2,6 +2,7 @@ defmodule RetWeb.ControllerHelpers do
   import Plug.Conn
   import Phoenix.Controller
   import RetWeb.ErrorHelpers
+  require Logger
 
   def render_error_json(conn, status, params) do
     conn
@@ -22,40 +23,45 @@ defmodule RetWeb.ControllerHelpers do
     render_error_json(conn, status, reason)
   end
 
-  def extract_our_code_location(stacktrace) do
-    try do
-      ind =
-        Enum.find_index(stacktrace, fn
-          {module, _function, _arity, [file: filepath, line: _line]} ->
-            filepath = List.to_string(filepath)
+  def log_our_code_location(stacktrace, error, description \\ "Failure") do
+    {filename, line, function} =
+      try do
+        ind =
+          Enum.find_index(stacktrace, fn
+            {module, _function, _arity, [file: filepath, line: _line]} ->
+              filepath = List.to_string(filepath)
 
-            is_not_dependency =
-              !String.contains?(filepath, "/deps/") && !String.contains?(filepath, "deps/")
+              is_not_dependency =
+                !String.contains?(filepath, "/deps/") && !String.contains?(filepath, "deps/")
 
-            is_reticulum_module = String.starts_with?(to_string(module), "Elixir.Ret")
-            is_not_dependency && is_reticulum_module
+              is_reticulum_module = String.starts_with?(to_string(module), "Elixir.Ret")
+              is_not_dependency && is_reticulum_module
 
-          # if stacktrace entry isn't in usual format, skips it
-          _ ->
-            false
-            # if no matching entry found, returns first entry
-        end) || 0
+            # if stacktrace entry isn't in usual format, skips it
+            _ ->
+              false
+              # if no matching entry found, returns first entry
+          end) || 0
 
-      {_module, _function, _arity, [file: filepath, line: line]} = Enum.at(stacktrace, ind)
-      filename = Path.basename(List.to_string(filepath))
+        {_module, _function, _arity, [file: filepath, line: line]} = Enum.at(stacktrace, ind)
+        filename = Path.basename(List.to_string(filepath))
 
-      function =
-        if ind > 0 do
-          {_m, function, _a, [_f, _l]} = Enum.at(stacktrace, ind - 1)
-          function
-        else
-          :unknown
-        end
+        function =
+          if ind > 0 do
+            {_mod, function, _ar, [_fil, _lin]} = Enum.at(stacktrace, ind - 1)
+            function
+          else
+            :unknown
+          end
 
-      {filename, line, function}
-    rescue
-      _coding_error ->
-        {"<unknown>", 0}
-    end
+        {filename, line, function}
+      rescue
+        _coding_error ->
+          {"<unknown>", 0, :unknown}
+      end
+
+    Logger.error("#{description} at #{filename}:#{line} calling #{function}: #{inspect(error)}")
+
+    {filename, line, function}
   end
 end

--- a/lib/ret_web/controllers/controller_helpers.ex
+++ b/lib/ret_web/controllers/controller_helpers.ex
@@ -21,4 +21,33 @@ defmodule RetWeb.ControllerHelpers do
     reason = Plug.Conn.Status.reason_phrase(code)
     render_error_json(conn, status, reason)
   end
+
+  def extract_our_code_location(stacktrace) do
+    try do
+      entry =
+        Enum.find(stacktrace, fn
+          {module, _function, _arity, [file: filepath, line: _line]} ->
+            filepath = List.to_string(filepath)
+
+            is_not_dependency =
+              !String.contains?(filepath, "/deps/") && !String.contains?(filepath, "deps/")
+
+            is_reticulum_module = String.starts_with?(to_string(module), "Elixir.Ret")
+            is_not_dependency && is_reticulum_module
+
+          # if stacktrace entry isn't in usual format, skips it
+          _ ->
+            false
+            # if no matching entry found, returns first entry
+        end) || hd(stacktrace)
+
+      {_module, _function, _arity, [file: filepath, line: line]} = entry
+      filename = Path.basename(List.to_string(filepath))
+
+      {filename, line}
+    rescue
+      _coding_error ->
+        {"<unknown>", 0}
+    end
+  end
 end

--- a/lib/ret_web/controllers/controller_helpers.ex
+++ b/lib/ret_web/controllers/controller_helpers.ex
@@ -43,13 +43,15 @@ defmodule RetWeb.ControllerHelpers do
               # if no matching entry found, returns first entry
           end) || 0
 
-        {_module, _function, _arity, [file: filepath, line: line]} = Enum.at(stacktrace, ind)
-        filename = Path.basename(List.to_string(filepath))
+        {_module, _function, _arity, location} = Enum.at(stacktrace, ind)
+        filepath = Keyword.get(location, :file)
+        line = Keyword.get(location, :line, 0)
+        filename = if filepath, do: Path.basename(List.to_string(filepath)), else: "<unknown>"
 
         function =
           if ind > 0 do
-            {_mod, function, _ar, [_fil, _lin]} = Enum.at(stacktrace, ind - 1)
-            function
+            {module, function, _ar, _location} = Enum.at(stacktrace, ind - 1)
+            "#{String.replace_prefix(to_string(module), "Elixir.", "")}.#{function}"
           else
             :unknown
           end
@@ -57,15 +59,17 @@ defmodule RetWeb.ControllerHelpers do
         {filename, line, function}
       rescue
         _coding_error ->
-          {"<unknown>", 0, :unknown}
+          {"<malformed stacktrace>", 0, :unknown}
       end
 
     Logger.error("#{description} at #{filename}:#{line} calling #{function}: #{inspect(error)}")
 
-    if System.get_env("STACKTRACE") === "FULL" do
-      Logger.error(Exception.format_stacktrace(stacktrace))
+    if System.get_env("STACKTRACE") === "FULL" or filename === "<unknown>" do
+      Logger.error(
+        "Stack trace (most recent call first):\n" <> Exception.format_stacktrace(stacktrace)
+      )
     else
-      Logger.debug("For full stacktraces, set the environment variable STACKTRACE to FULL.")
+      Logger.info("For full stacktraces, set the environment variable STACKTRACE to FULL.")
     end
 
     {filename, line, function}

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -21,8 +21,12 @@ defmodule RetWeb.HealthController do
       send_resp(conn, 200, "ok")
     rescue
       error ->
-        {filename, line} = extract_our_code_location(__STACKTRACE__)
-        Logger.error("Health check failed at #{filename}:#{line}: #{inspect(error)}")
+        {filename, line, function} = extract_our_code_location(__STACKTRACE__)
+
+        Logger.error(
+          "Health check failed at #{filename}:#{line} calling #{function}: #{inspect(error)}"
+        )
+
         send_resp(conn, 500, "error")
     end
   end

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -1,7 +1,6 @@
 defmodule RetWeb.HealthController do
   use RetWeb, :controller
   import Ecto.Query
-  require Logger
 
   def index(conn, _params) do
     try do
@@ -21,11 +20,7 @@ defmodule RetWeb.HealthController do
       send_resp(conn, 200, "ok")
     rescue
       error ->
-        {filename, line, function} = extract_our_code_location(__STACKTRACE__)
-
-        Logger.error(
-          "Health check failed at #{filename}:#{line} calling #{function}: #{inspect(error)}"
-        )
+        log_our_code_location(__STACKTRACE__, error, "Health check failed")
 
         send_resp(conn, 500, "error")
     end

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -21,7 +21,8 @@ defmodule RetWeb.HealthController do
       send_resp(conn, 200, "ok")
     rescue
       error ->
-        Logger.error("Health check failed: #{inspect(error)}")
+        {filename, line} = extract_our_code_location(__STACKTRACE__)
+        Logger.error("Health check failed at #{filename}:#{line}: #{inspect(error)}")
         send_resp(conn, 500, "error")
     end
   end

--- a/lib/ret_web/controllers/health_controller.ex
+++ b/lib/ret_web/controllers/health_controller.ex
@@ -1,22 +1,29 @@
 defmodule RetWeb.HealthController do
   use RetWeb, :controller
   import Ecto.Query
+  require Logger
 
   def index(conn, _params) do
-    # Check database
-    if module_config(:check_repo) do
-      Ret.Repo.all(from Ret.Hub, limit: 0)
+    try do
+      # Check database
+      if module_config(:check_repo) do
+        Ret.Repo.all(from Ret.Hub, limit: 0)
+      end
+
+      # Check page cache
+      true = Cachex.get(:page_chunks, {:hubs, "index.html"}) |> elem(1) |> Enum.count() > 0
+      true = Cachex.get(:page_chunks, {:hubs, "hub.html"}) |> elem(1) |> Enum.count() > 0
+      true = Cachex.get(:page_chunks, {:spoke, "index.html"}) |> elem(1) |> Enum.count() > 0
+
+      # Check room routing
+      true = Ret.RoomAssigner.get_available_host("") != nil
+
+      send_resp(conn, 200, "ok")
+    rescue
+      error ->
+        Logger.error("Health check failed: #{inspect(error)}")
+        send_resp(conn, 500, "error")
     end
-
-    # Check page cache
-    true = Cachex.get(:page_chunks, {:hubs, "index.html"}) |> elem(1) |> Enum.count() > 0
-    true = Cachex.get(:page_chunks, {:hubs, "hub.html"}) |> elem(1) |> Enum.count() > 0
-    true = Cachex.get(:page_chunks, {:spoke, "index.html"}) |> elem(1) |> Enum.count() > 0
-
-    # Check room routing
-    true = Ret.RoomAssigner.get_available_host("") != nil
-
-    send_resp(conn, 200, "ok")
   end
 
   defp module_config(key) do

--- a/test/ret_web/controllers/controller_helpers_test.exs
+++ b/test/ret_web/controllers/controller_helpers_test.exs
@@ -6,19 +6,22 @@ defmodule RetWeb.ControllerHelpersTest do
   require Logger
 
   setup_all do
-    Logger.configure(level: :debug)
+    Logger.configure(level: :info)
     :ok
   end
 
   describe "log_our_code_location/3" do
+    @tag :error_logging
     test "ignores dependency modules and finds innermost project module" do
       log =
-        capture_log([level: :debug], fn ->
+        capture_log([level: :info], fn ->
           stacktrace = [
             {Bamboo.Email, :new_email, 0,
              [file: ~c"_build/test/lib/bamboo/ebin/Elixir.Bamboo.Email.beam", line: 190]},
             {RetWeb.Email, :auth_email, 2, [file: ~c"lib/ret_web/email.ex", line: 19]},
-            {RetWeb.Endpoint, :get_cors_origins, 0, [file: ~c"lib/ret_web/endpoint.ex", line: 10]}
+            {RetWeb.Endpoint, :get_cors_origins, 0,
+             [file: ~c"lib/ret_web/endpoint.ex", line: 10]},
+            {RetWeb.Endpoint, :allowed_origin?, 1, [file: ~c"lib/ret_web/endpoint.ex", line: 16]}
           ]
 
           ControllerHelpers.log_our_code_location(stacktrace, :email_error, "Pseudo-failure")
@@ -26,14 +29,16 @@ defmodule RetWeb.ControllerHelpersTest do
 
       assert log =~ "Pseudo-failure"
       assert log =~ "at email.ex:19"
-      assert log =~ "calling new_email"
+      assert log =~ "calling Bamboo.Email.new_email"
       assert log =~ ":email_error"
       assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      refute log =~ "Stack trace (most recent call first)"
     end
 
+    @tag :error_logging
     test "falls back to the first entry if no project module is found" do
       log =
-        capture_log([level: :debug], fn ->
+        capture_log([level: :info], fn ->
           stacktrace = [
             {Plug.Conn, :send_resp, 3, [file: ~c"deps/plug/lib/plug/spam.ex", line: 400]},
             {Phoenix.Controller, :render, 3,
@@ -48,11 +53,13 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "calling unknown"
       assert log =~ ":another_error"
       assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      refute log =~ "Stack trace (most recent call first)"
     end
 
-    test "handles malformed stacktrace entries by returning unknown" do
+    @tag :error_logging
+    test "handles malformed stacktrace entries by returning <malformed stacktrace>" do
       log =
-        capture_log([level: :debug], fn ->
+        capture_log([level: :info], fn ->
           # This should trigger the rescue block because pattern doesn't match
           stacktrace = [
             {:not, :a, :standard, :entry}
@@ -62,26 +69,30 @@ defmodule RetWeb.ControllerHelpersTest do
         end)
 
       assert log =~ "Probe failure"
-      assert log =~ "at <unknown>:0"
+      assert log =~ "at <malformed stacktrace>:0"
       assert log =~ "calling unknown"
       assert log =~ ":spam_error"
       assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      refute log =~ "Stack trace (most recent call first)"
     end
 
-    test "handles empty stacktrace by returning unknown" do
+    @tag :error_logging
+    test "handles empty stacktrace by returning <malformed stacktrace>" do
       log =
-        capture_log([level: :debug], fn ->
+        capture_log([level: :info], fn ->
           # This should trigger the rescue block because there's no entry to match
           ControllerHelpers.log_our_code_location([], :strange_error, "Weird failure")
         end)
 
       assert log =~ "Weird failure"
-      assert log =~ "at <unknown>:0"
+      assert log =~ "at <malformed stacktrace>:0"
       assert log =~ "calling unknown"
       assert log =~ ":strange_error"
       assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      refute log =~ "Stack trace (most recent call first)"
     end
 
+    @tag :error_logging
     test "logs full stacktrace when STACKTRACE environment variable is set to FULL" do
       System.put_env("STACKTRACE", "FULL")
 
@@ -90,7 +101,7 @@ defmodule RetWeb.ControllerHelpersTest do
       end)
 
       log =
-        capture_log([level: :debug], fn ->
+        capture_log([level: :info], fn ->
           stacktrace = [
             {RetWeb.Email, :auth_email, 2, [file: ~c"lib/ret_web/email.ex", line: 19]},
             {RetWeb.Endpoint, :get_cors_origins, 0, [file: ~c"lib/ret_web/endpoint.ex", line: 10]}
@@ -103,9 +114,35 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "at email.ex:19"
       assert log =~ "calling unknown"
       assert log =~ ":full_error"
+      refute log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      assert log =~ "Stack trace (most recent call first)"
       assert log =~ "RetWeb.Email.auth_email/2"
       assert log =~ "RetWeb.Endpoint.get_cors_origins/0"
+    end
+
+    @tag :error_logging
+    test "handles stacktrace entry without filepath by returning <unknown>" do
+      log =
+        capture_log([level: :info], fn ->
+          # Entry with arity but no location information
+          stacktrace = [
+            {RetWeb.HealthController, :index, 2, []}
+          ]
+
+          ControllerHelpers.log_our_code_location(
+            stacktrace,
+            :no_filepath_error,
+            "No-filepath failure"
+          )
+        end)
+
+      assert log =~ "No-filepath failure"
+      assert log =~ "at <unknown>:0"
+      assert log =~ "calling unknown"
+      assert log =~ ":no_filepath_error"
       refute log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      assert log =~ "Stack trace (most recent call first)"
+      assert log =~ "RetWeb.HealthController.index/2"
     end
   end
 end

--- a/test/ret_web/controllers/controller_helpers_test.exs
+++ b/test/ret_web/controllers/controller_helpers_test.exs
@@ -1,0 +1,75 @@
+defmodule RetWeb.ControllerHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias RetWeb.ControllerHelpers
+
+  describe "extract_our_code_location/1" do
+    test "extracts location from a project module" do
+      stacktrace = [
+        {RetWeb.ControllerHelpers, :extract_our_code_location, 1,
+         [file: ~c"lib/ret_web/controllers/controller_helpers.ex", line: 25]}
+      ]
+
+      assert {"controller_helpers.ex", 25, :unknown} ==
+               ControllerHelpers.extract_our_code_location(stacktrace)
+    end
+
+    test "ignores dependency modules and finds project module" do
+      stacktrace = [
+        {Plug.Conn, :send_resp, 3, [file: ~c"deps/plug/lib/plug/conn.ex", line: 400]},
+        {RetWeb.ControllerHelpers, :render_error_json, 3,
+         [file: ~c"lib/ret_web/controllers/controller_helpers.ex", line: 6]}
+      ]
+
+      assert {"controller_helpers.ex", 6, :send_resp} ==
+               ControllerHelpers.extract_our_code_location(stacktrace)
+    end
+
+    test "falls back to the first entry if no project module is found" do
+      stacktrace = [
+        {Plug.Conn, :send_resp, 3, [file: ~c"deps/plug/lib/plug/conn.ex", line: 400]},
+        {Phoenix.Controller, :render, 3,
+         [file: ~c"deps/phoenix/lib/phoenix/controller.ex", line: 100]}
+      ]
+
+      assert {"conn.ex", 400, :unknown} ==
+               ControllerHelpers.extract_our_code_location(stacktrace)
+    end
+
+    test "handles stacktrace with charlist paths (standard in Erlang/Elixir)" do
+      stacktrace = [
+        {RetWeb.SomeModule, :some_func, 0, [file: ~c"lib/ret_web/some_module.ex", line: 10]}
+      ]
+
+      assert {"some_module.ex", 10, :unknown} ==
+               ControllerHelpers.extract_our_code_location(stacktrace)
+    end
+
+    test "handles malformed stacktrace entries by returning unknown" do
+      # This should trigger the rescue block because of the pattern match
+      stacktrace = [
+        {:not, :a, :standard, :entry}
+      ]
+
+      assert {"<unknown>", 0} ==
+               ControllerHelpers.extract_our_code_location(stacktrace)
+    end
+
+    test "handles empty stacktrace" do
+      assert {"<unknown>", 0} ==
+               ControllerHelpers.extract_our_code_location([])
+    end
+
+    test "detects project module even if it is not the first one" do
+      stacktrace = [
+        {SomeOther.Module, :func, 0, [file: ~c"lib/other.ex", line: 1]},
+        {RetWeb.ControllerHelpers, :func, 0,
+         [file: ~c"lib/ret_web/controller_helpers.ex", line: 2]}
+      ]
+
+      # SomeOther.Module does not start with Elixir.Ret
+      assert {"controller_helpers.ex", 2, :func} ==
+               ControllerHelpers.extract_our_code_location(stacktrace)
+    end
+  end
+end

--- a/test/ret_web/controllers/controller_helpers_test.exs
+++ b/test/ret_web/controllers/controller_helpers_test.exs
@@ -57,7 +57,7 @@ defmodule RetWeb.ControllerHelpersTest do
     end
 
     @tag :error_logging
-    test "handles malformed stacktrace entries by returning <malformed stacktrace>" do
+    test "handles malformed stacktrace entries by logging full stack trace" do
       log =
         capture_log([level: :info], fn ->
           # This should trigger the rescue block because pattern doesn't match
@@ -72,12 +72,12 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "at <malformed stacktrace>:0"
       assert log =~ "calling unknown"
       assert log =~ ":spam_error"
-      assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
-      refute log =~ "Stack trace (most recent call first)"
+      refute log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      assert log =~ "Stack trace (nonstandard)"
     end
 
     @tag :error_logging
-    test "handles empty stacktrace by returning <malformed stacktrace>" do
+    test "handles empty stacktrace by logging full stacktrace" do
       log =
         capture_log([level: :info], fn ->
           # This should trigger the rescue block because there's no entry to match
@@ -88,8 +88,8 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "at <malformed stacktrace>:0"
       assert log =~ "calling unknown"
       assert log =~ ":strange_error"
-      assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
-      refute log =~ "Stack trace (most recent call first)"
+      refute log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+      assert log =~ "Stack trace (most recent call first)"
     end
 
     @tag :error_logging

--- a/test/ret_web/controllers/controller_helpers_test.exs
+++ b/test/ret_web/controllers/controller_helpers_test.exs
@@ -5,10 +5,15 @@ defmodule RetWeb.ControllerHelpersTest do
   import ExUnit.CaptureLog
   require Logger
 
+  setup_all do
+    Logger.configure(level: :debug)
+    :ok
+  end
+
   describe "log_our_code_location/3" do
     test "ignores dependency modules and finds innermost project module" do
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :debug], fn ->
           stacktrace = [
             {Bamboo.Email, :new_email, 0,
              [file: ~c"_build/test/lib/bamboo/ebin/Elixir.Bamboo.Email.beam", line: 190]},
@@ -23,11 +28,12 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "at email.ex:19"
       assert log =~ "calling new_email"
       assert log =~ ":email_error"
+      assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
     end
 
     test "falls back to the first entry if no project module is found" do
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :debug], fn ->
           stacktrace = [
             {Plug.Conn, :send_resp, 3, [file: ~c"deps/plug/lib/plug/spam.ex", line: 400]},
             {Phoenix.Controller, :render, 3,
@@ -41,11 +47,12 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "at spam.ex:400"
       assert log =~ "calling unknown"
       assert log =~ ":another_error"
+      assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
     end
 
     test "handles malformed stacktrace entries by returning unknown" do
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :debug], fn ->
           # This should trigger the rescue block because pattern doesn't match
           stacktrace = [
             {:not, :a, :standard, :entry}
@@ -58,11 +65,12 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "at <unknown>:0"
       assert log =~ "calling unknown"
       assert log =~ ":spam_error"
+      assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
     end
 
     test "handles empty stacktrace by returning unknown" do
       log =
-        capture_log([level: :error], fn ->
+        capture_log([level: :debug], fn ->
           # This should trigger the rescue block because there's no entry to match
           ControllerHelpers.log_our_code_location([], :strange_error, "Weird failure")
         end)
@@ -71,6 +79,33 @@ defmodule RetWeb.ControllerHelpersTest do
       assert log =~ "at <unknown>:0"
       assert log =~ "calling unknown"
       assert log =~ ":strange_error"
+      assert log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
+    end
+
+    test "logs full stacktrace when STACKTRACE environment variable is set to FULL" do
+      System.put_env("STACKTRACE", "FULL")
+
+      on_exit(fn ->
+        System.delete_env("STACKTRACE")
+      end)
+
+      log =
+        capture_log([level: :debug], fn ->
+          stacktrace = [
+            {RetWeb.Email, :auth_email, 2, [file: ~c"lib/ret_web/email.ex", line: 19]},
+            {RetWeb.Endpoint, :get_cors_origins, 0, [file: ~c"lib/ret_web/endpoint.ex", line: 10]}
+          ]
+
+          ControllerHelpers.log_our_code_location(stacktrace, :full_error, "Full failure")
+        end)
+
+      assert log =~ "Full failure"
+      assert log =~ "at email.ex:19"
+      assert log =~ "calling unknown"
+      assert log =~ ":full_error"
+      assert log =~ "RetWeb.Email.auth_email/2"
+      assert log =~ "RetWeb.Endpoint.get_cors_origins/0"
+      refute log =~ "For full stacktraces, set the environment variable STACKTRACE to FULL."
     end
   end
 end

--- a/test/ret_web/controllers/controller_helpers_test.exs
+++ b/test/ret_web/controllers/controller_helpers_test.exs
@@ -94,6 +94,7 @@ defmodule RetWeb.ControllerHelpersTest do
 
     @tag :error_logging
     test "logs full stacktrace when STACKTRACE environment variable is set to FULL" do
+      # Note: manipulation of this environment variable within async tests is deemed safe because it only relates to this module.
       System.put_env("STACKTRACE", "FULL")
 
       on_exit(fn ->

--- a/test/ret_web/controllers/controller_helpers_test.exs
+++ b/test/ret_web/controllers/controller_helpers_test.exs
@@ -2,74 +2,75 @@ defmodule RetWeb.ControllerHelpersTest do
   use ExUnit.Case, async: true
 
   alias RetWeb.ControllerHelpers
+  import ExUnit.CaptureLog
+  require Logger
 
-  describe "extract_our_code_location/1" do
-    test "extracts location from a project module" do
-      stacktrace = [
-        {RetWeb.ControllerHelpers, :extract_our_code_location, 1,
-         [file: ~c"lib/ret_web/controllers/controller_helpers.ex", line: 25]}
-      ]
+  describe "log_our_code_location/3" do
+    test "ignores dependency modules and finds innermost project module" do
+      log =
+        capture_log([level: :error], fn ->
+          stacktrace = [
+            {Bamboo.Email, :new_email, 0,
+             [file: ~c"_build/test/lib/bamboo/ebin/Elixir.Bamboo.Email.beam", line: 190]},
+            {RetWeb.Email, :auth_email, 2, [file: ~c"lib/ret_web/email.ex", line: 19]},
+            {RetWeb.Endpoint, :get_cors_origins, 0, [file: ~c"lib/ret_web/endpoint.ex", line: 10]}
+          ]
 
-      assert {"controller_helpers.ex", 25, :unknown} ==
-               ControllerHelpers.extract_our_code_location(stacktrace)
-    end
+          ControllerHelpers.log_our_code_location(stacktrace, :email_error, "Pseudo-failure")
+        end)
 
-    test "ignores dependency modules and finds project module" do
-      stacktrace = [
-        {Plug.Conn, :send_resp, 3, [file: ~c"deps/plug/lib/plug/conn.ex", line: 400]},
-        {RetWeb.ControllerHelpers, :render_error_json, 3,
-         [file: ~c"lib/ret_web/controllers/controller_helpers.ex", line: 6]}
-      ]
-
-      assert {"controller_helpers.ex", 6, :send_resp} ==
-               ControllerHelpers.extract_our_code_location(stacktrace)
+      assert log =~ "Pseudo-failure"
+      assert log =~ "at email.ex:19"
+      assert log =~ "calling new_email"
+      assert log =~ ":email_error"
     end
 
     test "falls back to the first entry if no project module is found" do
-      stacktrace = [
-        {Plug.Conn, :send_resp, 3, [file: ~c"deps/plug/lib/plug/conn.ex", line: 400]},
-        {Phoenix.Controller, :render, 3,
-         [file: ~c"deps/phoenix/lib/phoenix/controller.ex", line: 100]}
-      ]
+      log =
+        capture_log([level: :error], fn ->
+          stacktrace = [
+            {Plug.Conn, :send_resp, 3, [file: ~c"deps/plug/lib/plug/spam.ex", line: 400]},
+            {Phoenix.Controller, :render, 3,
+             [file: ~c"deps/phoenix/lib/phoenix/controller.ex", line: 100]}
+          ]
 
-      assert {"conn.ex", 400, :unknown} ==
-               ControllerHelpers.extract_our_code_location(stacktrace)
-    end
+          ControllerHelpers.log_our_code_location(stacktrace, :another_error)
+        end)
 
-    test "handles stacktrace with charlist paths (standard in Erlang/Elixir)" do
-      stacktrace = [
-        {RetWeb.SomeModule, :some_func, 0, [file: ~c"lib/ret_web/some_module.ex", line: 10]}
-      ]
-
-      assert {"some_module.ex", 10, :unknown} ==
-               ControllerHelpers.extract_our_code_location(stacktrace)
+      assert log =~ "Failure"
+      assert log =~ "at spam.ex:400"
+      assert log =~ "calling unknown"
+      assert log =~ ":another_error"
     end
 
     test "handles malformed stacktrace entries by returning unknown" do
-      # This should trigger the rescue block because of the pattern match
-      stacktrace = [
-        {:not, :a, :standard, :entry}
-      ]
+      log =
+        capture_log([level: :error], fn ->
+          # This should trigger the rescue block because pattern doesn't match
+          stacktrace = [
+            {:not, :a, :standard, :entry}
+          ]
 
-      assert {"<unknown>", 0} ==
-               ControllerHelpers.extract_our_code_location(stacktrace)
+          ControllerHelpers.log_our_code_location(stacktrace, :spam_error, "Probe failure")
+        end)
+
+      assert log =~ "Probe failure"
+      assert log =~ "at <unknown>:0"
+      assert log =~ "calling unknown"
+      assert log =~ ":spam_error"
     end
 
-    test "handles empty stacktrace" do
-      assert {"<unknown>", 0} ==
-               ControllerHelpers.extract_our_code_location([])
-    end
+    test "handles empty stacktrace by returning unknown" do
+      log =
+        capture_log([level: :error], fn ->
+          # This should trigger the rescue block because there's no entry to match
+          ControllerHelpers.log_our_code_location([], :strange_error, "Weird failure")
+        end)
 
-    test "detects project module even if it is not the first one" do
-      stacktrace = [
-        {SomeOther.Module, :func, 0, [file: ~c"lib/other.ex", line: 1]},
-        {RetWeb.ControllerHelpers, :func, 0,
-         [file: ~c"lib/ret_web/controller_helpers.ex", line: 2]}
-      ]
-
-      # SomeOther.Module does not start with Elixir.Ret
-      assert {"controller_helpers.ex", 2, :func} ==
-               ControllerHelpers.extract_our_code_location(stacktrace)
+      assert log =~ "Weird failure"
+      assert log =~ "at <unknown>:0"
+      assert log =~ "calling unknown"
+      assert log =~ ":strange_error"
     end
   end
 end

--- a/test/ret_web/controllers/health_controller_test.exs
+++ b/test/ret_web/controllers/health_controller_test.exs
@@ -1,0 +1,18 @@
+defmodule RetWeb.HealthControllerTest do
+  use RetWeb.ConnCase
+
+  import ExUnit.CaptureLog
+  require Logger
+
+  test "GET /health returns 500 and logs error inspection when a check fails", %{conn: conn} do
+    log =
+      capture_log([level: :error], fn ->
+        # Cachex and RoomAssigner aren't mocked so this will fail.
+        resp = conn |> get("/health")
+        assert resp.status === 500
+        assert resp.resp_body === "error"
+      end)
+
+    assert log =~ "Error"
+  end
+end

--- a/test/ret_web/controllers/health_controller_test.exs
+++ b/test/ret_web/controllers/health_controller_test.exs
@@ -16,7 +16,7 @@ defmodule RetWeb.HealthControllerTest do
     # It should log health_controller.ex (reticulum code) even if the error
     # occurs inside a library (like Enum or Cachex).
     assert log =~ "Health check failed"
-    assert log =~ "at health_controller.ex:14"
+    assert log =~ "at health_controller.ex:13"
     assert log =~ "calling count"
   end
 end

--- a/test/ret_web/controllers/health_controller_test.exs
+++ b/test/ret_web/controllers/health_controller_test.exs
@@ -4,7 +4,7 @@ defmodule RetWeb.HealthControllerTest do
   import ExUnit.CaptureLog
   require Logger
 
-  test "GET /health returns 500 and logs error inspection when a check fails", %{conn: conn} do
+  test "GET /health, when a check fails, returns 500 and logs error & location", %{conn: conn} do
     log =
       capture_log([level: :error], fn ->
         # Cachex and RoomAssigner aren't mocked so this will fail.
@@ -13,6 +13,9 @@ defmodule RetWeb.HealthControllerTest do
         assert resp.resp_body === "error"
       end)
 
-    assert log =~ "Error"
+    # It should log health_controller.ex (reticulum code) even if the error
+    # occurs inside a library (like Enum or Cachex).
+    assert log =~ "Health check failed at"
+    assert log =~ "health_controller.ex"
   end
 end

--- a/test/ret_web/controllers/health_controller_test.exs
+++ b/test/ret_web/controllers/health_controller_test.exs
@@ -15,7 +15,8 @@ defmodule RetWeb.HealthControllerTest do
 
     # It should log health_controller.ex (reticulum code) even if the error
     # occurs inside a library (like Enum or Cachex).
-    assert log =~ "Health check failed at"
-    assert log =~ "health_controller.ex"
+    assert log =~ "Health check failed"
+    assert log =~ "at health_controller.ex:14"
+    assert log =~ "calling count"
   end
 end

--- a/test/ret_web/controllers/health_controller_test.exs
+++ b/test/ret_web/controllers/health_controller_test.exs
@@ -4,6 +4,7 @@ defmodule RetWeb.HealthControllerTest do
   import ExUnit.CaptureLog
   require Logger
 
+  @tag :error_logging
   test "GET /health, when a check fails, returns 500 and logs error & location", %{conn: conn} do
     log =
       capture_log([level: :error], fn ->
@@ -17,6 +18,6 @@ defmodule RetWeb.HealthControllerTest do
     # occurs inside a library (like Enum or Cachex).
     assert log =~ "Health check failed"
     assert log =~ "at health_controller.ex:13"
-    assert log =~ "calling count"
+    assert log =~ "calling Enum.count"
   end
 end


### PR DESCRIPTION
## What?
Catches exceptions in 'HealthController.index/2' method & logs error and location in our code at level :error

## Why?
So it can be understood *why* reticulum is unhealthy and point toward what needs to be fixed

## Examples
### old log message
```
request_id=GIjrZYolRUXFTPEAAOXF [info] GET /health
...
request_id=GIjrZYolRUXFTPEAAOXF [warning] Failed to send Sentry event.Cannot send Sentry event because of invalid DSN
```
Sentry is an error reporting tool which is not configured — this message is unrelated to the actual problem.

### new log message
```
request_id=GIkhm_C-aE93flYAADlB [info] GET /health
request_id=GIkhm_C-aE93flYAADlB [error] Health check failed at health_controller.ex:14 calling count: %Protocol.UndefinedError{protocol: Enumerable, value: nil, description: ""}
```
In this case, we know that the call to count/1 at health_controller.ex line 14 is failing because it's trying to enumerate `nil`

## How to test
1. run `mix test` (or look at CI), observe that new automated test for reticulum being unhealthy passes
2. deploy to instance,
3. from a pod, run `curl -i http://ret:4001/health` & observe that "ok" is still returned (or visit `<your-domain>/health`)
4. run `kubectl scale deploy spoke --replicas=0 -n hcce` to kill Spoke
5. run `kubectl scale deploy reticulum --replicas=0 -n hcce` then run `kubectl scale deploy reticulum --replicas=1 -n hcce` to restart reticulum with empty caches
6. run `kubectl logs -l app=reticulum -f -n hcce`; observe log message including "[error] Health check failed at health_controller.ex:15 calling count: %Protocol.UndefinedError{protocol: Enumerable, value: nil, description: ""}" showing that the Hubs tests pass, but the Spoke test fails.

## Documentation of functionality
For the most part, no documentation change is needed; this just produces better logs when reticulum is not healthy.  The new STACKTRACE environment variable has been documented in the readme.

## Open questions
Could Cachex and RoomAssigner be mocked, so an automated test for reticulum being healthy could be written?

## Additional details or related context
Written with the help of JetBrains' Junie LLM, but reworked by me.
The end result is similar to page_controller.ex lines 844–847.

For full stacktraces, set the environment variable STACKTRACE to FULL.

This introduces a slight change in behavior when the health check fails, a 500 error is now returned and the entire instance is rendered inaccessible instead of just the problematic service (e.g. before, if Spoke was down, you could still enter a Hubs room, while now you can't); however, the previous behavior resulted in periodic crashes due to Reticulum restarts, so it is likely better/safer to have the whole instance inaccessible.
