### PR TITLE
Increase lint-and-test workflow security and tighten permissions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -2,6 +2,8 @@ name: lint-and-test
 
 on: [push, workflow_dispatch]
 
+permissions: {}
+
 jobs:
   test-current:
     strategy:
@@ -28,15 +30,17 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: '1.16.3-otp-25'
           otp-version: '25.3.2.20'
 #       When changing versions, change it everywhere (check the README).
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             deps
@@ -107,14 +111,16 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: ${{ matrix.versions.elixir }}
           otp-version: ${{ matrix.versions.otp }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             deps
@@ -149,14 +155,16 @@ jobs:
     runs-on: 'ubuntu-24.04'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           elixir-version: ${{ matrix.versions.elixir }}
           otp-version: ${{ matrix.versions.otp }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             deps


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Sets permissions to none, pins calls to external actions to specific commits, and prevents credentials from actions/checkout from persisting.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
To minimize the chance of the workflow being hacked or vulnerable to a supply chain hack (pinning the external action calls helps with this), and in preparation to globally restrict permissions for all Hubs Foundation workflows.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Push the changes to your fork.
2. Run the workflow (if it doesn't run automatically).
3. See that it works normally.

To verify that all the Zizmor issues have been addressed, run the following command from the repository folder and see that Zizmor reports no issues (that we care about) for the lint-and-test workflow.
```
docker run --rm --name zizmor -v .:/usr/repo ghcr.io/zizmorcore/zizmor --fix=all /usr/repo
```

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This doesn't change the functionality of the workflow, so no documentation update is needed.

## Known limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
This doesn't update any of the external workflow versions.  I feel it is out of scope for this PR and can/should be done along with all the others in further PRs when addressing GitHub's required update to use Node 24+.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
These security improvements were advised by the Zizmor tool and `GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 #v1 Beta 9`

Part of https://github.com/Hubs-Foundation/.github/issues/13