### PR TITLE
Allow the ret-turkey workflow to run on all branches

### DIFF
--- a/.github/workflows/ret-turkey.yml
+++ b/.github/workflows/ret-turkey.yml
@@ -1,9 +1,6 @@
 name: reticulum
 on:
   push:
-    branches:
-      - 'master'
-      - 'hotfix/**'
     paths-ignore: [".github/**", "guides/**", "README.md", "LICENSE", "CODE_OF_CONDUCT.md"]
   workflow_dispatch:
 


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Removes the restriction that only the `master` branch and branches starting with `hotfix/` will trigger the ret-turkey workflow.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
The build job in turkeyGitops that ret-turkey calls is useful for  all branches (it tests whether the code builds, but doesn't try to push anything) and the tag jobs that push Docker images are restricted to the correct branches in turkeyGitops, so restricting the branches here in the calling workflow is no longer needed/helpful.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Push the updated workflow to the master branch on your fork.
2. Push up another branch containing the modified workflow (and some other change to a non-ignored file), that doesn't conform to the previously allowed naming scheme. 
3. See that the workflow runs for the new branch and completes the build job (but no others).

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This workflow isn't currently documented, so there isn't any documentation to update, plus this change makes it consistent with all the other workflows that call turkeyGitops.

## Known limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
This PR doesn't change any of the ignored paths.  The ignored paths aren't entirely consistent across the calling workflows for turkeyGitops and changing them wasn't discussed, so they are deemed out of scope for this PR.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
The branch restrictions were originally put in place in https://github.com/Hubs-Foundation/reticulum/pull/731 before turkeyGitops had been updated to have the restrictions itself in https://github.com/Hubs-Foundation/hubs-ops/pull/210.

This change was discussed at the [2026-07-07 Hubs Dev Meetup](https://docs.google.com/document/d/1OMh3-_DpjHABMMrXtECzLPNxipQMixx32l6K4zqSoYY/edit?tab=t.0#heading=h.2evylzzbp6g5).
